### PR TITLE
Update connectors API reference for key masking

### DIFF
--- a/docs/connectors-api-reference.md
+++ b/docs/connectors-api-reference.md
@@ -227,7 +227,7 @@ An attacker with a stolen session cannot normally read existing keys via
 `GET /wp/v2/settings` — they only see the masked version (e.g.,
 `••••••••••••fj39`).
 
-There is a correctness edge case for values of length 4 or fewer, which are
+As noted earlier, there is a correctness edge case for values of length 4 or fewer, which are
 returned unchanged by `_wp_connectors_mask_api_key()`. That is source- and
 runtime-verified, but not a realistic practical concern for typical AI provider
 credentials.


### PR DESCRIPTION
Clarify edge case for API key masking in documentation.

## Summary

- What changed?
- Why was this change needed?

## Validation

- [ ] `composer test`
- [ ] Relevant `npm run test:e2e*` or manual checks are described

## Checklist

- [ ] Linked issue or explained why none was needed
- [ ] Updated docs, tests, or manual testing guidance if behavior changed
- [ ] No sensitive details disclosed publicly
