### PR TITLE
fix(test): make UninstallTest deterministic in wp-env shared-DB topology

### DIFF
--- a/bin/run-integration-tests.sh
+++ b/bin/run-integration-tests.sh
@@ -22,7 +22,19 @@ resolve_wp_tests_config_path() {
 }
 
 find_wp_env_tests_container() {
-	docker ps --format '{{.Names}}' 2>/dev/null | grep -E -- '-tests-cli-1$' | head -n 1 || true
+	# Several wp-env environments can run side by side (one per project
+	# path hash), so match the container that bind-mounts THIS repo rather
+	# than taking the first tests-cli container on the machine.
+	local candidate
+
+	for candidate in $(docker ps --format '{{.Names}}' 2>/dev/null | grep -E -- '-tests-cli-1$' || true); do
+		if docker inspect "$candidate" --format '{{range .Mounts}}{{.Source}}{{"\n"}}{{end}}' 2>/dev/null | grep -qx -- "$REPO_ROOT"; then
+			printf '%s\n' "$candidate"
+			return 0
+		fi
+	done
+
+	return 0
 }
 
 extract_wp_env_version() {
@@ -118,6 +130,8 @@ run_inside_wp_env_tests_container() {
 	local wp_version="$2"
 	local multisite_env=""
 	local inner_command=""
+	local exec_uid=""
+	local exec_gid=""
 
 	if [ -n "$WP_MULTISITE_VALUE" ]; then
 		multisite_env="WP_MULTISITE=$WP_MULTISITE_VALUE "
@@ -125,11 +139,23 @@ run_inside_wp_env_tests_container() {
 
 	echo "Host DB connection is unavailable; running integration suite inside wp-env container $container_name"
 
-	docker exec -u root "$container_name" sh -lc "mkdir -p /tmp/wordpress/wp-content/uploads && chmod 0777 /tmp/wordpress/wp-content/uploads"
+	# The suite runs as the container's default exec user, so /tmp/wordpress
+	# must not stay root-owned after the root mkdir below.
+	exec_uid="$(docker exec "$container_name" id -u)"
+	exec_gid="$(docker exec "$container_name" id -g)"
+	docker exec -u root "$container_name" sh -lc "mkdir -p /tmp/wordpress/wp-content/uploads && chmod 0777 /tmp/wordpress/wp-content/uploads && chown -R ${exec_uid}:${exec_gid} /tmp/wordpress"
 
+	# The wp-env cli image bakes WP_TESTS_DIR=/wordpress-phpunit into the
+	# environment, so install-wp-tests.sh skips its test-suite step and only
+	# provisions the wordpress_test database, WP core, and plugins. The
+	# /wordpress-phpunit config reads DB_NAME and $table_prefix from
+	# WORDPRESS_* env vars and otherwise defaults to the live tests site's
+	# database and wp_ prefix — sharing tables with a site that auto-activates
+	# this plugin. Point the suite at the dedicated database and the canonical
+	# wptests_ prefix so test runs are isolated from the live site.
 	inner_command="cd /var/www/html/wp-content/plugins/wp-sudo && "
 	inner_command="${inner_command}WP_SUDO_FORCE_DROP_DB=1 bash bin/install-wp-tests.sh wordpress_test root password tests-mysql $wp_version >/dev/null && "
-	inner_command="${inner_command}${multisite_env}WP_TESTS_DIR=/wordpress-phpunit ./vendor/bin/phpunit --configuration $PHPUNIT_CONFIG"
+	inner_command="${inner_command}${multisite_env}WORDPRESS_DB_NAME=wordpress_test WORDPRESS_TABLE_PREFIX=wptests_ WP_TESTS_DIR=/wordpress-phpunit ./vendor/bin/phpunit --configuration $PHPUNIT_CONFIG"
 
 	docker exec "$container_name" sh -lc "$inner_command"
 }

--- a/docs/current-metrics.md
+++ b/docs/current-metrics.md
@@ -20,10 +20,10 @@ Verification environment: local workspace, PHP 8.x
 | Metric | Value | Verification |
 |---|---:|---|
 | Production PHP lines (`includes/`, `wp-sudo.php`, `uninstall.php`, `mu-plugin/`, `bridges/`) | 14,760 | `find ./includes ./wp-sudo.php ./uninstall.php ./mu-plugin ./bridges -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
-| Tests PHP lines (`tests/`) | 27,449 | `find ./tests -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
-| Production + tests PHP lines | 42,209 | sum of the two rows above |
-| Test-to-production ratio | 1.86:1 | `27449 / 14760` |
-| Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`) | 42,472 | `find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/vendor_test/*" ! -path "*/.tmp/*" ! -path "*/.git/*" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Tests PHP lines (`tests/`) | 27,485 | `find ./tests -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Production + tests PHP lines | 42,245 | sum of the two rows above |
+| Test-to-production ratio | 1.86:1 | `27485 / 14760` |
+| Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`) | 42,508 | `find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/vendor_test/*" ! -path "*/.tmp/*" ! -path "*/.git/*" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
 
 ## Architectural Facts
 

--- a/tests/Integration/UninstallTest.php
+++ b/tests/Integration/UninstallTest.php
@@ -59,6 +59,46 @@ class UninstallTest extends TestCase {
 	}
 
 	/**
+	 * Drop any pre-existing events table so this test owns its provenance.
+	 *
+	 * In wp-env, the suite's wp-tests-config.php shares the database and
+	 * `wp_` prefix with the live tests site, which auto-activates the plugin
+	 * and creates a REAL wpsudo_events table. The suite's query filter
+	 * rewrites DROP TABLE to DROP TEMPORARY TABLE, so uninstall can never
+	 * remove that real table and the non-existence assertion would always
+	 * fail. Dropping both provenances first guarantees the table this test
+	 * creates is a suite-owned TEMPORARY table that uninstall CAN drop.
+	 *
+	 * Must run before any DB write in the test: the unfiltered DROP is DDL
+	 * and implicitly commits the test's transaction in all environments,
+	 * even when no table exists. Fixtures created after this call still
+	 * roll back normally.
+	 *
+	 * @return void
+	 */
+	private function purge_events_table_all_provenances(): void {
+		global $wpdb;
+
+		$wpdb->suppress_errors( true );
+
+		// Drop a suite-created TEMPORARY table, if any (the query filter
+		// rewrites this to DROP TEMPORARY TABLE IF EXISTS).
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange, WordPress.DB.PreparedSQL.NotPrepared -- Event_Store::table_name() is a safe identifier; test-environment cleanup.
+		$wpdb->query( 'DROP TABLE IF EXISTS ' . Event_Store::table_name() );
+
+		// Drop a REAL table leaked from outside the suite (e.g. the live
+		// wp-env tests site sharing this database and prefix).
+		remove_filter( 'query', array( $this, '_drop_temporary_tables' ) );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange, WordPress.DB.PreparedSQL.NotPrepared -- Event_Store::table_name() is a safe identifier; test-environment cleanup.
+		$wpdb->query( 'DROP TABLE IF EXISTS ' . Event_Store::table_name() );
+		add_filter( 'query', array( $this, '_drop_temporary_tables' ) );
+
+		$wpdb->suppress_errors( false );
+
+		Event_Store::reset_runtime_cache();
+	}
+
+	/**
 	 * Single-site uninstall removes all plugin data.
 	 *
 	 * Exercises the full uninstall path: options, user meta, and
@@ -70,7 +110,8 @@ class UninstallTest extends TestCase {
 			$this->markTestSkipped( 'Single-site test — skipped on multisite.' );
 		}
 
-		// Arrange: activate plugin and create data.
+		// Arrange: start from a known table provenance, then activate.
+		$this->purge_events_table_all_provenances();
 		$this->activate_plugin();
 
 		$password = 'test-password';
@@ -100,6 +141,7 @@ class UninstallTest extends TestCase {
 		if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 			define( 'WP_UNINSTALL_PLUGIN', 'wp-sudo/wp-sudo.php' );
 		}
+		$this->assertTrue( \WP_Sudo\Uninstall_Guard::is_authorized(), 'Uninstall must be authorized before loading uninstall.php — it exits the process otherwise.' );
 		require dirname( __DIR__, 2 ) . '/uninstall.php';
 
 		// Assert: options are removed.
@@ -123,22 +165,27 @@ class UninstallTest extends TestCase {
 	}
 
 	/**
-	 * Multisite uninstall cleans user meta when no site has the plugin active.
+	 * Multisite uninstall cleans user meta network-wide.
 	 *
-	 * On multisite, user meta is stored in a shared table. The uninstall
-	 * routine must only delete it when no remaining site still has the
-	 * plugin active.
+	 * On multisite, user meta is stored in a shared table. By the time
+	 * WordPress runs uninstall.php all plugin data is orphaned, so the
+	 * uninstall routine deletes sudo user meta unconditionally across
+	 * the network. The acting user is a super admin, mirroring the real
+	 * network uninstall actor (delete_plugins is super-admin-only on
+	 * multisite).
 	 */
 	public function test_multisite_uninstall_cleans_user_meta(): void {
 		if ( ! is_multisite() ) {
 			$this->markTestSkipped( 'Multisite test — skipped on single-site.' );
 		}
 
-		// Arrange: activate plugin and create data.
+		// Arrange: start from a known table provenance, then activate.
+		$this->purge_events_table_all_provenances();
 		$this->activate_plugin();
 
 		$password = 'test-password';
 		$user     = $this->make_admin( $password );
+		grant_super_admin( $user->ID );
 		wp_set_current_user( $user->ID );
 
 		// Activate a sudo session.
@@ -159,25 +206,14 @@ class UninstallTest extends TestCase {
 
 		$this->assertTrue( $this->ensure_events_table(), 'Events table should exist before uninstall.' );
 
-		// Ensure the plugin is NOT in the active plugins list for the current site
-		// (simulates the state after WordPress has already deactivated the plugin
-		// but before the uninstall routine runs).
-		$active_plugins = (array) get_option( 'active_plugins', array() );
-		$active_plugins = array_diff( $active_plugins, array( 'wp-sudo/wp-sudo.php' ) );
-		update_option( 'active_plugins', $active_plugins );
-
-		// Also ensure it's not network-activated.
-		$network_plugins = (array) get_site_option( 'active_sitewide_plugins', array() );
-		unset( $network_plugins['wp-sudo/wp-sudo.php'] );
-		update_site_option( 'active_sitewide_plugins', $network_plugins );
-
 		// Act: run uninstall.
 		if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 			define( 'WP_UNINSTALL_PLUGIN', 'wp-sudo/wp-sudo.php' );
 		}
+		$this->assertTrue( \WP_Sudo\Uninstall_Guard::is_authorized(), 'Uninstall must be authorized before loading uninstall.php — it exits the process otherwise.' );
 		require dirname( __DIR__, 2 ) . '/uninstall.php';
 
-		// Assert: user meta is cleaned (no site has the plugin active).
+		// Assert: user meta is cleaned network-wide.
 		$this->assertEmpty( get_user_meta( $user->ID, '_wp_sudo_expires', true ), 'Expiry meta should be deleted on multisite.' );
 		$this->assertEmpty( get_user_meta( $user->ID, '_wp_sudo_token', true ), 'Token meta should be deleted on multisite.' );
 		$this->assertEmpty( get_user_meta( $user->ID, '_wp_sudo_failed_attempts', true ), 'Legacy failed attempts meta should be deleted on multisite.' );


### PR DESCRIPTION
## Summary

Makes `tests/Integration/UninstallTest.php` pass deterministically when the integration suite runs inside a wp-env `tests-cli` container (the repo's WordPress 7.0 forward lane), where it previously failed every run on `test_single_site_uninstall_cleans_all_data` and silently truncated the whole suite on multisite.

## Root cause

In wp-env, the suite's `wp-tests-config.php` shares its database and `wp_` prefix with the **live** tests site. That site auto-activates the plugin and creates a **real** `wp_wpsudo_events` table. The WP test framework rewrites `DROP TABLE` → `DROP TEMPORARY TABLE`, so `uninstall.php` can never drop that real table — `DESCRIBE` still sees it and the "Events table should be dropped" assertion fails. Host-side CI uses a dedicated DB with the `wptests_` prefix, so it never hit this.

A second, separate bug: on multisite the test's plain admin lacks `delete_plugins` (super-admin-only), so `Uninstall_Guard::is_authorized()` returned false and `uninstall.php`'s `exit` **killed PHPUnit mid-suite with status 0** — every multisite run since the 3.1.5 uninstall guard was silently truncated and reported as passing.

## Changes (test-only)

- `purge_events_table_all_provenances()` drops both the suite-owned TEMPORARY table and any leaked real table (by briefly removing the framework's `_drop_temporary_tables` filter) before each uninstall test arranges data, so the test always exercises a table `uninstall.php` can remove.
- Multisite: `grant_super_admin()` before `wp_set_current_user()` (mirrors the real network-uninstall actor); docblock and a dead `active_plugins` arrangement corrected to match actual production behavior (multisite user-meta cleanup is unconditional).
- Both tests gain a pre-flight `assertTrue( Uninstall_Guard::is_authorized() )` so a future authorization regression fails loudly instead of silently killing the suite.
- `bin/run-integration-tests.sh`: select the `tests-cli` container that mounts *this* checkout, chown `/tmp/wordpress` to the container exec user, and pass `WORDPRESS_DB_NAME`/`WORDPRESS_TABLE_PREFIX` so in-container runs use the dedicated DB (defense-in-depth alongside the purge helper).

No production code changes — the production drop path was verified correct.

## Validation

- Unit: 784 tests green; PHPStan level 6 clean; PHPCS clean.
- Integration in the wp-env container (WP 7.0, MariaDB 12.3): single-site and multisite both 183/183 green (multisite previously truncated at ~155/183).

## Scope note

This isolates only the UninstallTest determinism fix. A related `fix(uninstall): remove governance caps` commit was intentionally **not** included here — it depends on governance API (`wp_sudo_governance_caps()`, the `sudo_can`→`wp_sudo_can` rename) that is not yet on `main`, so it ships with the governance branch where its dependencies live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
