### PR TITLE
fix(test): guard integration runner against silent exits; docs-only reviewer skip

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -35,6 +35,14 @@ fi
 
 APPROVAL_FILE="$REPO_ROOT/$REVIEWER_APPROVAL_FILE"
 
+# ── Staged file classification ───────────────────────────────────────────────
+# Docs-only = every staged file (lockfiles excluded) matches the text-only
+# pattern. Used to skip both the reviewer-approval check and the test suite.
+NON_TEXT_FILES=$(git diff --cached --name-only \
+  | grep -Ev "$REVIEWER_EXCLUDED_FILES" \
+  | grep -Ev "$REVIEWER_TEXT_ONLY_PATTERN" \
+  | wc -l | tr -d ' ')
+
 # ── Header ───────────────────────────────────────────────────────────────────
 echo "🔍 Pre-Commit Validation"
 echo "=============================="
@@ -46,6 +54,11 @@ echo "1️⃣  Checking reviewer agent approval..."
 if [ "$USER_COMMIT" = "1" ]; then
   echo -e "${YELLOW}⚠️  User commit bypass enabled${NC}"
   echo "   Skipping reviewer agent check (USER_COMMIT=1)"
+elif [ "$NON_TEXT_FILES" -eq 0 ]; then
+  echo "   ℹ️  Docs-only commit — no code files staged (pattern: $REVIEWER_TEXT_ONLY_PATTERN)"
+  echo -e "${GREEN}✅ Reviewer approval not required for docs-only commits (per CLAUDE.md)${NC}"
+  # Consume any leftover approval flag so it cannot be reused by a later code commit.
+  rm -f "$APPROVAL_FILE"
 elif [ -f "$APPROVAL_FILE" ]; then
   APPROVAL_TIME=$(cat "$APPROVAL_FILE")
   CURRENT_TIME=$(date +%s)
@@ -98,11 +111,6 @@ if [ "$USER_COMMIT" != "1" ]; then
 fi
 
 # ── Step 3: Tests (skip for text-only changes) ───────────────────────────────
-NON_TEXT_FILES=$(git diff --cached --name-only \
-  | grep -Ev "$REVIEWER_EXCLUDED_FILES" \
-  | grep -Ev "$REVIEWER_TEXT_ONLY_PATTERN" \
-  | wc -l | tr -d ' ')
-
 echo "3️⃣  Running tests..."
 echo ""
 
@@ -170,10 +178,10 @@ done
 echo -e "${GREEN}✅ No secrets${NC}"
 echo ""
 
-# ── Step 5: Reviewer reminder (AI commits only) ──────────────────────────────
-if [ "$USER_COMMIT" != "1" ]; then
+# ── Step 5: Reviewer reminder (AI code commits only) ─────────────────────────
+if [ "$USER_COMMIT" != "1" ] && [ "$NON_TEXT_FILES" -gt 0 ]; then
   echo "5️⃣  Reviewer oversight check..."
-  echo -e "${YELLOW}⚠️  MANDATORY: Reviewer agent must approve before every commit.${NC}"
+  echo -e "${YELLOW}⚠️  MANDATORY: Reviewer agent must approve before every code commit.${NC}"
   echo "   1. Spawn reviewer agent with Claude Code's Agent tool"
   echo "   2. Get APPROVE decision"
   echo "   3. Reviewer writes the approval flag"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,9 +72,12 @@ The **main agent must not write this file** — that would bypass the review int
 
 ### When to skip
 
-Docs-only commits — no `.php` files changed, only `.md`, `.txt`, or non-code
-config/data files (e.g. `blueprint.json`, `readme.txt`, `CHANGELOG.md`) — do
-not require a reviewer. Commit directly.
+Docs-only commits do not require the reviewer agent and can be committed
+directly. A commit is docs-only when no code files are staged — only `.md`,
+`.txt`, `.rst`, or lockfiles (the pattern is `REVIEWER_TEXT_ONLY_PATTERN` in
+`.reviewer-config.sh`). The pre-commit hook detects this and skips the
+approval check automatically. Any commit touching `.php`, scripts, or other
+code still requires a fresh reviewer approval.
 
 ### User bypass (your own commits only)
 

--- a/bin/run-integration-tests.sh
+++ b/bin/run-integration-tests.sh
@@ -125,6 +125,31 @@ host_db_reachable() {
 	nc -z "$host_part" "$port_part" >/dev/null 2>&1
 }
 
+# PHPUnit's exit code alone is not a reliable success signal: a plain `exit;`
+# in code under test (e.g. the WP_UNINSTALL_PLUGIN guard in uninstall.php)
+# terminates the PHP process mid-suite with status 0. PHPUnit never prints its
+# final summary, yet the wrapper and CI would report success while silently
+# skipping every remaining test. Guard against that by capturing the output
+# and requiring a final PHPUnit summary line ("OK (...)", "OK, but ...", or
+# "Tests: ..., Assertions: ...") in addition to a zero exit code. Failing runs
+# ("FAILURES!"/"ERRORS!") still fail via the exit code as before.
+run_phpunit_guarded() {
+	local output_file
+	local status=0
+
+	output_file="$(mktemp "${TMPDIR:-/tmp}/wp-sudo-phpunit.XXXXXX")"
+
+	"$@" 2>&1 | tee "$output_file" || status=$?
+
+	if [ "$status" -eq 0 ] && ! grep -E -q '^OK |^OK,|^Tests: [0-9]+.*Assertions:' "$output_file"; then
+		echo 'PHPUnit exited 0 without printing a result summary — the suite was likely terminated early by an exit() in code under test.' >&2
+		status=1
+	fi
+
+	rm -f "$output_file"
+	return "$status"
+}
+
 run_inside_wp_env_tests_container() {
 	local container_name="$1"
 	local wp_version="$2"
@@ -157,7 +182,7 @@ run_inside_wp_env_tests_container() {
 	inner_command="${inner_command}WP_SUDO_FORCE_DROP_DB=1 bash bin/install-wp-tests.sh wordpress_test root password tests-mysql $wp_version >/dev/null && "
 	inner_command="${inner_command}${multisite_env}WORDPRESS_DB_NAME=wordpress_test WORDPRESS_TABLE_PREFIX=wptests_ WP_TESTS_DIR=/wordpress-phpunit ./vendor/bin/phpunit --configuration $PHPUNIT_CONFIG"
 
-	docker exec "$container_name" sh -lc "$inner_command"
+	run_phpunit_guarded docker exec "$container_name" sh -lc "$inner_command"
 }
 
 main() {
@@ -169,7 +194,8 @@ main() {
 	local wp_tests_config=""
 
 	if [ -n "${CI:-}" ] && [ -n "${WP_TESTS_DIR:-}" ] && [ -f "${WP_TESTS_DIR%/}/wp-tests-config.php" ]; then
-		exec ./vendor/bin/phpunit --configuration "$PHPUNIT_CONFIG"
+		run_phpunit_guarded ./vendor/bin/phpunit --configuration "$PHPUNIT_CONFIG"
+		return $?
 	fi
 
 	MYSQLADMIN_BIN="$(resolve_mysqladmin_bin || true)"
@@ -179,7 +205,8 @@ main() {
 	db_password="$(extract_db_host "$wp_tests_config" "DB_PASSWORD" || true)"
 
 	if [ -n "$db_host" ] && host_db_reachable "$db_host" "$db_user" "$db_password"; then
-		exec ./vendor/bin/phpunit --configuration "$PHPUNIT_CONFIG"
+		run_phpunit_guarded ./vendor/bin/phpunit --configuration "$PHPUNIT_CONFIG"
+		return $?
 	fi
 
 	tests_container="$(find_wp_env_tests_container)"
@@ -187,7 +214,7 @@ main() {
 	if [ -n "$tests_container" ]; then
 		wp_version="$(extract_wp_env_version)"
 		run_inside_wp_env_tests_container "$tests_container" "$wp_version"
-		return 0
+		return $?
 	fi
 
 	if [ -n "$db_host" ]; then

--- a/docs/developer-reference.md
+++ b/docs/developer-reference.md
@@ -408,9 +408,9 @@ Session binding is enforced during the grace window — `verify_token()` is call
 
 The admin bar UI uses `is_active()` only; it always reflects the true session state.
 
-### `Sudo_Session::activate( int $user_id ): void`
+### `Sudo_Session::activate( int $user_id ): bool`
 
-Creates a new sudo session: generates a token, writes user meta, sets the httponly cookie, and fires `wp_sudo_activated`. Also called automatically by `Plugin::grant_session_on_login()` on successful browser-based login (`wp_login` hook); that automatic grant can be suppressed via the `wp_sudo_grant_session_on_login` filter.
+Creates a new sudo session: generates a token, writes user meta, sets the httponly cookie, and fires `wp_sudo_activated`. Returns `true` on success. Also called automatically by `Plugin::grant_session_on_login()` on successful browser-based login (`wp_login` hook); that automatic grant can be suppressed via the `wp_sudo_grant_session_on_login` filter.
 
 ### `Sudo_Session::GRACE_SECONDS`
 


### PR DESCRIPTION
## Summary

Three independent test-infra / workflow improvements, split out from the UninstallTest determinism work in #50 so each lands on its own.

### 1. Guard the integration runner against silent PHPUnit exits (`bin/run-integration-tests.sh`)

PHPUnit's exit code alone is not a reliable success signal: a plain `exit;` in code under test (e.g. the `WP_UNINSTALL_PLUGIN` guard in `uninstall.php`) terminates the PHP process mid-suite with status 0. PHPUnit never prints its final summary, yet the wrapper and CI would report success while silently skipping every remaining test. This actually happened — multisite runs were truncated at ~155/183 and reported green until #50 fixed the underlying authorization arrangement.

`run_phpunit_guarded()` wraps every phpunit invocation (in-container, host-DB, and CI paths) and treats exit 0 **without** a final summary line (`OK (...)` / `Tests: N, Assertions:`) as a failure. Genuine failures still fail via the exit code as before.

> The container-match, `WORDPRESS_TABLE_PREFIX` isolation, and `/tmp/wordpress` chown that this branch originally also carried already landed via #50, so the rebase collapses those down — this commit now adds only the guard.

### 2. Auto-skip reviewer approval for docs-only commits (`.githooks/pre-commit`, `CLAUDE.md`)

Classifies staged files once at the top of the hook and skips the reviewer-approval requirement when no code files are staged (only files matching `REVIEWER_TEXT_ONLY_PATTERN` in `.reviewer-config.sh`). Any leftover approval flag is consumed on the docs-only path so it can't be banked for a later code commit. `CLAUDE.md`'s "When to skip" section is reworded to describe the actual hook mechanism (the prior wording listed `blueprint.json`, which the pattern does not match).

### 3. `Sudo_Session::activate()` returns bool (`docs/developer-reference.md`)

Doc signature corrected from `: void` to `: bool` (verified at `includes/class-sudo-session.php:256`); merged with main's newer note about the `wp_sudo_grant_session_on_login` filter.

## Validation

- Unit: 784 tests green; PHPStan level 6 clean; PHPCS clean.
- `bash -n` clean on both scripts.
- `composer verify:metrics` passes on a clean checkout (the only local "drift" is a nested `.claude/worktrees` copy, absent in CI).
- Integration via `bash bin/run-integration-tests.sh` in the wp-env container (WP 7.0, MariaDB 12.3): 183/183 green, exit 0, summary correctly detected by the new guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
