### PR TITLE
Make unit suite order-independent and guard with random-order CI

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -49,11 +49,17 @@ jobs:
       - name: Run unit tests
         env:
           WP_SUDO_VENDOR_AUTOLOAD: ${{ github.workspace }}/.github/php80-tests/vendor/autoload.php
+        # Random order guards against cross-file test coupling (leaked
+        # process-global state). PHPUnit prints "Random Seed: N" in its
+        # header; reproduce a failure locally with
+        # ./vendor/bin/phpunit --order-by=random --random-order-seed=N
+        # The coverage job below stays in default order so one
+        # deterministic lane remains for comparison.
         run: |
           if [ "${{ matrix.php }}" = "8.0" ]; then
-            ./.github/php80-tests/vendor/bin/phpunit --configuration phpunit.xml.dist
+            ./.github/php80-tests/vendor/bin/phpunit --configuration phpunit.xml.dist --order-by=random
           else
-            composer test:unit
+            composer test:unit -- --order-by=random
           fi
 
   unit-tests-coverage:

--- a/docs/current-metrics.md
+++ b/docs/current-metrics.md
@@ -20,10 +20,10 @@ Verification environment: local workspace, PHP 8.x
 | Metric | Value | Verification |
 |---|---:|---|
 | Production PHP lines (`includes/`, `wp-sudo.php`, `uninstall.php`, `mu-plugin/`, `bridges/`) | 14,760 | `find ./includes ./wp-sudo.php ./uninstall.php ./mu-plugin ./bridges -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
-| Tests PHP lines (`tests/`) | 27,485 | `find ./tests -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
-| Production + tests PHP lines | 42,245 | sum of the two rows above |
-| Test-to-production ratio | 1.86:1 | `27485 / 14760` |
-| Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`) | 42,508 | `find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/vendor_test/*" ! -path "*/.tmp/*" ! -path "*/.git/*" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Tests PHP lines (`tests/`) | 27,538 | `find ./tests -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Production + tests PHP lines | 42,298 | sum of the two rows above |
+| Test-to-production ratio | 1.87:1 | `27538 / 14760` |
+| Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`) | 42,561 | `find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/vendor_test/*" ! -path "*/.tmp/*" ! -path "*/.git/*" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
 
 ## Architectural Facts
 

--- a/patchwork.json
+++ b/patchwork.json
@@ -5,6 +5,8 @@
         "hash_equals",
         "headers_sent",
         "function_exists",
+        "class_exists",
+        "defined",
         "file_get_contents",
         "is_writable",
         "is_dir"

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -79,6 +79,7 @@ abstract class TestCase extends PHPUnitTestCase {
 		\WP_Sudo\Sudo_Session::reset_cache();
 		\WP_Sudo\Admin::reset_cache();
 		\WP_Sudo\Event_Store::reset_runtime_cache();
+		\WP_Sudo\Event_Recorder::reset_buffer();
 
 		Monkey\tearDown();
 		parent::tearDown();

--- a/tests/Unit/AdminTest.php
+++ b/tests/Unit/AdminTest.php
@@ -1606,8 +1606,17 @@ class AdminTest extends TestCase {
 			}
 		);
 
-		// WP_SUDO_MU_LOADED is not defined, so render_mu_plugin_status()
-		// will show "Not installed" and an install button.
+		// WP_SUDO_MU_LOADED is process-global once any earlier test defines
+		// it (SiteHealthTest), so force the not-installed branch instead of
+		// relying on the constant being absent.
+		\Patchwork\redefine(
+			'defined',
+			function ( string $constant_name ): bool {
+				return 'WP_SUDO_MU_LOADED' === $constant_name ? false : \Patchwork\relay();
+			}
+		);
+
+		// render_mu_plugin_status() will show "Not installed" and an install button.
 		$admin = new Admin();
 
 		ob_start();
@@ -1646,6 +1655,15 @@ class AdminTest extends TestCase {
 			'is_writable',
 			function ( string $path ): bool {
 				return str_contains( $path, 'wp-content' ) ? false : \Patchwork\relay();
+			}
+		);
+
+		// Force the not-installed branch regardless of whether an earlier
+		// test defined the process-global WP_SUDO_MU_LOADED constant.
+		\Patchwork\redefine(
+			'defined',
+			function ( string $constant_name ): bool {
+				return 'WP_SUDO_MU_LOADED' === $constant_name ? false : \Patchwork\relay();
 			}
 		);
 

--- a/tests/Unit/DashboardWidgetTest.php
+++ b/tests/Unit/DashboardWidgetTest.php
@@ -340,6 +340,22 @@ class DashboardWidgetTest extends TestCase {
 	private ?object $original_wpdb = null;
 
 	/**
+	 * Set up test environment.
+	 *
+	 * dbDelta must be stubbed unconditionally: Brain\Monkey eval-defines it
+	 * process-globally once any earlier test file stubs it, after which
+	 * Event_Store::create_table() sees function_exists('dbDelta') as true
+	 * and calls it. Without a local stub, render tests would then throw
+	 * MissingFunctionExpectations depending on test-file ordering.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		Functions\when( 'dbDelta' )->justReturn( array() );
+	}
+
+	/**
 	 * Set up fake wpdb.
 	 *
 	 * @return void

--- a/tests/Unit/SiteHealthTest.php
+++ b/tests/Unit/SiteHealthTest.php
@@ -77,10 +77,14 @@ class SiteHealthTest extends TestCase {
 			return 'https://example.com/wp-admin/' . $path;
 		} );
 
-		// Only runs when WP_SUDO_MU_LOADED is NOT defined yet.
-		if ( defined( 'WP_SUDO_MU_LOADED' ) ) {
-			$this->markTestSkipped( 'WP_SUDO_MU_LOADED already defined by another test.' );
-		}
+		// Force the not-installed branch regardless of whether an earlier
+		// test defined the process-global WP_SUDO_MU_LOADED constant.
+		\Patchwork\redefine(
+			'defined',
+			function ( string $constant_name ): bool {
+				return 'WP_SUDO_MU_LOADED' === $constant_name ? false : \Patchwork\relay();
+			}
+		);
 
 		$result = $this->health->test_mu_plugin_status();
 
@@ -91,11 +95,15 @@ class SiteHealthTest extends TestCase {
 	public function test_mu_plugin_installed_returns_good(): void {
 		Functions\when( '__' )->returnArg();
 
-		// Simulate WP_SUDO_MU_LOADED being defined.
-		// We can test the branch by pre-defining the constant.
-		if ( ! defined( 'WP_SUDO_MU_LOADED' ) ) {
-			define( 'WP_SUDO_MU_LOADED', true );
-		}
+		// Simulate WP_SUDO_MU_LOADED being defined. Redefining defined()
+		// instead of calling define() keeps the constant out of the
+		// process-global namespace so later tests are not contaminated.
+		\Patchwork\redefine(
+			'defined',
+			function ( string $constant_name ): bool {
+				return 'WP_SUDO_MU_LOADED' === $constant_name ? true : \Patchwork\relay();
+			}
+		);
 
 		$result = $this->health->test_mu_plugin_status();
 

--- a/tests/Unit/WsalSensorBridgeTest.php
+++ b/tests/Unit/WsalSensorBridgeTest.php
@@ -20,6 +20,16 @@ class WsalSensorBridgeTest extends TestCase {
 	 */
 	public function test_01_bridge_is_inert_when_wsal_unavailable(): void {
 
+		// The Alert_Manager stub eval-defined by the other tests in this
+		// file is process-global, so hide it from the bridge's availability
+		// check instead of relying on the class being absent.
+		\Patchwork\redefine(
+			'class_exists',
+			function ( string $class_name, bool $autoload = true ): bool {
+				return false !== strpos( $class_name, 'Alert_Manager' ) ? false : \Patchwork\relay();
+			}
+		);
+
 		$registered_hooks = array();
 		Functions\when( 'add_action' )->alias(
 			static function ( string $hook, callable $callback ) use ( &$registered_hooks ): bool {


### PR DESCRIPTION
## Summary

The unit suite passed in default order but failed under `--order-by=random` (reproducible with seeds 1, 3, 20260610) due to four families of cross-file test-order coupling. This PR makes every test self-contained — no assertions weakened, all changes test-side, no production code touched — and adds a CI guard so the coupling cannot silently regress.

### Commit 1 — `test:` order-independence fixes

| Family | Root cause | Fix |
|---|---|---|
| DashboardWidgetTest (16 errors) | Brain\Monkey eval-defines `dbDelta` process-globally once EventStoreTest/UpgraderTest stub it; `Event_Store::create_table()`'s `function_exists` guard then routed render tests into the throwing stub | Stub `dbDelta` in `setUp()` |
| EventRecorderTest (size 0 vs 1) | `Event_Recorder::$buffer_armed` static leaked from buffering tests (and `Plugin::init`), so direct-insert tests buffered instead of inserting | `Event_Recorder::reset_buffer()` added to shared `TestCase::tearDown()` |
| AdminTest mu-plugin renders (2 failures) | `WP_SUDO_MU_LOADED` constant `define()`d by SiteHealthTest is process-global | Patchwork-redefine `defined()` for that constant; SiteHealthTest now simulates the constant the same way instead of defining it, and its order-dependent `markTestSkipped` is removed (the suite's permanent "Skipped: 1" is gone) |
| WsalSensorBridgeTest (inert test) | Eval-defined `Alert_Manager` stub from tests 02–06 can't be undefined | Patchwork-redefine `class_exists()` to hide the stub from the bridge's availability check |

`patchwork.json` gains `defined` and `class_exists` in `redefinable-internals` — the same mechanism already used for `is_writable`/`is_dir`/`function_exists`. Brain\Monkey's tearDown calls `Patchwork\restoreAll()`, so redefines cannot leak between tests.

### Commit 2 — `ci:` random-order guard

The unit-tests matrix job now passes `--order-by=random` on all five PHP lanes (five seed samples per CI run). PHPUnit prints `Random Seed: N` in the job log; reproduce locally with `./vendor/bin/phpunit --order-by=random --random-order-seed=N`. The coverage job intentionally stays in default order so one deterministic lane remains for comparison.

## Verification

- Seeds 1, 3, 7, 42, 99999, 20260610 and default order all pass: 784 tests, 2242 assertions, 0 skipped
- Each touched test file passes standalone
- `composer lint` clean; PHPStan level 6 clean
- Each commit independently approved by the reviewer agent (pre-commit hook re-ran tests, lint, and PHPStan at commit time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)