### PR TITLE
chore(workflow): widen reviewer approval window to 1800s

### DIFF
--- a/.reviewer-config.sh
+++ b/.reviewer-config.sh
@@ -9,7 +9,9 @@ REVIEWER_E2E_CMD=""
 
 REVIEWER_MAX_FILES=10
 REVIEWER_MAX_INSERTIONS=1000
-REVIEWER_APPROVAL_TIMEOUT=300
+# 1800s: agent round-trip latency in long sessions exceeded the old 300s
+# window (observed 19-21 min between flag write and commit on 2026-06-12).
+REVIEWER_APPROVAL_TIMEOUT=1800
 REVIEWER_APPROVAL_FILE="reviewer-approved"
 
 REVIEWER_TEXT_ONLY_PATTERN='\.(md|txt|rst)$'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ to fixing a contract break after commit.
 2. Spawn the reviewer agent using the Agent tool (subagent_type=reviewer)
 3. Reviewer runs tests, checks quality, and decides APPROVE or REJECT
 4. If APPROVED: reviewer writes the `reviewer-approved` flag
-5. Commit within 5 minutes of approval
+5. Commit within 30 minutes of approval (`REVIEWER_APPROVAL_TIMEOUT` in `.reviewer-config.sh`)
 
 ### Spawning the reviewer
 


### PR DESCRIPTION
## Summary

The pre-commit reviewer-enforcement hook sources the tracked `.reviewer-config.sh` at commit time, so its `REVIEWER_APPROVAL_TIMEOUT=300` always overrode the wider default in the local hook. On 2026-06-12 this expired two consecutive reviewer approvals — observed agent round-trip latency between the reviewer writing the approval flag and `git commit` executing was 19–21 minutes.

- `.reviewer-config.sh` — `REVIEWER_APPROVAL_TIMEOUT` raised 300 → 1800 (30 min, confirmed with maintainer), with a comment recording the observed latency
- `CLAUDE.md` — Pre-Commit Reviewer Workflow step updated from "Commit within 5 minutes of approval" to "Commit within 30 minutes of approval" and now points at the config variable so docs can't silently drift from the enforced value

The local (untracked) `.git/hooks/pre-commit` fallback default was also aligned to 1800 with a note that `.reviewer-config.sh` is authoritative.

## Test plan

- Dev-workflow config only; no PHP production code touched
- The commit on this branch exercised the change end-to-end: reviewer approval flag accepted, hook ran 784 unit tests + PHPCS + PHPStan, and the hook's reminder output printed "Commit within 1800s"

🤖 Generated with [Claude Code](https://claude.com/claude-code)