### PR TITLE
docs: archive governance spec, update stale references

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -80,7 +80,7 @@ The v3.0.0 release consolidates Phases 7–9 work plus pre-release fixes:
 - **Gutenberg block editor integration** — Detect block editor context, queue reauthentication via `@wordpress/notices` snackbar instead of page redirect. Natural trigger for Playwright E2E tests.
 - **Network policy hierarchy for multisite** — Super admins set minimum session duration and maximum entry-point policies; site admins can only tighten.
 - **Session-store architecture follow-up** — Evaluate and likely implement a dedicated sudo-session table, with the current recommendation favoring an authoritative table plus usermeta shadow writes. See [`docs/session-store-evaluation.md`](session-store-evaluation.md).
-- **Internal admin governance hardening** — Move Sudo management away from broad `manage_options` defaults by introducing dedicated capabilities and explicit grants. Implement with migration-safe phases documented in [`docs/internal-admin-governance-spec.md`](internal-admin-governance-spec.md) and roadmap §11.2.
+- **Internal admin governance hardening** — ✅ Shipped in 3.2.0. Dedicated `manage_wp_sudo`, `view_wp_sudo_activity`, `export_wp_sudo_activity`, and `revoke_wp_sudo_sessions` capabilities replace broad `manage_options` defaults. See [`docs/archive/internal-admin-governance-spec.md`](archive/internal-admin-governance-spec.md) for the archived design spec.
 
 ### UI Documentation Rule
 
@@ -1526,7 +1526,7 @@ migration endpoint.
 
 ### Spec and design source
 
-- [`docs/internal-admin-governance-spec.md`](internal-admin-governance-spec.md)
+- [`docs/archive/internal-admin-governance-spec.md`](archive/internal-admin-governance-spec.md)
 
 ### Rollout
 

--- a/docs/archive/internal-admin-governance-spec.md
+++ b/docs/archive/internal-admin-governance-spec.md
@@ -1,6 +1,6 @@
 # Internal Admin Governance Spec
 
-*Status: proposed (post-v3.0.0), April 20, 2026*
+*Status: implemented in 3.2.0 (June 2026). Archived — the developer reference and codebase are now authoritative.*
 
 ## Why this exists
 
@@ -71,7 +71,7 @@ Introduce dedicated capabilities:
 All access checks MUST route through a single centralized helper:
 
 ```php
-function sudo_can( string $cap, ?int $user_id = null ): bool {
+function wp_sudo_can( string $cap, ?int $user_id = null ): bool {
     $user_id ??= get_current_user_id();
     if ( is_multisite() && is_super_admin( $user_id ) ) {
         return true;
@@ -83,7 +83,7 @@ function sudo_can( string $cap, ?int $user_id = null ): bool {
 }
 ```
 
-The super-admin short-circuit is required because super admins do not literally hold `manage_network_options` in their cap set on subsite contexts — `current_user_can()` works via `map_meta_cap`'s super-admin bypass, but `user_can( $user_id, $cap )` does not. Every call site in `Admin`, `Dashboard_Widget`, `Site_Health`, and any future activity screen MUST use `sudo_can()`. The Phase 1 exit criterion is: zero direct `current_user_can('manage_options')` or `current_user_can('manage_network_options')` calls remain in Sudo code for governance-sensitive surfaces.
+The super-admin short-circuit is required because super admins do not literally hold `manage_network_options` in their cap set on subsite contexts — `current_user_can()` works via `map_meta_cap`'s super-admin bypass, but `user_can( $user_id, $cap )` does not. Every call site in `Admin`, `Dashboard_Widget`, `Site_Health`, and any future activity screen MUST use `wp_sudo_can()`. The Phase 1 exit criterion is: zero direct `current_user_can('manage_options')` or `current_user_can('manage_network_options')` calls remain in Sudo code for governance-sensitive surfaces.
 
 ## Privilege-sensitive operations (gated by Sudo itself)
 
@@ -173,15 +173,15 @@ Set-once-forget is the primary failure mode. Two mitigations:
 
 ## Implementation phases
 
-Because there is no existing install base, the original three-phase compatibility-first rollout is replaced with a compressed implementation plan. Strict-capability mode ships as the default in v3.1; compatibility mode is present as an opt-in from day one but is not the migration endpoint of a multi-version transition.
+Because there is no existing install base, the original three-phase compatibility-first rollout was replaced with a compressed implementation plan. Strict-capability mode shipped as the default in 3.2.0; compatibility mode is present as an opt-in from day one but is not the migration endpoint of a multi-version transition.
 
-### Phase 1 (v3.1): Ship strict governance as the default
+### Phase 1 (shipped in 3.2.0): Ship strict governance as the default
 
 Build the whole capability surface in one coordinated release:
 
 **Core**
 - Capability constants: `manage_wp_sudo`, `view_wp_sudo_activity`, `export_wp_sudo_activity`, `revoke_wp_sudo_sessions`.
-- Centralized `sudo_can()` helper per the Helper contract above.
+- Centralized `wp_sudo_can()` helper per the Helper contract above.
 - Governance-mode option `wp_sudo_governance_mode` = `strict` (default) | `compatibility`. Persisted per-site on multisite.
 - On activation: grant all four caps to the installing user (single-site) or to the activating super admin (multisite).
 
@@ -204,7 +204,7 @@ Build the whole capability surface in one coordinated release:
 - Developer-reference entry on the three new audit hooks.
 - `docs/security-model.md` §19 update reflecting the shipped capability boundary (not just a planned one).
 
-### Phase 2 (v3.2, optional): Governance polish
+### Phase 2 (not yet implemented): Governance polish
 
 Additive improvements that benefit from a release of production field data:
 
@@ -226,7 +226,7 @@ Per the project's TDD policy, every capability gate lands with tests first.
 
 ### Unit tests
 
-- `sudo_can()` helper: strict-mode path, compatibility-mode path, super-admin short-circuit on multisite subsites, recovery-mode short-circuit.
+- `wp_sudo_can()` helper: strict-mode path, compatibility-mode path, super-admin short-circuit on multisite subsites, recovery-mode short-circuit.
 - Each capability gate path: `manage_wp_sudo`, `view_wp_sudo_activity`, `export_wp_sudo_activity`, `revoke_wp_sudo_sessions` × single-site + multisite contexts.
 - "Last manager" guard: grant/revoke transitions that would leave zero holders are rejected with a specific error.
 - Access-model audit hooks fire with the expected argument shapes.

--- a/docs/execution-plan-v3.1-v3.3.md
+++ b/docs/execution-plan-v3.1-v3.3.md
@@ -353,7 +353,7 @@ review and need runtime confirmation or WP 7.0 RC source validation:
    - `sudo_can()` helper, `options.wp_sudo_access` gated rule, Access tab with
      drift detection, "last manager" guard, `WP_SUDO_RECOVERY_MODE`
      break-glass, audit hooks for all access-model transitions.
-   - See [`docs/internal-admin-governance-spec.md`](internal-admin-governance-spec.md).
+   - See [`docs/archive/internal-admin-governance-spec.md`](archive/internal-admin-governance-spec.md).
 6. Request-stash replay/data-minimization follow-up:
    - Add pattern-based redaction for non-standard secret names.
    - Add custom-rule metadata for redacted, replay-safe, and non-replayable
@@ -659,6 +659,6 @@ Across all phases:
 ## Source mapping
 
 - Primary roadmap source: [`docs/ROADMAP.md`](ROADMAP.md)
-- Governance spec: [`docs/internal-admin-governance-spec.md`](internal-admin-governance-spec.md)
+- Governance spec: [`docs/archive/internal-admin-governance-spec.md`](archive/internal-admin-governance-spec.md)
 - Session-store options: [`docs/session-store-evaluation.md`](session-store-evaluation.md)
 - External Audit Mode spec: [`docs/external-audit-mode-spec.md`](external-audit-mode-spec.md)

--- a/docs/external-audit-mode-spec.md
+++ b/docs/external-audit-mode-spec.md
@@ -62,7 +62,7 @@ Switching `wp_sudo_external_audit` away from `off` is gated by four checks,
 in order:
 
 1. **Capability.** Setting is editable only by `sudo_can( 'manage_wp_sudo' )`
-   (per the [governance spec](internal-admin-governance-spec.md)).
+   (per the [governance spec](archive/internal-admin-governance-spec.md)).
 2. **Sudo-gated.** The save handler writes through the
    `options.wp_sudo_access` gated rule, so the mutation itself requires an
    active sudo session. Changing audit destination is privilege-sensitive.

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -56,8 +56,8 @@ Operationally, this implies:
   `options.wp_sudo_access` gated rule, requiring an active sudo session before
   proceeding.
 
-See [`docs/internal-admin-governance-spec.md`](internal-admin-governance-spec.md)
-for the full design rationale.
+See [`docs/archive/internal-admin-governance-spec.md`](archive/internal-admin-governance-spec.md)
+for the archived design spec (implemented in 3.2.0).
 
 ## Threat Model: The Kill Chain
 


### PR DESCRIPTION
Moves `internal-admin-governance-spec.md` to `docs/archive/` and corrects stale content.

- Status updated to implemented in 3.2.0
- `sudo_can()` renamed to `wp_sudo_can()` throughout (shipped name; old is now a deprecated alias)
- Phase version references corrected (phantom v3.1 to 3.2.0)
- Phase 2 marked not yet implemented
- All four referencing docs updated to the new archive path
- ROADMAP item marked shipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)