### PR TITLE
fix(ci): repair silently-dead Psalm gate + restore type-coverage badge

### DIFF
--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -35,9 +35,26 @@ jobs:
       - name: Install Composer dependencies
         run: composer install --no-interaction --prefer-dist
 
-      - name: Run Psalm
-        run: composer analyse:psalm
+      - name: Run Psalm (gate + silent-no-op guard)
+        # `composer analyse:psalm` exits nonzero on real errors (the gate). But a
+        # broken config can make Psalm exit 0 with zero output and no analysis (a
+        # silent no-op — e.g. a top-level `exit;` in an analyzed file). That would
+        # make this gate a false-pass. Guard against it: if the run completes
+        # without emitting a type-coverage figure, fail loudly.
+        run: |
+          output="$(composer analyse:psalm 2>&1)" || { printf '%s\n' "$output"; exit 1; }
+          printf '%s\n' "$output"
+          if printf '%s\n' "$output" | grep -qE 'infer types for [0-9.]+%'; then
+            echo "Type coverage measured — gate healthy."
+          else
+            echo "::error::Psalm emitted no type-coverage figure — analysis did not complete (silent no-op). See the uninstall.php note in psalm.xml.dist."
+            exit 1
+          fi
 
       - name: Publish Shepherd type coverage
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        # shepherd.dev is an experimental service; never let a badge-publish
+        # outage fail the Psalm release gate. A failed send is visible in the
+        # step log (no "🐑 results sent" line) without blocking the build.
+        continue-on-error: true
         run: composer analyse:psalm:shepherd

--- a/docs/current-metrics.md
+++ b/docs/current-metrics.md
@@ -19,11 +19,11 @@ Verification environment: local workspace, PHP 8.x
 
 | Metric | Value | Verification |
 |---|---:|---|
-| Production PHP lines (`includes/`, `wp-sudo.php`, `uninstall.php`, `mu-plugin/`, `bridges/`) | 14,718 | `find ./includes ./wp-sudo.php ./uninstall.php ./mu-plugin ./bridges -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
-| Tests PHP lines (`tests/`) | 27,545 | `find ./tests -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
-| Production + tests PHP lines | 42,263 | sum of the two rows above |
-| Test-to-production ratio | 1.87:1 | `27545 / 14718` |
-| Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`) | 42,526 | `find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/vendor_test/*" ! -path "*/.tmp/*" ! -path "*/.git/*" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Production PHP lines (`includes/`, `wp-sudo.php`, `uninstall.php`, `mu-plugin/`, `bridges/`) | 14,839 | `find ./includes ./wp-sudo.php ./uninstall.php ./mu-plugin ./bridges -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Tests PHP lines (`tests/`) | 27,726 | `find ./tests -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Production + tests PHP lines | 42,565 | sum of the two rows above |
+| Test-to-production ratio | 1.87:1 | `27726 / 14839` |
+| Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`) | 42,828 | `find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/vendor_test/*" ! -path "*/.tmp/*" ! -path "*/.git/*" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
 
 ## Architectural Facts
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="6.15.1@28dc127af1b5aecd52314f6f645bafc10d0e11f9">
+<files psalm-version="6.16.0@7cf3e8b988edd75e0766963b0b9e671b220f5785">
   <file src="bridges/wp-sudo-webauthn-bridge.php">
     <HookNotFound>
       <code><![CDATA[add_filter(
@@ -214,6 +214,14 @@
       <code><![CDATA[\WSAL\Controllers\Alert_Manager]]></code>
     </UndefinedClass>
   </file>
+  <file src="includes/class-admin-bar.php">
+    <UndefinedConstant>
+      <code><![CDATA[WP_SUDO_PLUGIN_URL]]></code>
+      <code><![CDATA[WP_SUDO_PLUGIN_URL]]></code>
+      <code><![CDATA[WP_SUDO_VERSION]]></code>
+      <code><![CDATA[WP_SUDO_VERSION]]></code>
+    </UndefinedConstant>
+  </file>
   <file src="includes/class-admin.php">
     <InvalidArgument>
       <code><![CDATA[(array) $input]]></code>
@@ -235,7 +243,7 @@
       <code><![CDATA[array(
 				'label_for'   => Gate::SETTING_REST_APP_PASS_POLICY,
 				'key'         => Gate::SETTING_REST_APP_PASS_POLICY,
-				'description' => __( 'Controls non-cookie-auth REST requests (Application Passwords, Bearer tokens, OAuth). Cookie-auth browser requests always get the sudo challenge. Default: Limited.', 'wp-sudo' ),
+				'description' => __( 'Controls non-cookie-auth REST requests (Application Passwords, Bearer tokens, OAuth). Cookie-auth browser requests always get the sudo challenge. In multisite, Connectors credentials saved in the database remain per-site, but env or wp-config.php-backed connector keys may still apply across the whole install/network. Default: Limited.', 'wp-sudo' ),
 			)]]></code>
       <code><![CDATA[array(
 				'label_for'   => Gate::SETTING_XMLRPC_POLICY,
@@ -243,16 +251,91 @@
 				'description' => __( 'Disabled shuts off the entire XML-RPC protocol. Limited blocks only gated operations. Unrestricted allows everything. Default: Limited.', 'wp-sudo' ),
 			)]]></code>
     </InvalidArgument>
+    <UndefinedConstant>
+      <code><![CDATA[WP_SUDO_PLUGIN_BASENAME]]></code>
+      <code><![CDATA[WP_SUDO_PLUGIN_DIR]]></code>
+      <code><![CDATA[WP_SUDO_PLUGIN_DIR]]></code>
+      <code><![CDATA[WP_SUDO_PLUGIN_URL]]></code>
+      <code><![CDATA[WP_SUDO_PLUGIN_URL]]></code>
+      <code><![CDATA[WP_SUDO_PLUGIN_URL]]></code>
+      <code><![CDATA[WP_SUDO_VERSION]]></code>
+      <code><![CDATA[WP_SUDO_VERSION]]></code>
+      <code><![CDATA[WP_SUDO_VERSION]]></code>
+    </UndefinedConstant>
+    <UndefinedFunction>
+      <code><![CDATA[wp_sudo_can( 'manage_wp_sudo' )]]></code>
+      <code><![CDATA[wp_sudo_can( 'manage_wp_sudo' )]]></code>
+      <code><![CDATA[wp_sudo_can( 'manage_wp_sudo' )]]></code>
+      <code><![CDATA[wp_sudo_can( 'manage_wp_sudo' )]]></code>
+      <code><![CDATA[wp_sudo_can( 'manage_wp_sudo' )]]></code>
+      <code><![CDATA[wp_sudo_can( 'manage_wp_sudo' )]]></code>
+      <code><![CDATA[wp_sudo_can( 'manage_wp_sudo' )]]></code>
+      <code><![CDATA[wp_sudo_can( 'manage_wp_sudo' )]]></code>
+      <code><![CDATA[wp_sudo_can( 'revoke_wp_sudo_sessions' )]]></code>
+      <code><![CDATA[wp_sudo_is_recovery_mode()]]></code>
+      <code><![CDATA[wp_sudo_is_recovery_mode()]]></code>
+    </UndefinedFunction>
   </file>
   <file src="includes/class-challenge.php">
     <UndefinedClass>
       <code><![CDATA[\Two_Factor_Core]]></code>
       <code><![CDATA[\Two_Factor_Core]]></code>
     </UndefinedClass>
+    <UndefinedConstant>
+      <code><![CDATA[WP_SUDO_PLUGIN_URL]]></code>
+      <code><![CDATA[WP_SUDO_PLUGIN_URL]]></code>
+      <code><![CDATA[WP_SUDO_VERSION]]></code>
+      <code><![CDATA[WP_SUDO_VERSION]]></code>
+    </UndefinedConstant>
+  </file>
+  <file src="includes/class-dashboard-widget.php">
+    <HookInvalidArgs>
+      <code><![CDATA[add_action( 'wp_dashboard_setup', array( self::class, 'register' ) )]]></code>
+    </HookInvalidArgs>
+    <HookNotFound>
+      <code><![CDATA[add_action( 'wp_sudo_activated', array( self::class, 'flush_active_sessions_cache' ), 10, 0 )]]></code>
+      <code><![CDATA[add_action( 'wp_sudo_deactivated', array( self::class, 'flush_active_sessions_cache' ), 10, 0 )]]></code>
+    </HookNotFound>
+    <InvalidArgument>
+      <code><![CDATA[array(
+					'force' => true,
+				)]]></code>
+    </InvalidArgument>
+    <UndefinedFunction>
+      <code><![CDATA[wp_sudo_can( 'view_wp_sudo_activity' )]]></code>
+    </UndefinedFunction>
+  </file>
+  <file src="includes/class-event-recorder.php">
+    <HookNotFound>
+      <code><![CDATA[add_action( $hook, array( self::class, $callback_method ), 10, $accepted_args )]]></code>
+    </HookNotFound>
+  </file>
+  <file src="includes/class-event-store.php">
+    <MissingFile>
+      <code><![CDATA[require_once $upgrade_file]]></code>
+    </MissingFile>
+  </file>
+  <file src="includes/class-gate.php">
+    <InvalidArgument>
+      <code><![CDATA[array_merge(
+				is_array( $get_params ) ? $get_params : array(),
+				is_array( $post_params ) ? $post_params : array()
+			)]]></code>
+    </InvalidArgument>
+  </file>
+  <file src="includes/class-plugin.php">
+    <UndefinedConstant>
+      <code><![CDATA[WP_SUDO_PLUGIN_BASENAME]]></code>
+      <code><![CDATA[WP_SUDO_PLUGIN_URL]]></code>
+      <code><![CDATA[WP_SUDO_PLUGIN_URL]]></code>
+      <code><![CDATA[WP_SUDO_PLUGIN_URL]]></code>
+      <code><![CDATA[WP_SUDO_VERSION]]></code>
+      <code><![CDATA[WP_SUDO_VERSION]]></code>
+      <code><![CDATA[WP_SUDO_VERSION]]></code>
+    </UndefinedConstant>
   </file>
   <file src="includes/class-request-stash.php">
     <InvalidArgument>
-      <code><![CDATA[$_GET]]></code>
       <code><![CDATA[$_POST]]></code>
     </InvalidArgument>
   </file>
@@ -260,5 +343,11 @@
     <UndefinedClass>
       <code><![CDATA[\Two_Factor_Core]]></code>
     </UndefinedClass>
+  </file>
+  <file src="includes/class-upgrader.php">
+    <UndefinedConstant>
+      <code><![CDATA[WP_SUDO_VERSION]]></code>
+      <code><![CDATA[WP_SUDO_VERSION]]></code>
+    </UndefinedConstant>
   </file>
 </files>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -13,7 +13,14 @@
         <directory name="mu-plugin" />
         <directory name="bridges" />
         <file name="wp-sudo.php" />
-        <file name="uninstall.php" />
+        <!--
+            uninstall.php is intentionally NOT analyzed. Including it makes Psalm
+            6.16 silently abort the entire run (exit 0, zero output, no analysis),
+            which turns this gate into a false-pass. Reproduces with no plugins and
+            no baseline, on PHP 8.3 (CI) and 8.5. Tracked upstream against
+            vimeo/psalm. uninstall.php is a thin bootstrap of already-analyzed
+            classes; excluding it is the pragmatic fix until the upstream bug lands.
+        -->
         <ignoreFiles>
             <directory name="vendor" />
             <directory name="tests" />


### PR DESCRIPTION
## Problem

The `Psalm` workflow had been **green while analyzing nothing**. `composer analyse:psalm` was exiting 0 with zero output — a silent no-op — so the gate caught no type errors and the type-coverage badge rendered `unknown` (it was never fed). The PHPUnit workflow was separately red on stale metrics.

## Root cause (bisected to a standalone reproduction)

Including `uninstall.php` in Psalm's `projectFiles` makes Psalm 6.16 **silently abort the entire run** (exit 0, no output, no analysis). The trigger, reduced to a 4-file MRE with no plugins/baseline, is:

> a `class_exists('\X')`-guarded `require_once` of an **autoloadable** file whose top level runs `exit;`

Resolving `class_exists()` consults the real autoloader, which loads the file and **executes its top-level `exit;`**, killing the Psalm process with status 0 before analysis runs. Reproduces on PHP 8.3 (CI) and 8.5. `uninstall.php` matches this pattern (top-level `exit;` + `class_exists()`-guarded requires of guard classes). This is being reported upstream to `vimeo/psalm` (no existing dup; closest relative is vimeo/psalm#3994, which surfaces a *visible* fatal rather than a silent exit-0).

## Changes

- **`psalm.xml.dist`** — exclude `uninstall.php` from analysis (it's a thin bootstrap of already-analyzed classes), with an inline comment. Psalm now completes: **96.0% type coverage**.
- **`psalm-baseline.xml`** — regenerated against the now-working config (7→14 files). The prior baseline was stale from the dead-gate period; surfaced entries are stub/strictness artifacts (namespaced-global calls, `WP_SUDO_*` constants, hook-stub gaps), not runtime bugs.
- **`.github/workflows/psalm.yml`** — the gate step now **fails loudly if Psalm emits no coverage figure** (a guard against this exact silent-no-op class), and the experimental shepherd.dev badge-publish step is marked `continue-on-error` so a third-party outage can't fail the release gate.
- **`docs/current-metrics.md`** — refresh PHP line counts (14,839 / 27,726 / 42,565 / 42,828) to fix the unrelated `verify:metrics` failure that was reddening the PHPUnit workflow.

## Verification

- `composer test` → 788 tests, 2256 assertions, OK
- `composer analyse` → PHPStan `[OK] No errors`; Psalm `No errors found!` @ 96.0050%
- New CI guard tested against healthy / silent-no-op / real-error cases
- The live shepherd.dev badge has been refreshed to **96.0%** (was a bogus stale value)

🤖 Generated with [Claude Code](https://claude.com/claude-code)