### PR TITLE
docs(roadmap): record recovery-mode naming/disambiguation decision (Phase R3)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1801,6 +1801,22 @@ break-glass mechanism should minimize the blast radius of its open window.
    - **Deferred:** broadening the notice to `all_admin_notices`. Notice fatigue plus
      multisite capability nuance outweigh the marginal reminder value once the Site
      Health flag exists.
+   - **Naming / disambiguation.** WP Sudo's "recovery mode" shares the phrase with
+     WordPress core's own recovery mode (`WP_Recovery_Mode`, the fatal-error handler;
+     e.g. the core cron event `recovery_mode_clean_expired_keys`), which confuses
+     readers — a tester mistook a core Site Health cron warning for a WP Sudo fault.
+     **Decision: do not rename the public API.** Every WP Sudo symbol is already
+     prefixed (`WP_SUDO_RECOVERY_MODE`, `wp_sudo_is_recovery_mode()`,
+     `wp_sudo_recovery_mode_active`), so there is no code collision — only the English
+     phrase overlaps — and renaming would break operator `wp-config.php` constants,
+     external SIEM hook subscribers, and the stored `recovery_mode` event type (and its
+     historical rows). Instead: (a) standardize **"break-glass"** as the lead term in
+     all human-facing text (notice, FAQ, security-model, the future Site Health test
+     description) so "recovery" rarely appears unqualified; (b) one safe, non-breaking
+     relabel — the dashboard event label "Recovery" (a display string, not a stored
+     value or API symbol) → **"Break-glass"**; (c) a one-line FAQ/security-model note
+     disambiguating from core's `WP_Recovery_Mode`. Any true symbol rename is deferred
+     to a major version with deprecation aliases.
 
 **Process:** Shipped via a Pre-Implementation Design Review (reviewer agent + design
 brief), strict TDD, and the Pre-Commit Reviewer Workflow, per `CLAUDE.md`.


### PR DESCRIPTION
Follow-up to #61 (which is merged). Adds a **naming / disambiguation** sub-item under the recovery-mode visibility entry (Phase R3 §12.1, item 5).

WP Sudo's "recovery mode" shares the phrase with WordPress core's `WP_Recovery_Mode` (the fatal-error handler — e.g. the core cron event `recovery_mode_clean_expired_keys`), which has already confused a tester (#62 documents that artifact).

**Decision recorded: do not rename the public API.** Every WP Sudo symbol is already `wp_sudo`-prefixed, so there's no code collision — only the English phrase overlaps — and a rename would break operator `wp-config.php` constants, external SIEM subscribers to `wp_sudo_recovery_mode_active`, and the stored `recovery_mode` event type (plus its historical rows). Instead:

- **(a)** standardize **"break-glass"** as the lead term in human-facing text (notice, FAQ, security-model, the future Site Health test description);
- **(b)** one safe, non-breaking relabel — the dashboard event label `"Recovery"` (display-only) → `"Break-glass"`;
- **(c)** a one-line FAQ/security-model note disambiguating from core's `WP_Recovery_Mode`.

Any true symbol rename is deferred to a major version with deprecation aliases. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)