### PR TITLE
ci(e2e): skip E2E on docs-only PRs without deadlocking required checks

### DIFF
--- a/.github/workflows/e2e-nginx.yml
+++ b/.github/workflows/e2e-nginx.yml
@@ -10,8 +10,55 @@ on:
     - cron: '0 6 * * 2'
 
 jobs:
-  e2e-nginx-smoke:
-    name: "E2E Nginx Smoke"
+  # See e2e.yml for the rationale. Documentation-only pull requests skip the
+  # heavy smoke job; the "E2E Nginx Smoke" gate job below always runs and
+  # reports the required status. Fail-safe: any non-doc file, any
+  # non-pull_request event (push / schedule / workflow_dispatch), or any error
+  # → run the smoke job.
+  changes:
+    name: Detect code changes
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      code: ${{ steps.decide.outputs.code }}
+    steps:
+      - name: Decide whether to run the smoke job
+        id: decide
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "Event '${{ github.event_name }}' is not a pull_request — running smoke."
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if ! files=$(gh pr view "${{ github.event.pull_request.number }}" \
+                --repo "${{ github.repository }}" --json files \
+                --jq '.files[].path' 2>/dev/null); then
+            echo "Could not list changed files — running smoke (fail-safe)."
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          code=false
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            case "$f" in
+              *.md|*.txt|*.rst|docs/*|LICENSE) ;;   # documentation — does not require the smoke job
+              *) code=true ;;                        # any non-doc file requires the smoke job
+            esac
+          done <<< "$files"
+          echo "Changed files:"
+          echo "$files"
+          echo "Non-documentation files changed: $code"
+          echo "code=$code" >> "$GITHUB_OUTPUT"
+
+  nginx-smoke:
+    name: "E2E Nginx Smoke (run)"
+    needs: changes
+    if: ${{ needs.changes.outputs.code == 'true' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 30
 
@@ -94,3 +141,28 @@ jobs:
       - name: Stop nginx stack
         if: always()
         run: docker compose -f .github/docker/nginx-mariadb.compose.yml down -v
+
+  # Required status check. Always runs (even when the smoke job is skipped) so
+  # the "E2E Nginx Smoke" context is always reported. Passes when the smoke job
+  # succeeded, or when it was skipped because the PR was documentation-only;
+  # fails on any real failure or cancellation.
+  e2e-nginx-smoke:
+    name: "E2E Nginx Smoke"
+    runs-on: ubuntu-24.04
+    needs: [changes, nginx-smoke]
+    if: always()
+
+    steps:
+      - name: Check smoke result
+        run: |
+          result="${{ needs.nginx-smoke.result }}"
+          if [ "$result" = "success" ]; then
+            echo "Nginx smoke passed."
+            exit 0
+          fi
+          if [ "$result" = "skipped" ] && [ "${{ needs.changes.outputs.code }}" != "true" ]; then
+            echo "Nginx smoke skipped (documentation-only change) — passing the required gate."
+            exit 0
+          fi
+          echo "Nginx smoke result: $result"
+          exit 1

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,8 +11,55 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Decide whether the heavy E2E matrix needs to run. Pull requests that touch
+  # only documentation skip the shards; the "E2E Tests" gate job below still
+  # runs and reports success, so the required status check is never left
+  # pending (which would deadlock the PR). Fail-safe: any non-doc file, any
+  # non-pull_request event, or any error → run E2E.
+  changes:
+    name: Detect code changes
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      code: ${{ steps.decide.outputs.code }}
+    steps:
+      - name: Decide whether to run E2E
+        id: decide
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "Event '${{ github.event_name }}' is not a pull_request — running E2E."
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if ! files=$(gh pr view "${{ github.event.pull_request.number }}" \
+                --repo "${{ github.repository }}" --json files \
+                --jq '.files[].path' 2>/dev/null); then
+            echo "Could not list changed files — running E2E (fail-safe)."
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          code=false
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            case "$f" in
+              *.md|*.txt|*.rst|docs/*|LICENSE) ;;   # documentation — does not require E2E
+              *) code=true ;;                        # any non-doc file requires E2E
+            esac
+          done <<< "$files"
+          echo "Changed files:"
+          echo "$files"
+          echo "Non-documentation files changed: $code"
+          echo "code=$code" >> "$GITHUB_OUTPUT"
+
   e2e-shard:
     name: "E2E Tests shard ${{ matrix.shard-index }}/${{ matrix.shard-total }}"
+    needs: changes
+    if: ${{ needs.changes.outputs.code == 'true' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     strategy:
@@ -80,18 +127,27 @@ jobs:
         if: always()
         run: npx wp-env stop --config .wp-env.e2e.json
 
+  # Required status check. Always runs (even when the shards are skipped) so the
+  # "E2E Tests" context is always reported. Passes when the shards succeeded, or
+  # when they were skipped because the PR was documentation-only; fails on any
+  # real shard failure or cancellation.
   e2e-tests:
     name: "E2E Tests"
     runs-on: ubuntu-24.04
-    needs: e2e-shard
+    needs: [changes, e2e-shard]
     if: always()
 
     steps:
       - name: Check shard results
         run: |
-          if [ "${{ needs.e2e-shard.result }}" != "success" ]; then
-            echo "E2E shard matrix result: ${{ needs.e2e-shard.result }}"
-            exit 1
+          result="${{ needs.e2e-shard.result }}"
+          if [ "$result" = "success" ]; then
+            echo "All E2E shards passed."
+            exit 0
           fi
-
-          echo "All E2E shards passed."
+          if [ "$result" = "skipped" ] && [ "${{ needs.changes.outputs.code }}" != "true" ]; then
+            echo "E2E shards skipped (documentation-only change) — passing the required gate."
+            exit 0
+          fi
+          echo "E2E shard matrix result: $result"
+          exit 1


### PR DESCRIPTION
## Problem
`E2E Tests` and `E2E Nginx Smoke` are **required** status checks but had no path filter, so the full browser/`wp-env` matrix ran on every PR — including docs-only ones (#61, #62, #63). The naive fix (workflow-level `paths`/`paths-ignore`) is a trap: a *required* check that's path-skipped is never reported, leaving the PR stuck "waiting for status" — it can never merge.

## Approach
Skip the **heavy jobs** while keeping the **required gate jobs** always-running:

- **`changes` job** — first-party detector (shell + `gh pr view --json files`, no third-party action). **Fail-safe:** non-`pull_request` events (push/schedule/workflow_dispatch), any error listing files, or any non-doc file → `code=true` (run E2E). Docs = `*.md`, `*.txt`, `*.rst`, `docs/*`, `LICENSE`.
- **Heavy jobs gated** — `e2e-shard` (matrix) and `nginx-smoke` get `needs: changes` + `if: needs.changes.outputs.code == 'true'`, so they **skip on docs-only PRs**.
- **Required gates unchanged in name** — `e2e-tests` (`name: "E2E Tests"`) and `e2e-nginx-smoke` (`name: "E2E Nginx Smoke"`) keep `if: always()`, so the required contexts are **always reported**. Each passes when its heavy job **succeeded** or was **skipped for a docs-only change**, and **fails on any real failure/cancellation**. The nginx heavy job is renamed `"E2E Nginx Smoke (run)"` so the required name moves to the gate. **No branch-protection changes needed.**

## Validation steps
- [ ] **Docs-only PR** (e.g. edit one `.md`): `changes` reports `code=false`; `e2e-shard`/`nginx-smoke` show **skipped**; `E2E Tests` and `E2E Nginx Smoke` report **success** with no shard run → PR is mergeable.
- [ ] **Code PR** (edit any `.php`/config): `code=true`; full matrix runs as before; required checks reflect real results.
- [ ] **Mixed PR** (docs + code): `code=true` → E2E runs (fail-safe).
- [ ] **Workflow-file change** (e.g. editing these YAMLs): `code=true` → E2E runs (the `*)` catch-all covers non-doc paths).
- [ ] **Push to `main` / weekly schedule / manual dispatch**: `code=true` → E2E runs (no regression to main/scheduled coverage).
- [ ] **Real failure not masked**: a genuinely failing shard on a code PR still fails the `E2E Tests` gate (gate passes only on `success`, or `skipped` + `code != 'true'`).

CI-config only; no PHP/source changed. Reviewed via the pre-commit reviewer workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)