### PR TITLE
docs(readme): rename "Lockout Protection" heading to "Break glass recovery scenario"

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -63,7 +63,7 @@ WP Sudo is not a general fix for broken authorization in plugin code. WP Sudo ga
 
 WP Sudo integrates with the **Site Health** tool in WordPress core for rich security diagnostics and advisory notifications. 
 
-### Lockout Protection
+### Break glass recovery scenario
 
 In a lost, last administrator scenario where no one has access to Sudo's settings, the break-glass mechanism is to set `WP_SUDO_RECOVERY_MODE` in `wp-config.php`. It requires filesystem access to activate, so it is not a remote-escalation vector. The grant is **role-gated**: while the constant is defined, the current user receives the master `manage_wp_sudo` capability only if they also hold `manage_options` (single-site) / `manage_network_options` (multisite), so a locked-out administrator recovers while non-admins gain nothing. A permanent non-dismissible notice appears on the Sudo settings screen while it is active, and the `wp_sudo_recovery_mode_active` audit hook fires so the usage is logged. The role gate does not eliminate the residual risk — every administrator regains full Sudo governance while the constant is set — so remove it the moment normal access is restored.
 


### PR DESCRIPTION
The `### Lockout Protection` heading in `readme.md` sat over the break-glass paragraph (`WP_SUDO_RECOVERY_MODE`), which describes an administrator **recovering** access after being locked out of Sudo governance — the opposite direction from "protection," which reads as the brute-force rate-limiting feature (the "5 failed attempts → 5-minute lockout" documented separately). The mislabel conflated two distinct concepts.

Renames it to **"Break glass recovery scenario"**, which matches the content and the break-glass terminology standardized in #63 (leading with "break-glass" to disambiguate from WordPress core's `WP_Recovery_Mode`).

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)