### PR TITLE
fix(playground): grant Sudo governance caps to admin in demo blueprints

### DIFF
--- a/blueprint-main.json
+++ b/blueprint-main.json
@@ -21,7 +21,9 @@
         "resource": "url",
         "url": "https://github.com/dknauss/Sudo/archive/refs/heads/main.zip"
       },
-      "options": { "activate": true }
+      "options": {
+        "activate": true
+      }
     },
     {
       "step": "installPlugin",
@@ -29,11 +31,17 @@
         "resource": "wordpress.org/plugins",
         "slug": "two-factor"
       },
-      "options": { "activate": true }
+      "options": {
+        "activate": true
+      }
     },
     {
       "step": "runPHP",
       "code": "<?php require_once '/wordpress/wp-load.php'; $admin = get_user_by('login', 'admin'); $admin_id = $admin ? (int) $admin->ID : 1; if ($admin) { foreach (array('_wp_sudo_expires', '_wp_sudo_token', '_wp_sudo_failed_attempts', '_wp_sudo_lockout_until', '_wp_sudo_failure_event', '_wp_sudo_throttle_until', '_two_factor_enabled_providers', '_two_factor_provider', '_two_factor_totp_key', '_two_factor_backup_codes') as $key) { delete_user_meta($admin_id, $key); } } $session_lengths = array('janesmith' => 5, 'bobdev' => 7, 'carlosadmin' => 10, 'sarahops' => 12, 'mariadev' => 15); $demo_users = array(array('janesmith', 'jane@example.com', 'Jane', 'Smith', 'editor', true), array('bobdev', 'bob@example.com', 'Bob', 'Developer', 'author', true), array('carlosadmin', 'carlos@example.com', 'Carlos', 'García', 'administrator', true), array('sarahops', 'sarah@example.com', 'Sarah', 'Nakamura', 'editor', true), array('liwei', 'li@example.com', 'Li', 'Wei', 'contributor', false), array('mariadev', 'maria@example.com', 'Maria', 'Santos', 'administrator', true), array('alexkim', 'alex@example.com', 'Alex', 'Kim', 'editor', false), array('priyapatel', 'priya@example.com', 'Priya', 'Patel', 'author', false)); $user_ids = array(); foreach ($demo_users as $u) { $existing = get_user_by('login', $u[0]); $uid = $existing ? (int) $existing->ID : wp_insert_user(array('user_login' => $u[0], 'user_email' => $u[1], 'user_pass' => 'password', 'first_name' => $u[2], 'last_name' => $u[3], 'display_name' => trim($u[2] . ' ' . $u[3]), 'role' => $u[4])); if (!is_wp_error($uid)) { $uid = (int) $uid; $user_ids[$u[0]] = $uid; wp_update_user(array('ID' => $uid, 'user_email' => $u[1], 'first_name' => $u[2], 'last_name' => $u[3], 'display_name' => trim($u[2] . ' ' . $u[3]), 'role' => $u[4])); if ($u[5]) { $minutes = $session_lengths[$u[0]] ?? 15; update_user_meta($uid, '_wp_sudo_expires', time() + ($minutes * MINUTE_IN_SECONDS)); update_user_meta($uid, '_wp_sudo_token', wp_hash(wp_generate_password(32, true, true))); } else { delete_user_meta($uid, '_wp_sudo_expires'); delete_user_meta($uid, '_wp_sudo_token'); } } } if (class_exists('\\WP_Sudo\\Event_Store')) { \\WP_Sudo\\Event_Store::maybe_create_table(); \\WP_Sudo\\Event_Store::bulk_insert(array(array('user_id' => $admin_id, 'event' => 'action_gated', 'rule_id' => 'options.wp_sudo', 'surface' => 'admin', 'ip' => '127.0.0.1', 'context' => array('demo' => true), 'created_at' => gmdate('Y-m-d H:i:s', time() - 90)), array('user_id' => $admin_id, 'event' => 'action_replayed', 'rule_id' => 'options.wp_sudo', 'surface' => '', 'ip' => '127.0.0.1', 'context' => array('demo' => true), 'created_at' => gmdate('Y-m-d H:i:s', time() - 70)), array('user_id' => $user_ids['mariadev'] ?? $admin_id, 'event' => 'action_passed', 'rule_id' => 'plugin.activate', 'surface' => 'admin', 'ip' => '127.0.0.1', 'context' => array('demo' => true), 'created_at' => gmdate('Y-m-d H:i:s', time() - 240)), array('user_id' => $user_ids['carlosadmin'] ?? $admin_id, 'event' => 'action_gated', 'rule_id' => 'user.delete', 'surface' => 'admin', 'ip' => '127.0.0.1', 'context' => array('demo' => true), 'created_at' => gmdate('Y-m-d H:i:s', time() - 520)), array('user_id' => $user_ids['sarahops'] ?? $admin_id, 'event' => 'action_blocked', 'rule_id' => 'auth.app_password', 'surface' => 'rest_app_password', 'ip' => '127.0.0.1', 'context' => array('demo' => true), 'created_at' => gmdate('Y-m-d H:i:s', time() - 960)), array('user_id' => $user_ids['bobdev'] ?? $admin_id, 'event' => 'action_allowed', 'rule_id' => 'tools.export', 'surface' => 'cli', 'ip' => '127.0.0.1', 'context' => array('demo' => true), 'created_at' => gmdate('Y-m-d H:i:s', time() - 1500)), array('user_id' => $user_ids['janesmith'] ?? $admin_id, 'event' => 'action_blocked', 'rule_id' => 'options.critical', 'surface' => 'xmlrpc', 'ip' => '127.0.0.1', 'context' => array('demo' => true), 'created_at' => gmdate('Y-m-d H:i:s', time() - 2300)), array('user_id' => $user_ids['liwei'] ?? $admin_id, 'event' => 'lockout', 'rule_id' => '', 'surface' => '', 'ip' => '127.0.0.1', 'context' => array('demo' => true, 'attempts' => 5), 'created_at' => gmdate('Y-m-d H:i:s', time() - 3600)))); } delete_transient('wp_sudo_active_sessions_' . (function_exists('get_current_blog_id') ? (int) get_current_blog_id() : 0)); update_user_meta($admin_id, 'meta-box-order_dashboard', array('side' => 'wp_sudo_activity,dashboard_quick_press,dashboard_primary', 'normal' => 'dashboard_site_health,dashboard_right_now,dashboard_activity')); update_user_meta($admin_id, 'screen_layout_dashboard', 2); echo 'Prepared WP Sudo demo data. Admin password: password. Sudo challenge password: password. Demo sessions: 5-15 minutes.';"
+    },
+    {
+      "step": "runPHP",
+      "code": "<?php require_once '/wordpress/wp-load.php'; $u = get_user_by( 'login', 'admin' ); if ( $u ) { foreach ( array( 'manage_wp_sudo', 'view_wp_sudo_activity', 'export_wp_sudo_activity', 'revoke_wp_sudo_sessions' ) as $c ) { $u->add_cap( $c ); } }"
     }
   ]
 }

--- a/blueprint.json
+++ b/blueprint.json
@@ -21,7 +21,9 @@
         "resource": "url",
         "url": "https://github.com/dknauss/Sudo/archive/refs/tags/v3.2.0.zip"
       },
-      "options": { "activate": true }
+      "options": {
+        "activate": true
+      }
     },
     {
       "step": "installPlugin",
@@ -29,11 +31,17 @@
         "resource": "wordpress.org/plugins",
         "slug": "two-factor"
       },
-      "options": { "activate": true }
+      "options": {
+        "activate": true
+      }
     },
     {
       "step": "runPHP",
       "code": "<?php require_once '/wordpress/wp-load.php'; $admin = get_user_by('login', 'admin'); $admin_id = $admin ? (int) $admin->ID : 1; if ($admin) { foreach (array('_wp_sudo_expires', '_wp_sudo_token', '_wp_sudo_failed_attempts', '_wp_sudo_lockout_until', '_wp_sudo_failure_event', '_wp_sudo_throttle_until', '_two_factor_enabled_providers', '_two_factor_provider', '_two_factor_totp_key', '_two_factor_backup_codes') as $key) { delete_user_meta($admin_id, $key); } } $session_lengths = array('janesmith' => 5, 'bobdev' => 7, 'carlosadmin' => 10, 'sarahops' => 12, 'mariadev' => 15); $demo_users = array(array('janesmith', 'jane@example.com', 'Jane', 'Smith', 'editor', true), array('bobdev', 'bob@example.com', 'Bob', 'Developer', 'author', true), array('carlosadmin', 'carlos@example.com', 'Carlos', 'García', 'administrator', true), array('sarahops', 'sarah@example.com', 'Sarah', 'Nakamura', 'editor', true), array('liwei', 'li@example.com', 'Li', 'Wei', 'contributor', false), array('mariadev', 'maria@example.com', 'Maria', 'Santos', 'administrator', true), array('alexkim', 'alex@example.com', 'Alex', 'Kim', 'editor', false), array('priyapatel', 'priya@example.com', 'Priya', 'Patel', 'author', false)); $user_ids = array(); foreach ($demo_users as $u) { $existing = get_user_by('login', $u[0]); $uid = $existing ? (int) $existing->ID : wp_insert_user(array('user_login' => $u[0], 'user_email' => $u[1], 'user_pass' => 'password', 'first_name' => $u[2], 'last_name' => $u[3], 'display_name' => trim($u[2] . ' ' . $u[3]), 'role' => $u[4])); if (!is_wp_error($uid)) { $uid = (int) $uid; $user_ids[$u[0]] = $uid; wp_update_user(array('ID' => $uid, 'user_email' => $u[1], 'first_name' => $u[2], 'last_name' => $u[3], 'display_name' => trim($u[2] . ' ' . $u[3]), 'role' => $u[4])); if ($u[5]) { $minutes = $session_lengths[$u[0]] ?? 15; update_user_meta($uid, '_wp_sudo_expires', time() + ($minutes * MINUTE_IN_SECONDS)); update_user_meta($uid, '_wp_sudo_token', wp_hash(wp_generate_password(32, true, true))); } else { delete_user_meta($uid, '_wp_sudo_expires'); delete_user_meta($uid, '_wp_sudo_token'); } } } if (class_exists('\\WP_Sudo\\Event_Store')) { \\WP_Sudo\\Event_Store::maybe_create_table(); \\WP_Sudo\\Event_Store::bulk_insert(array(array('user_id' => $admin_id, 'event' => 'action_gated', 'rule_id' => 'options.wp_sudo', 'surface' => 'admin', 'ip' => '127.0.0.1', 'context' => array('demo' => true), 'created_at' => gmdate('Y-m-d H:i:s', time() - 90)), array('user_id' => $admin_id, 'event' => 'action_replayed', 'rule_id' => 'options.wp_sudo', 'surface' => '', 'ip' => '127.0.0.1', 'context' => array('demo' => true), 'created_at' => gmdate('Y-m-d H:i:s', time() - 70)), array('user_id' => $user_ids['mariadev'] ?? $admin_id, 'event' => 'action_passed', 'rule_id' => 'plugin.activate', 'surface' => 'admin', 'ip' => '127.0.0.1', 'context' => array('demo' => true), 'created_at' => gmdate('Y-m-d H:i:s', time() - 240)), array('user_id' => $user_ids['carlosadmin'] ?? $admin_id, 'event' => 'action_gated', 'rule_id' => 'user.delete', 'surface' => 'admin', 'ip' => '127.0.0.1', 'context' => array('demo' => true), 'created_at' => gmdate('Y-m-d H:i:s', time() - 520)), array('user_id' => $user_ids['sarahops'] ?? $admin_id, 'event' => 'action_blocked', 'rule_id' => 'auth.app_password', 'surface' => 'rest_app_password', 'ip' => '127.0.0.1', 'context' => array('demo' => true), 'created_at' => gmdate('Y-m-d H:i:s', time() - 960)), array('user_id' => $user_ids['bobdev'] ?? $admin_id, 'event' => 'action_allowed', 'rule_id' => 'tools.export', 'surface' => 'cli', 'ip' => '127.0.0.1', 'context' => array('demo' => true), 'created_at' => gmdate('Y-m-d H:i:s', time() - 1500)), array('user_id' => $user_ids['janesmith'] ?? $admin_id, 'event' => 'action_blocked', 'rule_id' => 'options.critical', 'surface' => 'xmlrpc', 'ip' => '127.0.0.1', 'context' => array('demo' => true), 'created_at' => gmdate('Y-m-d H:i:s', time() - 2300)), array('user_id' => $user_ids['liwei'] ?? $admin_id, 'event' => 'lockout', 'rule_id' => '', 'surface' => '', 'ip' => '127.0.0.1', 'context' => array('demo' => true, 'attempts' => 5), 'created_at' => gmdate('Y-m-d H:i:s', time() - 3600)))); } delete_transient('wp_sudo_active_sessions_' . (function_exists('get_current_blog_id') ? (int) get_current_blog_id() : 0)); update_user_meta($admin_id, 'meta-box-order_dashboard', array('side' => 'wp_sudo_activity,dashboard_quick_press,dashboard_primary', 'normal' => 'dashboard_site_health,dashboard_right_now,dashboard_activity')); update_user_meta($admin_id, 'screen_layout_dashboard', 2); echo 'Prepared WP Sudo demo data. Admin password: password. Sudo challenge password: password. Demo sessions: 5-15 minutes.';"
+    },
+    {
+      "step": "runPHP",
+      "code": "<?php require_once '/wordpress/wp-load.php'; $u = get_user_by( 'login', 'admin' ); if ( $u ) { foreach ( array( 'manage_wp_sudo', 'view_wp_sudo_activity', 'export_wp_sudo_activity', 'revoke_wp_sudo_sessions' ) as $c ) { $u->add_cap( $c ); } }"
     }
   ]
 }


### PR DESCRIPTION
## Problem
The demo Playground blueprints (`blueprint.json`, `blueprint-main.json`) showcase WP Sudo but **cannot open Settings → Sudo**. The settings page requires the `manage_wp_sudo` capability (`Admin::PAGE_SLUG`), and the plugin grants the four governance caps only to the *activating user* (`get_current_user_id()` in the activation hook, `includes/class-plugin.php:438`). WordPress Playground activates plugins **programmatically with no current user**, so no account receives the caps.

This is the same gap `.github/workflows/e2e-nginx.yml` already works around with `wp user add-cap admin manage_wp_sudo …` (Docker CLI activation also has no current user). It went unnoticed because the demos land on `/wp-admin/`, not the Sudo settings page.

## Fix
Append one `runPHP` step to each blueprint granting `manage_wp_sudo`, `view_wp_sudo_activity`, `export_wp_sudo_activity`, and `revoke_wp_sudo_sessions` to the `admin` user — reproducing the intended single-site-install state ("the installing administrator receives all four caps", per readme). Idempotent and harmless if activation already granted them. The recovery scenario blueprint (`blueprint-recovery-mode.json`) is intentionally left as-is (it relies on recovery mode for access).

## Notes
- `jq` reserialized the JSON, so the diff also shows a **whitespace-only** inline→multiline reformat of two `installPlugin options` blocks. The large demo-seed `runPHP` string is **byte-identical**, and the seed remains identical between the two blueprints.
- Reviewed via the pre-commit reviewer workflow (JSON valid + schema-conformant, PHP lints, additive-only, grants exactly the four caps).

## Validation (not yet browser-confirmed)
Runtime behavior is reasoned from source — I could not boot Playground. To confirm: load each blueprint and navigate to `/wp-admin/options-general.php?page=wp-sudo-settings`; the `admin` user should now reach the settings page and see the Sudo activity dashboard widget (needs `view_wp_sudo_activity`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)