### PR TITLE
docs(roadmap): mark stale §23.8 manual-testing item as done

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1842,9 +1842,9 @@ brief), strict TDD, and the Pre-Commit Reviewer Workflow, per `CLAUDE.md`.
   `docs/security-model.md` and `docs/FAQ.md`. (`readme.md` carries pre-existing
   unrelated working-tree edits; reconcile its recovery wording there.)
 - ✅ Updated `docs/llm-lies-log.md` #20 notes to mark the containment as built.
-- ⏳ `tests/MANUAL-TESTING.md` §23.8 still documents the *uncontained* behavior
-  (non-admin gains access); update it to expect denial for non-admins and add steps
-  for the notice and audit event.
+- ✅ `tests/MANUAL-TESTING.md` §23.8 documents the contained behavior — it expects
+  denial for non-administrators and includes steps for the non-dismissible notice and
+  the sampled `recovery_mode` audit event.
 
 #### Phase R4: E2E CI acceleration and release-assurance tuning
 


### PR DESCRIPTION
The Phase R3 §12.1 "Docs reconciled" list still flagged `tests/MANUAL-TESTING.md` §23.8 as outstanding (⏳ "still documents the *uncontained* behavior … update it to expect denial for non-admins and add steps for the notice and audit event").

That note is **stale** — §23.8 already documents the contained, role-gated behavior:
- non-administrator **denial** (steps 5-7),
- the **non-dismissible notice** (step 4),
- the sampled **`recovery_mode` audit event** (step 8).

Flips the item from ⏳ to ✅. Docs-only.

> Scope note: this is the one roadmap item I could **verify** as stale. I did not attempt a broad roadmap audit — that overlaps with the in-flight v3.3.0 doc pass on `docs/ROADMAP.md` (see below).

🤖 Generated with [Claude Code](https://claude.com/claude-code)