### PR TITLE
docs: fix slug everywhere

### DIFF
--- a/.planning/phases/10-settings-ui-revision/10-01-PLAN.md
+++ b/.planning/phases/10-settings-ui-revision/10-01-PLAN.md
@@ -345,7 +345,7 @@ Tasks 4, 5, and 6 are independent and can be done in parallel.
   survive the POST-redirect cycle. The redirect URL (line 867) should include
   `&tab=settings` if not already default.
 - **Bookmark URLs:** Tab links should be stable URLs so users can bookmark
-  e.g., `?page=wp-sudo&tab=tester` directly.
+  e.g., `?page=wp-sudo-settings&tab=tester` directly.
 - **Screen options / help panel:** Help panel is registered once via
   `add_help_tabs()` on the `load-{page}` hook. All 12 tabs show regardless
   of which settings tab is active. This is standard WordPress behavior — help

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1748,7 +1748,7 @@ Verified against the code path and WordPress core admin-page routing (describes 
 - WordPress core gates the Sudo submenu page by its own capability
   (`user_can_access_admin_page()` → `current_user_can('manage_wp_sudo')`, mapped to
   `exist` in recovery mode), so a non-admin reaching
-  `options-general.php?page=wp-sudo` directly passes — the hidden Settings menu is
+  `options-general.php?page=wp-sudo-settings` directly passes — the hidden Settings menu is
   not a real barrier.
 - The promised safeguards never existed: no admin notice and no
   `governance.recovery_mode` audit event are implemented anywhere in `includes/`.

--- a/tests/MANUAL-TESTING.md
+++ b/tests/MANUAL-TESTING.md
@@ -1825,7 +1825,7 @@ curl -sk -X POST "YOUR_SITE_URL/graphql" \
   `manage_wp_sudo`.
 
 1. Navigate directly to **Settings > Sudo** (or
-   `/wp-admin/options-general.php?page=wp-sudo`).
+   `/wp-admin/options-general.php?page=wp-sudo-settings`).
 2. **Expected:** WordPress displays "Sorry, you are not allowed to access this
    page." The **Settings > Sudo** menu item does not appear in the sidebar for
    this user.
@@ -1938,7 +1938,7 @@ access to non-administrators.
    should be removed once access is restored.
 5. Log out and log in as a **non-administrator** user (e.g. Editor or
    Subscriber) that lacks `manage_options`.
-6. Navigate directly to `/wp-admin/options-general.php?page=wp-sudo`.
+6. Navigate directly to `/wp-admin/options-general.php?page=wp-sudo-settings`.
 7. **Expected:** The page is **denied** — WordPress displays "Sorry, you are
    not allowed to access this page." The recovery path now requires
    `manage_options` / `manage_network_options`, so a non-admin gains nothing


### PR DESCRIPTION
Fixes every occurrence of the wrong Sudo settings-page slug `?page=wp-sudo` → the real slug **`wp-sudo-settings`** (`WP_Sudo\Admin::PAGE_SLUG`). Verified zero `?page=wp-sudo` (non-`-settings`) references remain in the repo.

Occurrences fixed:
- **`tests/MANUAL-TESTING.md`** §23 and §23.8 — both are access-**denial** steps, so the wrong slug made them pass for the *wrong reason* (a non-existent admin page also returns "Sorry, you are not allowed to access this page"); they now exercise the real capability gate.
- **`docs/ROADMAP.md`** — the Phase R3 finding's example URL.
- **`.planning/phases/10-settings-ui-revision/10-01-PLAN.md`** — a bookmark-URL example in the archived phase-10 plan (included per request to make the fix complete everywhere).

No code/JS references exist (production uses the `PAGE_SLUG` constant). Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)