### PR TITLE
ci: skip unit/integration/Psalm/CodeQL on docs-only PRs (no deadlock)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,8 +15,54 @@ permissions:
   security-events: write
 
 jobs:
+  # Documentation-only pull requests skip CodeQL analysis (it scans code, not
+  # docs); the "CodeQL" gate job below always runs and reports the required
+  # status. Fail-safe: any non-doc file (including workflow files, which CodeQL's
+  # `actions` language scans), any non-pull_request event, or any error → analyze.
+  changes:
+    name: Detect code changes
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      code: ${{ steps.decide.outputs.code }}
+    steps:
+      - name: Decide whether to run CodeQL
+        id: decide
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "Event '${{ github.event_name }}' is not a pull_request — running CodeQL."
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if ! files=$(gh pr view "${{ github.event.pull_request.number }}" \
+                --repo "${{ github.repository }}" --json files \
+                --jq '.files[].path' 2>/dev/null); then
+            echo "Could not list changed files — running CodeQL (fail-safe)."
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          code=false
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            case "$f" in
+              *.md|*.txt|*.rst|docs/*|LICENSE) ;;   # documentation — does not require CodeQL
+              *) code=true ;;                        # any non-doc file requires CodeQL
+            esac
+          done <<< "$files"
+          echo "Changed files:"
+          echo "$files"
+          echo "Non-documentation files changed: $code"
+          echo "code=$code" >> "$GITHUB_OUTPUT"
+
   analyze:
     name: "Analyze (${{ matrix.language }})"
+    needs: changes
+    if: ${{ needs.changes.outputs.code == 'true' }}
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
@@ -37,16 +83,28 @@ jobs:
         with:
           category: "/language:${{ matrix.language }}"
 
+  # Required status check. Always runs (even when analysis is skipped) so the
+  # "CodeQL" context is always reported. Passes when analysis succeeded, or when
+  # it was skipped because the PR was documentation-only; fails otherwise.
   codeql-summary:
     name: "CodeQL"
     runs-on: ubuntu-24.04
-    needs: [analyze]
+    needs: [changes, analyze]
     if: ${{ always() }}
 
     steps:
       - name: Enforce successful CodeQL analysis
         run: |
-          if [ "${{ needs.analyze.result }}" != "success" ]; then
-            echo "CodeQL analysis did not succeed."
+          if [ "${{ needs.changes.result }}" != "success" ]; then
+            echo "Change detector did not succeed (${{ needs.changes.result }}) — failing the gate (fail-safe)."
             exit 1
           fi
+          if [ "${{ needs.changes.outputs.code }}" != "true" ]; then
+            echo "Documentation-only change — CodeQL skipped; gate passes."
+            exit 0
+          fi
+          if [ "${{ needs.analyze.result }}" != "success" ]; then
+            echo "CodeQL analysis did not succeed: ${{ needs.analyze.result }}"
+            exit 1
+          fi
+          echo "CodeQL analysis passed."

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -8,6 +8,12 @@ on:
   schedule:
     - cron: '0 3 * * *'  # Nightly at 3 AM UTC — catches stable floor and 7.0 regressions.
 
+# Least-privilege default for GITHUB_TOKEN (CodeQL actions hardening). Jobs that
+# need more (the change detector's pull-requests: read; notify-on-failure's
+# issues: write) set it per-job.
+permissions:
+  contents: read
+
 jobs:
   # Documentation-only pull requests skip the heavy test/quality jobs; the
   # "PHPUnit" gate job below always runs and reports the required status, so the

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -9,8 +9,55 @@ on:
     - cron: '0 3 * * *'  # Nightly at 3 AM UTC — catches stable floor and 7.0 regressions.
 
 jobs:
+  # Documentation-only pull requests skip the heavy test/quality jobs; the
+  # "PHPUnit" gate job below always runs and reports the required status, so the
+  # required check is never left pending (which would deadlock the PR).
+  # Fail-safe: any non-doc file, any non-pull_request event (push / nightly
+  # schedule), or any error → run the heavy jobs.
+  changes:
+    name: Detect code changes
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      code: ${{ steps.decide.outputs.code }}
+    steps:
+      - name: Decide whether to run the heavy jobs
+        id: decide
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "Event '${{ github.event_name }}' is not a pull_request — running heavy jobs."
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if ! files=$(gh pr view "${{ github.event.pull_request.number }}" \
+                --repo "${{ github.repository }}" --json files \
+                --jq '.files[].path' 2>/dev/null); then
+            echo "Could not list changed files — running heavy jobs (fail-safe)."
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          code=false
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            case "$f" in
+              *.md|*.txt|*.rst|docs/*|LICENSE) ;;   # documentation — does not require the test suite
+              *) code=true ;;                        # any non-doc file requires the test suite
+            esac
+          done <<< "$files"
+          echo "Changed files:"
+          echo "$files"
+          echo "Non-documentation files changed: $code"
+          echo "code=$code" >> "$GITHUB_OUTPUT"
+
   unit-tests:
     name: "Unit Tests (PHP ${{ matrix.php }})"
+    needs: changes
+    if: ${{ needs.changes.outputs.code == 'true' }}
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
@@ -64,6 +111,8 @@ jobs:
 
   unit-tests-coverage:
     name: "Unit Tests (Coverage)"
+    needs: changes
+    if: ${{ needs.changes.outputs.code == 'true' }}
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
@@ -111,6 +160,8 @@ jobs:
 
   integration-tests:
     name: "Integration Tests (PHP ${{ matrix.php }}, WP ${{ matrix.wp }}, MS ${{ matrix.multisite }}, ${{ matrix.db_label }})"
+    needs: changes
+    if: ${{ needs.changes.outputs.code == 'true' }}
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
@@ -235,6 +286,8 @@ jobs:
 
   code-quality:
     name: "Code Quality (lint + static analysis)"
+    needs: changes
+    if: ${{ needs.changes.outputs.code == 'true' }}
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
@@ -270,14 +323,26 @@ jobs:
       - name: Run PHPStan
         run: composer analyse:phpstan
 
+  # Required status check. Always runs (even when the heavy jobs are skipped) so
+  # the "PHPUnit" context is always reported. Passes when the heavy jobs
+  # succeeded, or when they were skipped because the PR was documentation-only;
+  # fails on any real failure or cancellation.
   phpunit-summary:
     name: "PHPUnit"
     runs-on: ubuntu-24.04
-    needs: [unit-tests, unit-tests-coverage, integration-tests, code-quality]
+    needs: [changes, unit-tests, unit-tests-coverage, integration-tests, code-quality]
     if: ${{ always() }}
     steps:
       - name: Enforce successful PHPUnit workflow jobs
         run: |
+          if [ "${{ needs.changes.result }}" != "success" ]; then
+            echo "Change detector did not succeed (${{ needs.changes.result }}) — failing the gate (fail-safe)."
+            exit 1
+          fi
+          if [ "${{ needs.changes.outputs.code }}" != "true" ]; then
+            echo "Documentation-only change — heavy jobs skipped; passing the PHPUnit gate."
+            exit 0
+          fi
           for result in \
             "${{ needs.unit-tests.result }}" \
             "${{ needs.unit-tests-coverage.result }}" \
@@ -288,6 +353,7 @@ jobs:
               exit 1
             fi
           done
+          echo "All PHPUnit jobs passed."
 
   notify-on-failure:
     name: "Notify on failure"

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -7,8 +7,54 @@ on:
     branches: [main]
 
 jobs:
-  psalm:
-    name: "Psalm"
+  # Documentation-only pull requests skip the heavy Psalm job; the "Psalm" gate
+  # job below always runs and reports the required status, so the required check
+  # is never left pending (which would deadlock the PR). Fail-safe: any non-doc
+  # file, any non-pull_request event, or any error → run Psalm.
+  changes:
+    name: Detect code changes
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      code: ${{ steps.decide.outputs.code }}
+    steps:
+      - name: Decide whether to run Psalm
+        id: decide
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "Event '${{ github.event_name }}' is not a pull_request — running Psalm."
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if ! files=$(gh pr view "${{ github.event.pull_request.number }}" \
+                --repo "${{ github.repository }}" --json files \
+                --jq '.files[].path' 2>/dev/null); then
+            echo "Could not list changed files — running Psalm (fail-safe)."
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          code=false
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            case "$f" in
+              *.md|*.txt|*.rst|docs/*|LICENSE) ;;   # documentation — does not require Psalm
+              *) code=true ;;                        # any non-doc file requires Psalm
+            esac
+          done <<< "$files"
+          echo "Changed files:"
+          echo "$files"
+          echo "Non-documentation files changed: $code"
+          echo "code=$code" >> "$GITHUB_OUTPUT"
+
+  psalm-run:
+    name: "Psalm (run)"
+    needs: changes
+    if: ${{ needs.changes.outputs.code == 'true' }}
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
@@ -58,3 +104,29 @@ jobs:
         # step log (no "🐑 results sent" line) without blocking the build.
         continue-on-error: true
         run: composer analyse:psalm:shepherd
+
+  # Required status check. Always runs (even when psalm-run is skipped) so the
+  # "Psalm" context is always reported. Passes when psalm-run succeeded, or when
+  # it was skipped because the PR was documentation-only; fails otherwise.
+  psalm:
+    name: "Psalm"
+    runs-on: ubuntu-24.04
+    needs: [changes, psalm-run]
+    if: always()
+    steps:
+      - name: Check Psalm result
+        run: |
+          if [ "${{ needs.changes.result }}" != "success" ]; then
+            echo "Change detector did not succeed (${{ needs.changes.result }}) — failing the gate (fail-safe)."
+            exit 1
+          fi
+          if [ "${{ needs.changes.outputs.code }}" != "true" ]; then
+            echo "Documentation-only change — Psalm skipped; gate passes."
+            exit 0
+          fi
+          if [ "${{ needs.psalm-run.result }}" = "success" ]; then
+            echo "Psalm passed."
+            exit 0
+          fi
+          echo "Psalm result: ${{ needs.psalm-run.result }}"
+          exit 1

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [main]
 
+# Least-privilege default for GITHUB_TOKEN (CodeQL actions hardening). Jobs that
+# need more (e.g. the change detector's pull-requests: read) set it per-job.
+permissions:
+  contents: read
+
 jobs:
   # Documentation-only pull requests skip the heavy Psalm job; the "Psalm" gate
   # job below always runs and reports the required status, so the required check


### PR DESCRIPTION
## Problem
`PHPUnit`, `Psalm`, and `CodeQL` are **required** status checks with no path filter, so the full test/static-analysis/security suite runs on every PR — including docs-only ones. (#64 already did this for E2E; this completes the set.) A workflow-level `paths` filter is **not** an option: a path-skipped *required* check is never reported and blocks merge forever.

## Approach (same gate pattern as #64)
- **`changes` detector** per workflow — first-party (shell + `gh pr view --json files`, no third-party action), **fail-safe**: non-`pull_request` events (push/nightly schedule/dispatch), any error, or any non-doc file → `code=true`. Docs = `*.md`/`*.txt`/`*.rst`/`docs/*`/`LICENSE`. Carries its own `pull-requests: read`.
- **Heavy jobs gated** on `needs.changes.outputs.code == 'true'`:
  - phpunit: `unit-tests`, `unit-tests-coverage`, `integration-tests`, `code-quality`
  - psalm: analysis job → renamed `psalm-run` / `"Psalm (run)"`
  - codeql: `analyze` matrix
- **Required gates keep exact names** (`PHPUnit`, `Psalm`, `CodeQL`), `if: always()`. Each gate:
  1. **fails** if the `changes` detector itself didn't succeed (closes a false-pass gap a failed detector could open — stricter than #64),
  2. else **passes** for docs-only changes (heavy jobs skipped),
  3. else requires the heavy jobs to have **succeeded**.

No branch-protection changes; required context names unchanged.

## Validation steps
- [ ] **Docs-only PR**: `changes` → `code=false`; heavy jobs **skipped**; `PHPUnit`/`Psalm`/`CodeQL` report **success**; PR mergeable.
- [ ] **Code PR** (`.php`/config): `code=true`; full suite runs; required checks reflect real results.
- [ ] **Workflow-file edit** (these YAMLs): `code=true` (catch-all) → full suite runs.
- [ ] **Push to main / nightly schedule / dispatch**: `code=true` → full suite runs (no regression).
- [ ] **Real failure not masked**: a failing heavy job on a code PR fails its gate.
- [ ] **Detector failure**: if a `changes` job is failed/cancelled, its gate **fails** (does not silently skip).

## Note
The new gates are **stricter than #64's e2e gates**, which lack the detector-result guard. Recommend a follow-up to harden `e2e.yml`/`e2e-nginx.yml` identically. (A shared composite action to de-duplicate the detector across all 5 workflows is also a reasonable future cleanup.)

CI-config only; no PHP/source changed. Reviewed twice via the pre-commit reviewer workflow (initial + the detector-guard hardening).

🤖 Generated with [Claude Code](https://claude.com/claude-code)