### PR TITLE
test(gate): fix random-order is_ssl flake (leaked REQUEST_URI)

### DIFF
--- a/docs/current-metrics.md
+++ b/docs/current-metrics.md
@@ -20,10 +20,10 @@ Verification environment: local workspace, PHP 8.x
 | Metric | Value | Verification |
 |---|---:|---|
 | Production PHP lines (`includes/`, `wp-sudo.php`, `uninstall.php`, `mu-plugin/`, `bridges/`) | 14,839 | `find ./includes ./wp-sudo.php ./uninstall.php ./mu-plugin ./bridges -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
-| Tests PHP lines (`tests/`) | 27,726 | `find ./tests -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
-| Production + tests PHP lines | 42,565 | sum of the two rows above |
-| Test-to-production ratio | 1.87:1 | `27726 / 14839` |
-| Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`) | 42,828 | `find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/vendor_test/*" ! -path "*/.tmp/*" ! -path "*/.git/*" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Tests PHP lines (`tests/`) | 27,740 | `find ./tests -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Production + tests PHP lines | 42,579 | sum of the two rows above |
+| Test-to-production ratio | 1.87:1 | `27740 / 14839` |
+| Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`) | 42,842 | `find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/vendor_test/*" ! -path "*/.tmp/*" ! -path "*/.git/*" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
 
 ## Architectural Facts
 

--- a/tests/Unit/GateTest.php
+++ b/tests/Unit/GateTest.php
@@ -44,9 +44,22 @@ class GateTest extends TestCase {
 
 	protected function setUp(): void {
 		parent::setUp();
+
+		// Clear request superglobals that other test files may leak. The notice
+		// tests assume get_current_admin_url() sees no REQUEST_URI (so it
+		// early-returns); a value leaked from a prior test pushes them into the
+		// is_ssl() branch, which under --order-by=random surfaced as a
+		// Brain\Monkey "is_ssl not defined nor mocked" flake.
+		unset( $_SERVER['REQUEST_URI'] );
+
 		$this->session = \Mockery::mock( Sudo_Session::class );
 		$this->stash   = \Mockery::mock( Request_Stash::class );
 		$this->gate    = new Gate( $this->session, $this->stash );
+
+		// Defense in depth: any test that does set REQUEST_URI and renders a
+		// notice reaches is_ssl(); stub it unconditionally so it is mocked
+		// regardless of execution order.
+		Functions\when( 'is_ssl' )->justReturn( false );
 	}
 
 	protected function tearDown(): void {
@@ -63,6 +76,7 @@ class GateTest extends TestCase {
 			$_POST['plugin'],
 			$_GET['download'],
 			$_SERVER['REQUEST_METHOD'],
+			$_SERVER['REQUEST_URI'],
 			$GLOBALS['pagenow'],
 			$GLOBALS['wpdb']
 		);


### PR DESCRIPTION
## Problem
The unit suite runs with `--order-by=random` (phpunit.yml). On some seeds — reproduced deterministically with **seed `1781378380`** — four GateTest notice tests error with Brain\Monkey *"is_ssl is not defined nor mocked in this test."* This flake has surfaced repeatedly in CI on unrelated PRs (e.g. it failed #75, which changed no PHP).

## Root cause
GateTest **passes in isolation**: the notice tests don't set `$_SERVER['REQUEST_URI']`, so `Gate::get_current_admin_url()` early-returns *before* calling `is_ssl()`. In the **full suite**, a prior test file leaks `$_SERVER['REQUEST_URI']` (GateTest's `tearDown` never unset it), pushing those tests into the `is_ssl()` branch where `is_ssl` was unmocked → Brain\Monkey error. Random ordering decides whether the leak lands before the notice tests, hence the seed-dependence.

## Fix (test-only, `tests/Unit/GateTest.php`)
- `setUp()`: `unset( $_SERVER['REQUEST_URI'] )` — clears leaked request state (the root cause), restoring the clean state the notice tests assume.
- `setUp()`: stub `is_ssl() → false` as **defense in depth** for any test that does set REQUEST_URI and renders a notice.
- `tearDown()`: also unset `$_SERVER['REQUEST_URI']` so GateTest stops leaking it to other files.

## Verification
- Previously-failing **seed `1781378380`**: now **OK (788 tests)**.
- Seeds 7 / 13 / 42 / 555 / 999999 / 1234567 and default order: all **OK**.
- PHPStan level 6: clean.
- Test-only; no assertions weakened, no tests skipped.

Reviewed via the pre-commit reviewer workflow. Once merged, this removes the random-order flake for **all** PRs (it's what's currently blocking #75's unit-test checks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)