### PR TITLE
ci: least-privilege permissions on all workflows + harden e2e gates

### DIFF
--- a/.github/workflows/compat-wordpress-minors.yml
+++ b/.github/workflows/compat-wordpress-minors.yml
@@ -5,6 +5,10 @@ on:
   schedule:
     - cron: '30 5 * * 3'
 
+# Least-privilege default for GITHUB_TOKEN (CodeQL actions hardening).
+permissions:
+  contents: read
+
 jobs:
   integration-compat:
     name: "Compat Sweep (PHP 8.1, WP ${{ matrix.wp }}, ${{ matrix.db_label }})"

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -9,6 +9,10 @@ on:
     paths:
       - .github/workflows/copilot-setup-steps.yml
 
+# Least-privilege default for GITHUB_TOKEN (CodeQL actions hardening).
+permissions:
+  contents: read
+
 jobs:
   copilot-setup-steps:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main ]
 
+# Least-privilege default for GITHUB_TOKEN (CodeQL actions hardening).
+permissions:
+  contents: read
+
 jobs:
   docs-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-nginx-multisite.yml
+++ b/.github/workflows/e2e-nginx-multisite.yml
@@ -5,6 +5,10 @@ on:
   schedule:
     - cron: '0 7 * * 4'
 
+# Least-privilege default for GITHUB_TOKEN (CodeQL actions hardening).
+permissions:
+  contents: read
+
 jobs:
   e2e-nginx-multisite-smoke:
     name: "E2E Nginx Multisite Smoke"

--- a/.github/workflows/e2e-nginx.yml
+++ b/.github/workflows/e2e-nginx.yml
@@ -9,6 +9,10 @@ on:
   schedule:
     - cron: '0 6 * * 2'
 
+# Least-privilege default for GITHUB_TOKEN (CodeQL actions hardening).
+permissions:
+  contents: read
+
 jobs:
   # See e2e.yml for the rationale. Documentation-only pull requests skip the
   # heavy smoke job; the "E2E Nginx Smoke" gate job below always runs and
@@ -155,6 +159,10 @@ jobs:
     steps:
       - name: Check smoke result
         run: |
+          if [ "${{ needs.changes.result }}" != "success" ]; then
+            echo "Change detector did not succeed (${{ needs.changes.result }}) — failing the gate (fail-safe)."
+            exit 1
+          fi
           result="${{ needs.nginx-smoke.result }}"
           if [ "$result" = "success" ]; then
             echo "Nginx smoke passed."

--- a/.github/workflows/e2e-sqlite.yml
+++ b/.github/workflows/e2e-sqlite.yml
@@ -5,6 +5,10 @@ on:
   schedule:
     - cron: '0 7 * * 4'
 
+# Least-privilege default for GITHUB_TOKEN (CodeQL actions hardening).
+permissions:
+  contents: read
+
 jobs:
   e2e-sqlite-smoke:
     name: "E2E Stack Smoke (Playground SQLite)"

--- a/.github/workflows/e2e-visual.yml
+++ b/.github/workflows/e2e-visual.yml
@@ -5,6 +5,10 @@ on:
   schedule:
     - cron: '30 4 * * *'
 
+# Least-privilege default for GITHUB_TOKEN (CodeQL actions hardening).
+permissions:
+  contents: read
+
 jobs:
   e2e-visual:
     name: "E2E Visual Baselines (Apache + MariaDB, non-blocking)"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,6 +10,10 @@ concurrency:
   group: e2e-tests-${{ github.ref }}
   cancel-in-progress: true
 
+# Least-privilege default for GITHUB_TOKEN (CodeQL actions hardening).
+permissions:
+  contents: read
+
 jobs:
   # Decide whether the heavy E2E matrix needs to run. Pull requests that touch
   # only documentation skip the shards; the "E2E Tests" gate job below still
@@ -140,6 +144,10 @@ jobs:
     steps:
       - name: Check shard results
         run: |
+          if [ "${{ needs.changes.result }}" != "success" ]; then
+            echo "Change detector did not succeed (${{ needs.changes.result }}) — failing the gate (fail-safe)."
+            exit 1
+          fi
           result="${{ needs.e2e-shard.result }}"
           if [ "$result" = "success" ]; then
             echo "All E2E shards passed."


### PR DESCRIPTION
Two follow-ups from the #75 review threads.

## 1. Least-privilege `permissions` on remaining workflows
CodeQL's "workflow does not contain permissions" finding (which fixed psalm/phpunit in #75) applies to the other workflows too. Adds a top-level `permissions: { contents: read }` to the **8** workflows that lacked one:
`compat-wordpress-minors`, `copilot-setup-steps`, `docs-lint`, `e2e`, `e2e-nginx`, `e2e-nginx-multisite`, `e2e-sqlite`, `e2e-visual`.

All are checkout + test/lint/setup runners — verified none creates issues, posts comments, uploads SARIF, deploys, or needs `packages:`/`id-token:` (artifact upload uses the runner token, not `GITHUB_TOKEN` scope). The e2e change-detector keeps its job-level `pull-requests: read` (job-level overrides the new default). Workflows that already had blocks (codeql, phpunit, psalm, playground-preview, composer-security, docs-links) are untouched.

## 2. Harden the e2e gates
Adds a `needs.changes.result != 'success'` guard as the **first** check in the `e2e.yml` and `e2e-nginx.yml` required gates, matching the stricter pattern shipped for phpunit/psalm/codeql in #75. A failed/cancelled change-detector now **fails** the gate instead of falling through to a docs-only pass — closing the same false-pass gap the #75 review flagged. Required context names (`E2E Tests`, `E2E Nginx Smoke`) and the skip logic are unchanged.

CI-config only; no PHP/source changed. Reviewed via the pre-commit reviewer workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)