### PR TITLE
chore(release): v3.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 3.4.0 - 2026-06-13
+
+- **Break-glass recovery mode hardened (role-gated + visible):** `WP_SUDO_RECOVERY_MODE` previously granted the master `manage_wp_sudo` capability to any logged-in user. The grant is now role-gated — it applies only to users who also hold `manage_options` (single-site) or `manage_network_options` (multisite), so a locked-out administrator recovers while subscribers, editors, and other non-admins gain nothing. A permanent, non-dismissible notice now renders on the Sudo settings screen while recovery mode is active, and a new `wp_sudo_recovery_mode_active` audit hook fires (stored as a sampled `recovery_mode` event, at most one per user per hour), so break-glass usage is explicit, bounded, and auditable.
+- **New audit hook `wp_sudo_recovery_mode_active`:** fires on each Sudo admin-page load while recovery mode is active. See the developer reference for the signature.
+- **Psalm gate repaired:** the type-coverage gate had been silently passing without analyzing anything — a top-level `exit` in `uninstall.php` aborted the Psalm run (exit 0, zero output). `uninstall.php` is now excluded from analysis, a guard fails the gate loudly if no type-coverage figure is emitted, and the shepherd.dev type-coverage badge reports again (~96%).
+- **CI hardening:** least-privilege `permissions` blocks added to all workflows; documentation-only pull requests now skip the heavy unit/integration/Psalm/CodeQL/E2E jobs without deadlocking the required status checks.
+- **Documentation audit:** a feature-implementation audit reconciled the docs with the code — corrected confabulated AJAX handler names and the OTP-resend rate-limit description in the changelog, and replaced drift-prone hardcoded counts (audit hooks, help tabs) with links to `docs/current-metrics.md`.
+- **Playground demos:** added recovery-mode and user-switching scenario blueprints for manual review.
+- **Fix:** removed an obsolete Editor role-error notice workaround in the admin UI; fixed a random-order unit-test flake in the SSL-detection path.
+
 ## 3.3.0 - 2026-06-12
 
 - **Governance backfill re-keyed to 3.3.0 (fixes strict-mode lockout):** the migration that grants `manage_wp_sudo` and the other governance capabilities to existing single-site administrators was keyed at `3.1.0` — a version that never had a public release (tags went v3.1.1 → v3.1.3 → v3.2.0). Sites upgrading from any public 3.1.x release skipped the backfill, leaving no `manage_wp_sudo` holders and locking administrators out of Settings → Sudo in the default strict governance mode (recovery only via `WP_SUDO_RECOVERY_MODE`). The routine is now keyed at `3.3.0` so it also runs once for sites already stamped `3.2.0`, and it skips when any user already holds `manage_wp_sudo`, preserving deliberate Access-tab grant/revoke configurations.

--- a/phpstan-bootstrap.php
+++ b/phpstan-bootstrap.php
@@ -10,7 +10,7 @@
  */
 
 // Plugin constants (defined in wp-sudo.php at runtime).
-define( 'WP_SUDO_VERSION', '3.3.0' );
+define( 'WP_SUDO_VERSION', '3.4.0' );
 define( 'WP_SUDO_PLUGIN_DIR', __DIR__ . '/' );
 define( 'WP_SUDO_PLUGIN_URL', 'https://example.com/wp-content/plugins/wp-sudo/' );
 define( 'WP_SUDO_PLUGIN_BASENAME', 'wp-sudo/wp-sudo.php' );

--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@ WP Sudo is a Multisite-compatible, zero-trust aligned, security-hardening plugin
 [![CodeQL](https://github.com/dknauss/Sudo/actions/workflows/codeql.yml/badge.svg)](https://github.com/dknauss/Sudo/actions/workflows/codeql.yml)
 [![Codecov](https://codecov.io/gh/dknauss/Sudo/graph/badge.svg?branch=main)](https://codecov.io/gh/dknauss/Sudo)
 [![Type Coverage](https://shepherd.dev/github/dknauss/Sudo/coverage.svg)](https://shepherd.dev/github/dknauss/Sudo)
-[![Try latest release in Playground](https://img.shields.io/badge/Try%20release-Playground-3858e9?logo=wordpress&logoColor=white)](https://playground.wordpress.net/?blueprint-url=https%3A%2F%2Fraw.githubusercontent.com%2Fdknauss%2FSudo%2Fv3.3.0%2Fblueprint.json)
+[![Try latest release in Playground](https://img.shields.io/badge/Try%20release-Playground-3858e9?logo=wordpress&logoColor=white)](https://playground.wordpress.net/?blueprint-url=https%3A%2F%2Fraw.githubusercontent.com%2Fdknauss%2FSudo%2Fv3.4.0%2Fblueprint.json)
 [![Try main in Playground](https://img.shields.io/badge/Try%20main-Playground-23282d?logo=wordpress&logoColor=white)](https://playground.wordpress.net/?blueprint-url=https%3A%2F%2Fraw.githubusercontent.com%2Fdknauss%2FSudo%2Fmain%2Fblueprint-main.json)
 
 Playground demo credentials are `admin` / `password`. When WP Sudo asks for reauthentication, enter the same password: `password`.

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
-_WP Sudo 3.3.0 fixes a strict-mode lockout: existing single-site admins on 3.1.x or 3.2.0 now receive the governance capabilities needed to access Settings → Sudo without needing recovery mode._
+_WP Sudo 3.4.0 hardens break-glass recovery: `WP_SUDO_RECOVERY_MODE` is now role-gated to administrators, shows a permanent non-dismissible notice while active, and fires a new `wp_sudo_recovery_mode_active` audit hook so the usage is logged._
 
-[Try the latest release in WordPress Playground](https://playground.wordpress.net/?blueprint-url=https%3A%2F%2Fraw.githubusercontent.com%2Fdknauss%2FSudo%2Fv3.3.0%2Fblueprint.json)
+[Try the latest release in WordPress Playground](https://playground.wordpress.net/?blueprint-url=https%3A%2F%2Fraw.githubusercontent.com%2Fdknauss%2FSudo%2Fv3.4.0%2Fblueprint.json)
 [Try current main in WordPress Playground](https://playground.wordpress.net/?blueprint-url=https%3A%2F%2Fraw.githubusercontent.com%2Fdknauss%2FSudo%2Fmain%2Fblueprint-main.json)
 
 Playground demo credentials are `admin` / `password`. When WP Sudo asks for reauthentication, enter the same password: `password`.
@@ -12,7 +12,7 @@ Tags:              sudo, security, reauthentication, access control, admin prote
 Requires at least: 6.2
 Tested up to:      7.0
 Requires PHP:      8.0
-Stable tag:        3.3.0
+Stable tag:        3.4.0
 License:           GPL-2.0-or-later
 License URI:       https://spdx.org/licenses/GPL-2.0-or-later.html
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -19,7 +19,7 @@ define( 'WPMU_PLUGIN_DIR', WP_CONTENT_DIR . '/mu-plugins' );
 define( 'WPMU_PLUGIN_URL', 'https://example.com/wp-content/mu-plugins' );
 
 // ── Plugin constants (normally defined in wp-sudo.php) ───────────────
-define( 'WP_SUDO_VERSION', '3.3.0' );
+define( 'WP_SUDO_VERSION', '3.4.0' );
 define( 'WP_SUDO_PLUGIN_DIR', dirname( __DIR__ ) . '/' );
 define( 'WP_SUDO_PLUGIN_URL', 'https://example.com/wp-content/plugins/wp-sudo/' );
 define( 'WP_SUDO_PLUGIN_BASENAME', 'wp-sudo/wp-sudo.php' );

--- a/wp-sudo.php
+++ b/wp-sudo.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Sudo
  * Plugin URI:        https://github.com/dknauss/Sudo
  * Description:       Action-gated reauthentication for WordPress. Dangerous operations require password confirmation before they proceed — regardless of user role.
- * Version:           3.3.0
+ * Version:           3.4.0
  * Requires at least: 6.2
  * Requires PHP:      8.0
  * Author:            Dan Knauss
@@ -27,7 +27,7 @@ require_once __DIR__ . '/includes/functions-governance.php';
 add_filter( 'map_meta_cap', 'wp_sudo_map_governance_meta_cap', 10, 4 );
 
 // Plugin version.
-define( 'WP_SUDO_VERSION', '3.3.0' );
+define( 'WP_SUDO_VERSION', '3.4.0' );
 
 // Plugin directory path.
 define( 'WP_SUDO_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );


### PR DESCRIPTION
Release bump for **v3.4.0**.

## Version sync (per the project checklist)
- `wp-sudo.php` — plugin header `Version:` + `WP_SUDO_VERSION` constant
- `phpstan-bootstrap.php` — `WP_SUDO_VERSION`
- `tests/bootstrap.php` — `WP_SUDO_VERSION`
- `readme.txt` — `Stable tag`
- `readme.txt` intro blurb + `readme.md`/`readme.txt` "Try latest release" Playground links → `v3.4.0`

## Changelog highlights (3.4.0)
- **Break-glass recovery mode hardened:** `WP_SUDO_RECOVERY_MODE` role-gated to administrators (`manage_options`/`manage_network_options`); non-admins gain nothing. Permanent non-dismissible notice on the Sudo settings screen while active; new **`wp_sudo_recovery_mode_active`** audit hook (sampled `recovery_mode` event).
- **Psalm gate repaired** (was a silent no-op via `uninstall.php`'s top-level `exit`) + restored shepherd.dev type-coverage badge (~96%).
- **CI hardening:** least-privilege workflow permissions; docs-only PRs skip heavy jobs without deadlocking gates.
- **Doc audit fixes** (confab AJAX handler names, OTP-resend mechanism, count drift) and Playground scenario blueprints.

## Pre-release checks
- Version-sync audit: all 5 points + Playground links at 3.4.0 ✅
- Reviewer-approved (788 tests, PHPCS clean, PHPStan clean, Psalm 96.0%) ✅
- External-claims audit satisfied by the merged v3.3.0 multi-agent doc audit (llm-lies-log #21–24) ✅

Tag `v3.4.0` will be pushed on this commit after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)