### PR TITLE
docs(readme): rewrite top sections for common-user accessibility

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # WP Sudo
 
-WP Sudo is a Multisite-compatible, zero-trust aligned, security-hardening plugin for WordPress. It adds **action-gated reauthentication**, enables **attack surface definition** (open, closed, or sudo-gated), gives **visibility to privileged action requests**, and confines Sudo administration to explicitly designated users.
+Require password confirmation before high-risk changes go through on your WordPress site — even from an already-authenticated admin session.
 
 [![License: GPL v2+](https://img.shields.io/badge/License-GPL%20v2%2B-blue.svg)](https://spdx.org/licenses/GPL-2.0-or-later.html)
 [![WordPress: 6.2+](https://img.shields.io/badge/WordPress-6.2%2B-0073aa.svg)](https://wordpress.org/)
@@ -16,52 +16,75 @@ WP Sudo is a Multisite-compatible, zero-trust aligned, security-hardening plugin
 
 Playground demo credentials are `admin` / `password`. When WP Sudo asks for reauthentication, enter the same password: `password`.
 
-## Overview
+## Features
 
-Before performing high-risk (Administrator and Super Administrator) actions in any interface or API surface, a privileged user session must re-authenticate by re-entering their credentials, followed by any active and compatible two-factor authentication requirement. Successful reauthentication starts a short, configurable window (up to 15 minutes) for privileged, gated actions without further challenge. Each non-interactive surface — WP-CLI, Cron, XML-RPC, REST App Passwords, WPGraphQL — can be independently set to Disabled, Limited (Gated), or Unrestricted. A built-in Access tab controls which users hold Sudo management privileges, with a drift-detection panel that surfaces capability mismatches introduced by third-party role plugins. All privileged sessions can be monitored in the dashboard or with compatible plugins for logging user activity. 
+- **Confirmation before destructive actions** — plugin installs/deletions, user management, settings changes, core updates, and more all require a fresh password before proceeding
+- **Two-factor support** — integrates with the [Two Factor plugin](https://wordpress.org/plugins/two-factor/) so the challenge includes your second factor when active
+- **Short sudo window** — one confirmation covers 1–15 minutes of related work (your choice); no repeated prompts for a burst of activity
+- **Per-surface policies** — configure WP-CLI, Cron, XML-RPC, REST App Passwords, and WPGraphQL independently as Disabled, Limited, or Unrestricted
+- **Governance controls** — manage which users and roles can administer WP Sudo settings via a dedicated Access tab
+- **Activity visibility** — audit hooks fire on every gated event; works with WP Activity Log, Stream, and similar plugins
+- **Multisite support** — network-aware; super admins governed separately from per-site admins
 
-## Why WP Sudo exists
+## Quick start
 
-WordPress has roles, capabilities, and authentication limiting who/what can take privileged actions. However, it has no native way to say, "This action is too consequential to assume a valid user session alone is sufficient to allow it." 
+1. Install and activate WP Sudo.
+2. Go to **Settings → Sudo**.
+3. Choose a session duration.
+4. Review the default policies for non-interactive surfaces.
+5. Optionally install the bundled mu-plugin loader from the settings page for earlier hook registration.
+6. Test a covered action such as plugin activation or a protected settings change.
 
-For high-value single sites and multisite networks with multiple administrators, this default posture is far too open. A phished user account, a hijacked admin session, and a rogue agent/non-human identity all appear legitimate and can freely take destructive actions. WP Sudo adds a missing layer to reduce these risks and limit the potential damage by intercepting the most privileged actions with a standard password challenge, followed by a second authentication requirement if 2FA is enabled. 
+### Recommended companion plugins
 
-Sudo is designed to reduce risk when an attacker has:
-- a stolen browser session cookie,
-- access to an unattended authenticated browser,
-- or a delegated request path that reaches a high-impact operation.
+- [Two Factor](https://wordpress.org/plugins/two-factor/) — strongly recommended for password + second-factor challenge flows.
+- [WP Activity Log](https://wordpress.org/plugins/wp-security-audit-log/) or [Stream](https://wordpress.org/plugins/stream/) — recommended if you want audit visibility from WP Sudo's action hooks.
 
-On those covered paths, a valid session without an active sudo window is not enough.
+## What gets protected
 
-## What WP Sudo gates and protects
+WP Sudo gates built-in operations across categories including:
+- plugin and theme installation, activation, and deletion
+- user creation, deletion, and role changes
+- file editor access
+- critical option changes
+- WordPress core updates
+- export flows
+- WP Sudo settings themselves
+- selected Multisite network actions
+- connector credential writes via the REST settings endpoint
 
-WP Sudo currently gates built-in operations across categories such as:
-- plugin and theme management,
-- user creation, deletion, and role changes,
-- file editor access,
-- critical option changes,
-- WordPress core updates,
-- export flows,
-- WP Sudo settings themselves,
-- selected Multisite network actions,
-- and connector credential writes saved through the REST settings endpoint.
+For the full rule list and surface counts, see [docs/current-metrics.md](docs/current-metrics.md).
 
-For the canonical current rule totals and surface counts, see [docs/current-metrics.md](docs/current-metrics.md).
+## Why it helps
 
-## What Sudo _doesn't_ defend against
+WordPress has roles and capabilities, but no native way to say "a logged-in session alone isn't enough for this action." WP Sudo adds that layer. It's most effective against:
 
-WP Sudo is not a general fix for broken authorization in plugin code. WP Sudo gates specific known operations on specific known surfaces. A plugin vulnerability that performs a privileged state change through its own code path — without routing through a surface WP Sudo intercepts — is outside this layer. WP Sudo is the guard at the door of the operations it knows about; it is not a monitor of arbitrary plugin execution.
+- a stolen or shared browser session
+- an unattended, still-authenticated browser
+- automated requests through REST, CLI, or XML-RPC that shouldn't bypass human confirmation
+
+Active sudo is **per browser session**, not site-wide. WP Sudo works alongside your existing roles — it does not replace them.
+
+## How it works
+
+**Browser (wp-admin):** gated actions redirect to a challenge screen. After successful reauthentication, the original request replays automatically.
+
+**AJAX and REST:** blocked requests receive a `sudo_required` error until reauthentication occurs.
+
+**Non-interactive surfaces** (WP-CLI, Cron, XML-RPC, REST App Passwords, WPGraphQL): each can be set independently to Disabled, Limited, or Unrestricted under Settings → Sudo.
+
+WP Sudo gates specific operations on specific surfaces. It is not a firewall, exploit detector, or fix for authorization vulnerabilities inside third-party plugin code.
 
 ## Sudo administration and governance
 
-"With great power comes great responsibility," so users with the capability to change Sudo settings, view sudo session activity, kill sudo sessions, or export sudo activity logs are limited by default:  
+"With great power comes great responsibility," so users with the capability to change Sudo settings, view sudo session activity, kill sudo sessions, or export sudo activity logs are limited by default:
 
 - On **single sites**, the installing administrator receives all four caps. Other admins receive none until explicitly granted.
 - On **multisite networks**, super administrators receive all four caps at network scope by default. Per-site admins receive none until explicitly delegated.
 
 (Export privileges are separated from view privileges because a portable export artifact is a distinct governance concern — SOC2/GDPR audits treat "can read" and "can take a copy offsite" differently.)
 
-WP Sudo integrates with the **Site Health** tool in WordPress core for rich security diagnostics and advisory notifications. 
+WP Sudo integrates with the **Site Health** tool in WordPress core for rich security diagnostics and advisory notifications.
 
 ### Break glass recovery scenario
 
@@ -71,36 +94,6 @@ In a lost, last administrator scenario where no one has access to Sudo's setting
 
 WP Sudo exposes a small, stable API. Custom gated rules are plain associative arrays registered via the `wp_sudo_gated_actions` filter, with per-surface matchers for admin, AJAX, REST, and CLI. The `wp_sudo_can()` helper centralizes all governance checks — super-admin short-circuit, recovery-mode bypass, and strict/compatibility mode — so integrations don't touch capability internals directly. Audit hooks fire on every session event, capability grant or revoke, tamper detection, and policy change; bridge classes for WP Activity Log and Stream are bundled. The `wp_sudo_grant_session_on_login` filter lets SSO and kiosk integrations suppress the automatic browser-login session grant. All of this is covered by a dual-layer test suite (unit tests + a full integration matrix) and PHPStan level 6.
 
-## How it works
-
-### Browser requests
-For wp-admin flows, WP Sudo redirects the user to a challenge screen. After successful reauthentication, the original request can continue.
-
-### AJAX and REST requests
-These receive a `sudo_required` error instead of silently proceeding.
-
-### Non-interactive surfaces
-WP Sudo supports configurable policies for:
-- WP-CLI
-- Cron
-- XML-RPC
-- REST Application Passwords
-- WPGraphQL (when active)
-
-Each surface can be set to **Disabled**, **Limited**, or **Unrestricted**.
-
-## What WP Sudo does **not** do
-
-WP Sudo is deliberately narrow. It is **not**:
-- a replacement for WordPress capabilities,
-- a firewall or exploit detector,
-- a fix for arbitrary broken access control inside third-party plugin code,
-- or a sandbox for malicious in-process code.
-
-It is strongest when an attacker has a valid session but **does not** have an active sudo window and must cross one of the plugin's covered action paths.
-
-Active sudo is **per browser session**, not site-wide.
-
 ## Requirements
 
 - **WordPress:** 6.2+
@@ -108,22 +101,6 @@ Active sudo is **per browser session**, not site-wide.
 - **Multisite:** supported
 
 For current release posture, supported lanes, and forward `main` notes, see [docs/release-status.md](docs/release-status.md).
-
-## Quick start
-
-1. Install and activate WP Sudo.
-2. Go to **Settings → Sudo**.
-3. Choose a session duration.
-4. Review the default policies for non-interactive surfaces.
-5. Optionally install the bundled mu-plugin loader from the settings page for earlier hook registration.
-6. Test a covered action, such as plugin activation or a protected settings change.
-
-You can also install [User Switching](https://en-ca.wordpress.org/plugins/user-switching/), switch to another admin user whose password is unknown, and see how your actions are limited by Sudo. 
-
-### Recommended companion plugins
-
-- [Two Factor](https://wordpress.org/plugins/two-factor/) — strongly recommended for password + second-factor challenge flows.
-- [WP Activity Log](https://wordpress.org/plugins/wp-security-audit-log/) or [Stream](https://wordpress.org/plugins/stream/) — recommended if you want audit visibility from WP Sudo's action hooks.
 
 ## Documentation
 
@@ -138,18 +115,18 @@ You can also install [User Switching](https://en-ca.wordpress.org/plugins/user-s
 - [docs/connectors-api-reference.md](docs/connectors-api-reference.md) — connector credential gating notes
 - [docs/ai-agentic-guidance.md](docs/ai-agentic-guidance.md) — AI and agent tooling guidance
 
-### Verification and project status docs for humans and LLMs
-- [tests/MANUAL-TESTING.md](tests/MANUAL-TESTING.md) — manual verification procedures for all surfaces
+### Verification and project status
+- [tests/MANUAL-TESTING.md](tests/MANUAL-TESTING.md) — manual verification procedures
 - [docs/current-metrics.md](docs/current-metrics.md) — canonical current counts and architectural facts
 - [docs/ROADMAP.md](docs/ROADMAP.md) — roadmap and backlog
 - [CHANGELOG.md](CHANGELOG.md) — release history
 
-### Background, research, and lessons learned
+### Background and research
 - [docs/sudo-architecture-comparison-matrix.md](docs/sudo-architecture-comparison-matrix.md) — comparison with other sudo/reauth approaches
 - [docs/abilities-api-assessment.md](docs/abilities-api-assessment.md) — WordPress Abilities API assessment
 - [docs/core-action-gate-proposal.md](docs/core-action-gate-proposal.md) — longer-form core proposal and design thinking
-- [docs/llm-lies-log.md](docs/llm-lies-log.md) — verification discipline for agentic coding and past documentation failures
-- [docs/project-introduction.md](docs/project-introduction.md) — the original conceptual introduction to sudo with some poetry, art, and history.
+- [docs/llm-lies-log.md](docs/llm-lies-log.md) — verification discipline and past documentation failures
+- [docs/project-introduction.md](docs/project-introduction.md) — the longer conceptual introduction, graphic, poem, and gate metaphor preserved from the earlier README
 
 ## Development
 


### PR DESCRIPTION
## Summary

Rewrites the top of `readme.md` for a general/common-user audience: a one-line plain-language intro, a scannable **Features** list, and a restructured **Quick start → What gets protected → Why it helps → How it works** flow. Replaces the previous `Overview` / `Why WP Sudo exists` / `What WP Sudo gates` prose, which was dense and security-jargon-heavy.

Supersedes the parked #55 (closed). This branch was rebased onto current `main` (now at v3.4.0, including #80's roadmap update).

## Content preserved during rebase (reviewer note)

The original rewrite was authored before v3.4.0 added three substantive README sections. To avoid silently dropping that content, the rebase **keeps** them after `How it works`:

- **Sudo administration and governance** — the four-cap delegation model and single-site/multisite defaults
- **Break glass recovery scenario** — the `WP_SUDO_RECOVERY_MODE` operational/security detail
- **For developers and integrators** — the `wp_sudo_gated_actions` / `wp_sudo_can()` API summary

**Editorial decision for review:** whether these detailed sections belong in the now-user-focused README or should move to `docs/` is a judgment call left to the reviewer. They are retained here so the choice is explicit rather than lost in the rewrite.

## Notes

- Playground release badge kept at `v3.4.0` (the rewrite had a stale `v3.3.0` that the rebase corrected).
- Diff is `readme.md` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)