### PR TITLE
fix(upgrader): prime wp_roles() before plugins_loaded capability query

### DIFF
--- a/includes/class-upgrader.php
+++ b/includes/class-upgrader.php
@@ -75,6 +75,16 @@ class Upgrader {
 			return;
 		}
 
+		// Prime the global $wp_roles before any routine runs. Migrations run at
+		// plugins_loaded (under WP-CLI/admin), where $wp_roles may not yet be
+		// initialized. On WP 7.0+, WP_User_Query::prepare_query() dereferences
+		// the raw global directly for a `capability` query ($wp_roles->for_site()),
+		// so a null global fatals with "Call to a member function for_site() on
+		// null". wp_roles() lazily instantiates the global; calling it here makes
+		// every present and future capability-based user query in the routines
+		// below safe, regardless of how early the upgrade fires.
+		wp_roles();
+
 		// Run each applicable routine in order.
 		foreach ( self::UPGRADES as $version => $method ) {
 			if ( version_compare( $stored, $version, '<' ) && is_callable( array( $this, $method ) ) ) {

--- a/tests/Integration/UpgraderTest.php
+++ b/tests/Integration/UpgraderTest.php
@@ -185,6 +185,73 @@ class UpgraderTest extends TestCase {
 	}
 
 	/**
+	 * Regression: 3.3.0 backfill must not fatal when the global $wp_roles is
+	 * uninitialized at the time the migration runs.
+	 *
+	 * Reproduces the WP 7.0 WP-CLI provisioning fatal. On WP 7.0,
+	 * WP_User_Query::prepare_query() dereferences the raw global $wp_roles
+	 * ($wp_roles->for_site()) when handling a `capability` query. At
+	 * plugins_loaded — where maybe_upgrade() runs under WP-CLI — that global can
+	 * be null, fataling with "Call to a member function for_site() on null".
+	 *
+	 * The integration suite's bootstrap initializes roles before plugins_loaded,
+	 * so we must explicitly null $wp_roles here to reproduce the production
+	 * condition, then restore it in finally to avoid cross-test pollution (the
+	 * base TestCase does not snapshot $wp_roles).
+	 *
+	 * Single-site only — the 3.3.0 backfill returns early on multisite.
+	 */
+	public function test_3_3_0_backfill_survives_uninitialized_wp_roles_global(): void {
+		if ( is_multisite() ) {
+			$this->markTestSkipped( 'The 3.3.0 governance backfill is single-site only.' );
+		}
+
+		// Arrange: stored 3.2.0 so only upgrade_3_3_0() is pending, and a fresh
+		// administrator with no governance cap so the backfill actually runs.
+		$this->update_wp_sudo_option( Upgrader::VERSION_OPTION, '3.2.0' );
+		$admin = $this->make_admin();
+		$this->assertFalse(
+			$admin->has_cap( 'manage_wp_sudo' ),
+			'Precondition: the new admin must not already hold the governance cap.'
+		);
+
+		$saved_roles = $GLOBALS['wp_roles'] ?? null;
+
+		try {
+			// Simulate the WP-CLI / plugins_loaded condition: roles not yet built.
+			// With the bug, the capability holder query inside upgrade_3_3_0()
+			// dereferences this null global and fatals.
+			// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Intentionally reproducing an uninitialized $wp_roles; restored in finally.
+			$GLOBALS['wp_roles'] = null;
+
+			$upgrader = new Upgrader();
+			$upgrader->maybe_upgrade();
+		} finally {
+			// Restore the saved roles object regardless of outcome so a failure
+			// (or the pre-fix fatal) cannot leak null $wp_roles into later tests.
+			// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Restoring the snapshot taken above.
+			$GLOBALS['wp_roles'] = $saved_roles;
+		}
+
+		// Assert: no fatal (reaching here proves it), version stamped, and the
+		// backfill granted the governance caps to the existing administrator.
+		$this->assertSame(
+			WP_SUDO_VERSION,
+			$this->get_wp_sudo_option( Upgrader::VERSION_OPTION ),
+			'maybe_upgrade() must complete and stamp the current version.'
+		);
+
+		$refetched = get_user_by( 'id', $admin->ID );
+		$this->assertInstanceOf( \WP_User::class, $refetched );
+		foreach ( Admin::GOVERNANCE_CAPS as $cap ) {
+			$this->assertTrue(
+				$refetched->has_cap( $cap ),
+				"Backfill must grant the {$cap} governance cap to existing admins."
+			);
+		}
+	}
+
+	/**
 	 * SURF-01: 2.2.0 preserves already-valid three-tier policy values.
 	 *
 	 * Verifies that 'disabled', 'limited', 'unrestricted' values survive

--- a/tests/Unit/UpgraderTest.php
+++ b/tests/Unit/UpgraderTest.php
@@ -30,6 +30,9 @@ class UpgraderTest extends TestCase {
 		Functions\when( 'wp_next_scheduled' )->justReturn( true );
 		Functions\when( 'wp_schedule_event' )->justReturn( true );
 		Functions\when( 'get_users' )->justReturn( array() );
+		// maybe_upgrade() primes wp_roles() before running routines so that
+		// capability-based user queries do not fatal on WP 7.0 (null $wp_roles).
+		Functions\when( 'wp_roles' )->justReturn( null );
 
 		// Preserve any existing wpdb.
 		$this->original_wpdb = isset( $GLOBALS['wpdb'] ) && is_object( $GLOBALS['wpdb'] ) ? $GLOBALS['wpdb'] : null;
@@ -422,6 +425,67 @@ class UpgraderTest extends TestCase {
 		$method->invoke( $upgrader );
 
 		$this->assertSame( 0, $queries, 'Multisite must return before any user query.' );
+	}
+
+	public function test_maybe_upgrade_primes_wp_roles_before_capability_user_query(): void {
+		// Regression for the WP 7.0 WP-CLI provisioning fatal. On WP 7.0,
+		// WP_User_Query::prepare_query() dereferences the raw global $wp_roles
+		// ($wp_roles->for_site()) when handling a `capability` query. At
+		// plugins_loaded — where maybe_upgrade() runs under WP-CLI — that global
+		// can be null, fataling with "Call to a member function for_site() on
+		// null". maybe_upgrade() must prime wp_roles() (which lazily initializes
+		// the global) BEFORE any routine issues a capability-based get_users()
+		// query, so this fatal cannot occur.
+		Functions\when( 'is_multisite' )->justReturn( false );
+
+		// Stored 3.2.0 < WP_SUDO_VERSION (3.4.0) and >= every earlier routine,
+		// so only upgrade_3_3_0() — the one with the capability query — runs.
+		Functions\when( 'get_option' )->alias(
+			function ( $key, $default = false ) {
+				if ( Upgrader::VERSION_OPTION === $key ) {
+					return '3.2.0';
+				}
+				return $default;
+			}
+		);
+		Functions\when( 'update_option' )->justReturn( true );
+
+		$sequence = array();
+		Functions\when( 'wp_roles' )->alias(
+			function () use ( &$sequence ) {
+				$sequence[] = 'wp_roles';
+				return null;
+			}
+		);
+		Functions\when( 'get_users' )->alias(
+			function ( array $args ) use ( &$sequence ) {
+				if ( isset( $args['capability'] ) ) {
+					$sequence[] = 'capability_query';
+				}
+				// No holders and no admins → backfill is a no-op (no add_cap).
+				return array();
+			}
+		);
+
+		$upgrader = new Upgrader();
+		$upgrader->maybe_upgrade();
+
+		$roles_pos      = array_search( 'wp_roles', $sequence, true );
+		$capability_pos = array_search( 'capability_query', $sequence, true );
+
+		$this->assertNotFalse(
+			$capability_pos,
+			'The 3.3.0 routine must issue the capability holder query.'
+		);
+		$this->assertNotFalse(
+			$roles_pos,
+			'maybe_upgrade() must call wp_roles() to initialize the global $wp_roles before capability queries.'
+		);
+		$this->assertLessThan(
+			$capability_pos,
+			$roles_pos,
+			'wp_roles() must be primed BEFORE the capability get_users() query to avoid a null $wp_roles fatal on WP 7.0.'
+		);
 	}
 
 	public function test_330_backfill_runs_via_maybe_upgrade_for_sites_stored_at_313(): void {


### PR DESCRIPTION
## Problem

`Upgrader::upgrade_3_3_0()`'s existing-holder guard runs `get_users( array( 'capability' => 'manage_wp_sudo', ... ) )`. On **WordPress 7.0**, `WP_User_Query::prepare_query()` dereferences the raw global `$wp_roles` directly (`$wp_roles->for_site()`) for a `capability` query, with no null guard. Migrations run from `Plugin::init()` at the `plugins_loaded` hook (gated `is_admin() || WP_CLI`), where `$wp_roles` can still be null — so under **WP-CLI** (reproduced via `wp-env start` provisioning on WP 7.0 GA) the guard fatals:

```
Uncaught Error: Call to a member function for_site() on null
in wp-includes/class-wp-user-query.php:458
```

Trigger scope: stored plugin version `< 3.3.0` (routine runs) **and** the first triggering request is WP-CLI. The PHPUnit integration bootstrap initializes roles before `plugins_loaded`, so the suite was previously unaffected.

## Fix

Prime the global `$wp_roles` with a single `wp_roles()` call at the top of `maybe_upgrade()` (after the version-compare early-return, before the routine loop). `wp_roles()` lazily instantiates the global, making every present and future capability-based user query in the routines safe regardless of how early the upgrade fires. Loop-level placement (vs inside the routine) keeps the no-op path free and removes the latent trap for future routines.

The sibling `role => administrator` query does not touch `$wp_roles`; an audit found no other `plugins_loaded`-time capability queries.

Verified against `WordPress/wordpress-develop` `class-wp-user-query.php` (`prepare_query`: `global $wpdb, $wp_roles`; the capability branch calls `$wp_roles->for_site()`/`->roles` unguarded).

## Tests

- **Unit** (`tests/Unit/UpgraderTest.php`): new ordering test asserts `wp_roles()` is invoked before the `capability` `get_users()` query; default `wp_roles` stub added in `setUp()`.
- **Integration** (`tests/Integration/UpgraderTest.php`): reproduces the null-`$wp_roles` condition (try/finally restore), runs `maybe_upgrade()`, asserts no fatal + version stamped + governance caps backfilled.

### Validation on real WP 7.0 GA (wp-env)

- Full integration suite: **187 tests green**.
- With the `wp_roles();` line removed, the integration test **errors** with `for_site() on null` at `class-wp-user-query.php:458` — confirming the test catches the regression and the fix resolves it.
- Unit suite: 794 green. PHPStan: no errors. PHPCS: clean.

## Notes

PHP-only change (upgrader + tests), no browser/admin UX surface — per AGENTS.md E2E policy, full Playwright E2E is not required here. Relevant to Phase 12 (floor bump) and Phase 14 (WordPress.org readiness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)