### PR TITLE
Access tab: wire grant/revoke UI + fix recovery-mode drift detection

### DIFF
--- a/admin/js/wp-sudo-admin.js
+++ b/admin/js/wp-sudo-admin.js
@@ -235,4 +235,223 @@
 			}
 		}
 	}
+
+	// --- Access tab: grant / revoke governance capabilities ---
+	//
+	// The grant/revoke/manage buttons POST to admin-ajax. Each carries its own
+	// wp_sudo_access data-nonce (NOT wpSudoAdmin.nonce, which is the MU-plugin
+	// nonce). These actions are gated by the Action Registry, so the Gate returns
+	// success:false with data.code === 'sudo_required' (plus a helpful message)
+	// when there is no active sudo session — surfaced verbatim, never bypassed.
+	var accessStrings = ( wpSudoAdmin && wpSudoAdmin.access ) || {};
+
+	/**
+	 * Announce a message to assistive technology (wp.a11y.speak is guarded).
+	 *
+	 * @param {string} msg Message to announce.
+	 */
+	function announce( msg ) {
+		if ( msg && window.wp && window.wp.a11y && window.wp.a11y.speak ) {
+			window.wp.a11y.speak( msg );
+		}
+	}
+
+	/**
+	 * POST an access action and route the outcome.
+	 *
+	 * Surfaces data.message verbatim on both success and ALL error responses,
+	 * so the operator sees the server's actionable guidance: sudo_required
+	 * (reauthenticate and retry), the 409 last-manager block, and the 429
+	 * revoke rate-limit all carry a specific message.
+	 *
+	 * @param {string}   action    AJAX action name.
+	 * @param {string}   nonce     The wp_sudo_access nonce from the element.
+	 * @param {Object}   fields    Extra POST fields (user_id, cap).
+	 * @param {Element}  button    The clicked button (disabled during the request).
+	 * @param {Function} onSuccess Optional DOM update to run on success.
+	 * @param {Element}  resultEl  Optional aria-live element for inline feedback.
+	 */
+	function sendAccessAction( action, nonce, fields, button, onSuccess, resultEl ) {
+		if ( ! wpSudoAdmin || ! wpSudoAdmin.ajaxUrl || ! action ) {
+			return;
+		}
+
+		if ( button ) {
+			button.disabled = true;
+			button.setAttribute( 'aria-busy', 'true' );
+		}
+		if ( resultEl ) {
+			resultEl.textContent = '';
+		}
+
+		var body = new FormData();
+		body.append( 'action', action );
+		body.append( '_nonce', nonce || '' );
+		Object.keys( fields ).forEach( function ( key ) {
+			body.append( key, fields[ key ] );
+		} );
+
+		fetch( wpSudoAdmin.ajaxUrl, {
+			method: 'POST',
+			credentials: 'same-origin',
+			body: body,
+		} )
+			.then( function ( response ) {
+				return response.json();
+			} )
+			.then( function ( result ) {
+				if ( button ) {
+					button.setAttribute( 'aria-busy', 'false' );
+				}
+				var data = result.data || {};
+
+				if ( result.success ) {
+					var smsg = data.message || accessStrings.success || '';
+					if ( resultEl ) {
+						resultEl.textContent = smsg;
+					}
+					announce( smsg );
+					// Re-enable for repeated use BEFORE onSuccess, so the controls
+					// that should not stay active still win: drift-grant/revoke-cap
+					// remove the button, and revoke-session re-disables + relabels.
+					if ( button ) {
+						button.disabled = false;
+					}
+					if ( onSuccess ) {
+						onSuccess();
+					}
+				} else {
+					if ( button ) {
+						button.disabled = false;
+					}
+					var emsg = data.message || strings.genericError || '';
+					if ( resultEl ) {
+						resultEl.textContent = emsg;
+					} else {
+						// eslint-disable-next-line no-alert
+						window.alert( emsg );
+					}
+					announce( emsg );
+				}
+			} )
+			.catch( function () {
+				if ( button ) {
+					button.disabled = false;
+					button.setAttribute( 'aria-busy', 'false' );
+				}
+				var nmsg = strings.networkError || '';
+				if ( resultEl ) {
+					resultEl.textContent = nmsg;
+				} else {
+					// eslint-disable-next-line no-alert
+					window.alert( nmsg );
+				}
+				announce( nmsg );
+			} );
+	}
+
+	// Main "Grant Capability" form.
+	var grantBtn    = document.getElementById( 'wp-sudo-grant-submit' );
+	var grantResult = document.getElementById( 'wp-sudo-grant-result' );
+	if ( grantBtn ) {
+		grantBtn.addEventListener( 'click', function () {
+			var userInput = document.getElementById( 'wp-sudo-grant-user' );
+			var capSelect = document.getElementById( 'wp-sudo-grant-cap' );
+			var userId    = userInput ? parseInt( userInput.value, 10 ) : 0;
+
+			if ( ! userId || userId < 1 ) {
+				var vmsg = accessStrings.invalidUser || '';
+				if ( grantResult ) {
+					grantResult.textContent = vmsg;
+				}
+				announce( vmsg );
+				if ( userInput ) {
+					userInput.focus();
+				}
+				return;
+			}
+
+			sendAccessAction(
+				wpSudoAdmin.grantAction,
+				grantBtn.getAttribute( 'data-nonce' ),
+				{ user_id: userId, cap: capSelect ? capSelect.value : '' },
+				grantBtn,
+				null,
+				grantResult
+			);
+		} );
+	}
+
+	// Delegated handlers for the (re-rendered) grantee/drift table rows.
+	document.addEventListener( 'click', function ( event ) {
+		var target = event.target;
+		if ( ! target || ! target.classList ) {
+			return;
+		}
+
+		// Drift-panel: grant manage_wp_sudo. On success the user no longer
+		// drifts, so remove their row.
+		if ( target.classList.contains( 'wp-sudo-grant-manage' ) ) {
+			var driftRow = target.closest( 'tr' );
+			sendAccessAction(
+				wpSudoAdmin.grantAction,
+				target.getAttribute( 'data-nonce' ),
+				{ user_id: target.getAttribute( 'data-user-id' ), cap: target.getAttribute( 'data-cap' ) },
+				target,
+				function () {
+					if ( driftRow && driftRow.parentNode ) {
+						driftRow.parentNode.removeChild( driftRow );
+					}
+				},
+				null
+			);
+			return;
+		}
+
+		// Revoke a single capability. Remove the cap label + its button; if the
+		// holder has no caps left, remove the whole row.
+		if ( target.classList.contains( 'wp-sudo-revoke-cap' ) ) {
+			var capCell = target.closest( 'td' );
+			var capRow  = target.closest( 'tr' );
+			var capCode = target.previousElementSibling;
+			sendAccessAction(
+				wpSudoAdmin.revokeCapAction,
+				target.getAttribute( 'data-nonce' ),
+				{ user_id: target.getAttribute( 'data-user-id' ), cap: target.getAttribute( 'data-cap' ) },
+				target,
+				function () {
+					if ( capCode && 'CODE' === capCode.tagName ) {
+						capCode.parentNode.removeChild( capCode );
+					}
+					if ( target.parentNode ) {
+						target.parentNode.removeChild( target );
+					}
+					if ( capRow && capCell && ! capCell.querySelector( '.wp-sudo-revoke-cap' ) && capRow.parentNode ) {
+						capRow.parentNode.removeChild( capRow );
+					}
+				},
+				null
+			);
+			return;
+		}
+
+		// Revoke an active session. The session can be re-established, so do not
+		// remove the row — disable and relabel the button.
+		if ( target.classList.contains( 'wp-sudo-revoke-session' ) ) {
+			sendAccessAction(
+				wpSudoAdmin.revokeSessionAction,
+				target.getAttribute( 'data-nonce' ),
+				{ user_id: target.getAttribute( 'data-user-id' ) },
+				target,
+				function () {
+					target.disabled = true;
+					if ( accessStrings.sessionRevoked ) {
+						target.textContent = accessStrings.sessionRevoked;
+					}
+				},
+				null
+			);
+			return;
+		}
+	} );
 } )();

--- a/docs/current-metrics.md
+++ b/docs/current-metrics.md
@@ -9,9 +9,9 @@ Verification environment: local workspace, PHP 8.x
 
 | Metric | Value | Verification |
 |---|---:|---|
-| Unit tests | 810 tests | `composer test:unit` |
-| Unit assertions | 2311 assertions | `composer test:unit` |
-| Integration tests in suite | 193 test methods | `rg -c "function test" tests/Integration/*.php | awk -F: '{sum+=$2} END{print sum}'` |
+| Unit tests | 812 tests | `composer test:unit` |
+| Unit assertions | 2315 assertions | `composer test:unit` |
+| Integration tests in suite | 194 test methods | `rg -c "function test" tests/Integration/*.php | awk -F: '{sum+=$2} END{print sum}'` |
 | Unit test files | 25 | `ls tests/Unit/*.php | wc -l` |
 | Integration test files | 26 | `ls tests/Integration/*.php | wc -l` |
 
@@ -19,11 +19,11 @@ Verification environment: local workspace, PHP 8.x
 
 | Metric | Value | Verification |
 |---|---:|---|
-| Production PHP lines (`includes/`, `wp-sudo.php`, `uninstall.php`, `mu-plugin/`, `bridges/`) | 14,991 | `find ./includes ./wp-sudo.php ./uninstall.php ./mu-plugin ./bridges -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
-| Tests PHP lines (`tests/`) | 29,460 | `find ./tests -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
-| Production + tests PHP lines | 44,451 | sum of the two rows above |
-| Test-to-production ratio | 1.97:1 | `29460 / 14991` |
-| Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`) | 44,714 | `find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/vendor_test/*" ! -path "*/.tmp/*" ! -path "*/.git/*" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Production PHP lines (`includes/`, `wp-sudo.php`, `uninstall.php`, `mu-plugin/`, `bridges/`) | 15,008 | `find ./includes ./wp-sudo.php ./uninstall.php ./mu-plugin ./bridges -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Tests PHP lines (`tests/`) | 29,596 | `find ./tests -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Production + tests PHP lines | 44,604 | sum of the two rows above |
+| Test-to-production ratio | 1.97:1 | `29596 / 15008` |
+| Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`) | 44,867 | `find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/vendor_test/*" ! -path "*/.tmp/*" ! -path "*/.git/*" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
 
 ## Architectural Facts
 

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -1451,7 +1451,16 @@ class Admin {
 		$drift = array_filter(
 			is_array( $options_admins ) ? $options_admins : array(),
 			static function ( \WP_User $user ): bool {
-				return ! $user->has_cap( 'manage_wp_sudo' );
+				// Check the RAW stored capability via allcaps, not has_cap().
+				// has_cap() routes through map_meta_cap, where the break-glass
+				// recovery mapper (wp_sudo_map_governance_meta_cap) rewrites
+				// manage_wp_sudo -> manage_options for the CURRENT user under
+				// recovery mode — which would hide a drifted admin from their own
+				// drift list while another viewer still sees them. allcaps holds
+				// role-derived + add_cap()-granted primitives and is immune to
+				// that remap, so drift reflects true stored governance state
+				// consistently regardless of who is viewing or recovery mode.
+				return empty( $user->allcaps['manage_wp_sudo'] );
 			}
 		);
 

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -977,7 +977,7 @@ class Admin {
 		wp_enqueue_script(
 			'wp-sudo-admin',
 			WP_SUDO_PLUGIN_URL . 'admin/js/wp-sudo-admin.js',
-			array(),
+			array( 'wp-a11y' ),
 			WP_SUDO_VERSION,
 			true
 		);
@@ -986,16 +986,24 @@ class Admin {
 			'wp-sudo-admin',
 			'wpSudoAdmin',
 			array(
-				'ajaxUrl'            => admin_url( 'admin-ajax.php' ),
-				'nonce'              => wp_create_nonce( 'wp_sudo_mu_plugin' ),
-				'installAction'      => self::AJAX_MU_INSTALL,
-				'uninstallAction'    => self::AJAX_MU_UNINSTALL,
-				'presetDescriptions' => self::get_preset_descriptions(),
-				'presetPolicies'     => self::get_preset_policies(),
-				'surfaceKeys'        => self::get_surface_keys(),
-				'strings'            => array(
+				'ajaxUrl'             => admin_url( 'admin-ajax.php' ),
+				'nonce'               => wp_create_nonce( 'wp_sudo_mu_plugin' ),
+				'installAction'       => self::AJAX_MU_INSTALL,
+				'uninstallAction'     => self::AJAX_MU_UNINSTALL,
+				'grantAction'         => self::AJAX_GRANT_CAP,
+				'revokeCapAction'     => self::AJAX_REVOKE_CAP,
+				'revokeSessionAction' => self::AJAX_REVOKE_SESSION,
+				'presetDescriptions'  => self::get_preset_descriptions(),
+				'presetPolicies'      => self::get_preset_policies(),
+				'surfaceKeys'         => self::get_surface_keys(),
+				'strings'             => array(
 					'genericError' => __( 'An error occurred.', 'wp-sudo' ),
 					'networkError' => __( 'A network error occurred. Please try again.', 'wp-sudo' ),
+				),
+				'access'              => array(
+					'success'        => __( 'Done.', 'wp-sudo' ),
+					'invalidUser'    => __( 'Enter a valid user ID.', 'wp-sudo' ),
+					'sessionRevoked' => __( 'Session revoked', 'wp-sudo' ),
 				),
 			)
 		);

--- a/tests/Integration/GovernanceTest.php
+++ b/tests/Integration/GovernanceTest.php
@@ -291,4 +291,73 @@ class GovernanceTest extends TestCase {
 			'cleanup_inert_governance_mode_option() must set the static $compat_option_cleared flag to true.'
 		);
 	}
+
+	/**
+	 * Drift detection must reflect the RAW stored capability, immune to the
+	 * recovery-mode remap. Regression for the bug where a manage_options-holder
+	 * lacking a stored manage_wp_sudo cap was hidden from their OWN drift list
+	 * under recovery mode: wp_sudo_map_governance_meta_cap() remaps
+	 * manage_wp_sudo -> manage_options for the current user, so has_cap() (the
+	 * old filter) returned true and excluded them. render_drift_detection_panel()
+	 * now filters on $user->allcaps, which the remap does not touch.
+	 *
+	 * This proof MUST be an integration test — the unit WP_User stub has no
+	 * map_meta_cap, so it cannot reproduce the remap.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_drift_panel_self_lists_current_user_under_recovery_mode(): void {
+		if ( ! defined( 'WP_SUDO_RECOVERY_MODE' ) ) {
+			define( 'WP_SUDO_RECOVERY_MODE', true );
+		}
+		$this->assertTrue( wp_sudo_is_recovery_mode() );
+
+		// Drifted CURRENT user: holds manage_options, no stored manage_wp_sudo.
+		$drifted = $this->make_admin();
+		$drifted->remove_cap( 'manage_wp_sudo' );
+		if ( is_multisite() ) {
+			$drifted->add_cap( 'manage_network_options' );
+		}
+		wp_set_current_user( $drifted->ID );
+
+		// Genuine holder: stored manage_wp_sudo (must be EXCLUDED from drift).
+		$holder = $this->make_admin();
+		$holder->add_cap( 'manage_wp_sudo' );
+		if ( is_multisite() ) {
+			$holder->add_cap( 'manage_network_options' );
+		}
+
+		// The bug trigger: under recovery mode the current user's has_cap() is
+		// remapped to true even though the cap is not stored on the record.
+		$current = wp_get_current_user();
+		$this->assertTrue(
+			$current->has_cap( 'manage_wp_sudo' ),
+			'Recovery remap makes has_cap() true for the current user (the old filter would hide them).'
+		);
+		$this->assertArrayNotHasKey(
+			'manage_wp_sudo',
+			$current->caps,
+			'But the cap is not stored on the user record.'
+		);
+
+		// Render the drift panel AS the drifted current user.
+		$admin  = new Admin();
+		$method = new \ReflectionMethod( Admin::class, 'render_drift_detection_panel' );
+		@$method->setAccessible( true ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+		ob_start();
+		$method->invoke( $admin, 'test-nonce' );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString(
+			$drifted->user_login,
+			$output,
+			'The drifted current user MUST appear in their own drift list under recovery mode.'
+		);
+		$this->assertStringNotContainsString(
+			$holder->user_login,
+			$output,
+			'A user holding a stored manage_wp_sudo cap MUST be excluded from drift.'
+		);
+	}
 }

--- a/tests/Unit/AdminTest.php
+++ b/tests/Unit/AdminTest.php
@@ -3544,6 +3544,72 @@ class AdminTest extends TestCase {
 	}
 
 	// -----------------------------------------------------------------
+	// render_drift_detection_panel()
+	// -----------------------------------------------------------------
+
+	/**
+	 * The drift filter must use the raw stored capability (allcaps), so a
+	 * manage_options-holder WITHOUT a stored manage_wp_sudo primitive is listed
+	 * and a holder (role- or directly-granted) is excluded. The recovery-mode
+	 * remap immunity is proven at the integration level (real map_meta_cap);
+	 * see tests/Integration — the unit WP_User stub has no map_meta_cap.
+	 */
+	public function test_drift_panel_lists_by_raw_stored_capability(): void {
+		Functions\when( '__' )->returnArg();
+		Functions\when( 'esc_html' )->returnArg();
+		Functions\when( 'esc_attr' )->returnArg();
+		Functions\when( 'esc_html_e' )->alias( static function ( $s ) { echo $s; } );
+		Functions\when( 'esc_attr_e' )->alias( static function ( $s ) { echo $s; } );
+		Functions\when( 'is_multisite' )->justReturn( false );
+
+		$drifted        = new \WP_User( 2 );
+		$drifted->display_name = 'Drifted Editor';
+		$drifted->user_login   = 'drifted';
+		$drifted->allcaps      = array( 'manage_options' => true ); // no manage_wp_sudo
+
+		$holder         = new \WP_User( 3 );
+		$holder->display_name  = 'Real Manager';
+		$holder->user_login    = 'manager';
+		$holder->allcaps       = array( 'manage_options' => true, 'manage_wp_sudo' => true );
+
+		Functions\when( 'get_users' )->justReturn( array( $drifted, $holder ) );
+
+		$admin = new Admin();
+		ob_start();
+		$method = new \ReflectionMethod( Admin::class, 'render_drift_detection_panel' );
+		@$method->setAccessible( true ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+		$method->invoke( $admin, 'test-nonce' );
+		$output = ob_get_clean();
+
+		// Drifted user (manage_options, no stored manage_wp_sudo) is listed.
+		$this->assertStringContainsString( 'Drifted Editor', $output );
+		$this->assertStringContainsString( 'drifted', $output );
+		// Holder (stored manage_wp_sudo) is excluded.
+		$this->assertStringNotContainsString( 'Real Manager', $output );
+	}
+
+	public function test_drift_panel_renders_nothing_when_no_drift(): void {
+		Functions\when( '__' )->returnArg();
+		Functions\when( 'esc_html' )->returnArg();
+		Functions\when( 'esc_attr' )->returnArg();
+		Functions\when( 'esc_html_e' )->alias( static function ( $s ) { echo $s; } );
+		Functions\when( 'is_multisite' )->justReturn( false );
+
+		$holder            = new \WP_User( 3 );
+		$holder->allcaps   = array( 'manage_options' => true, 'manage_wp_sudo' => true );
+		Functions\when( 'get_users' )->justReturn( array( $holder ) );
+
+		$admin = new Admin();
+		ob_start();
+		$method = new \ReflectionMethod( Admin::class, 'render_drift_detection_panel' );
+		@$method->setAccessible( true ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+		$method->invoke( $admin, 'test-nonce' );
+		$output = ob_get_clean();
+
+		$this->assertSame( '', $output );
+	}
+
+	// -----------------------------------------------------------------
 	// render_recovery_mode_notice() / maybe_record_recovery_mode_usage()
 	// -----------------------------------------------------------------
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -43,12 +43,13 @@ define( 'COOKIE_DOMAIN', '' );
 
 if ( ! class_exists( 'WP_User' ) ) {
 	class WP_User {
-		public int    $ID         = 0;
-		public array  $roles      = [];
-		public array  $caps       = [];
-		public string $user_pass  = '';
-		public array  $allcaps    = [];
-		public string $user_login = '';
+		public int    $ID           = 0;
+		public array  $roles        = [];
+		public array  $caps         = [];
+		public string $user_pass    = '';
+		public array  $allcaps      = [];
+		public string $user_login   = '';
+		public string $display_name = '';
 
 		public function __construct( int $id = 0, array $roles = [] ) {
 			$this->ID    = $id;

--- a/tests/e2e/specs/access-grant.spec.ts
+++ b/tests/e2e/specs/access-grant.spec.ts
@@ -1,0 +1,126 @@
+/**
+ * Access tab — grant capability flow (ACCESS-01, ACCESS-02)
+ *
+ * Regression for the dead-button bug: the Settings → Sudo → Access "Grant
+ * Capability" button had NO client JavaScript, so clicking it did nothing. The
+ * unit tests exercised the PHP handler (handle_grant_cap) directly and never
+ * clicked the button, so the inert UI shipped unnoticed. These specs click the
+ * real button and assert the end-to-end effect.
+ *
+ * The grant AJAX (wp_sudo_grant_cap) is gated by the options.wp_sudo_access rule,
+ * so it requires an active sudo session:
+ *
+ * - ACCESS-01: with NO active sudo session, the Gate blocks the request and the
+ *   result span shows the sudo_required reauthentication message; the capability
+ *   is NOT granted.
+ * - ACCESS-02: with an active sudo session, the grant succeeds and the capability
+ *   lands on the target user.
+ *
+ * Source: includes/class-admin.php handle_grant_cap() + render_access_tab() (verified)
+ * Source: admin/js/wp-sudo-admin.js — Access module wires #wp-sudo-grant-submit (verified)
+ * Source: includes/class-action-registry.php — options.wp_sudo_access gates wp_sudo_grant_cap (verified)
+ */
+import { test, expect, activateSudoSession } from '../fixtures/test';
+import { execSync } from 'child_process';
+import { wpEnvRun } from '../fixtures/wp-env';
+
+// 'cli' targets the development site (port 8889) — the same site the browser uses.
+const WP_ENV_RUN_CLI = wpEnvRun( 'cli' );
+const ACCESS_QUERY = 'page=wp-sudo-settings&tab=access';
+
+/** Run a WP-CLI command in the dev-site container and return trimmed stdout. */
+function cli( command: string ): string {
+	return execSync( `${ WP_ENV_RUN_CLI } ${ command }`, { encoding: 'utf8' } ).trim();
+}
+
+/** Whether a user effectively holds a capability (robust vs. list-caps formatting). */
+function userCan( userId: number, cap: string ): boolean {
+	return cli( `wp eval "echo user_can( ${ userId }, '${ cap }' ) ? 'yes' : 'no';"` ) === 'yes';
+}
+
+test.describe( 'Access tab — grant capability', () => {
+	let targetId: number;
+
+	test.beforeAll( () => {
+		// The granting admin (user 1) must hold manage_wp_sudo to reach the Access
+		// tab and authorize grants — guarantee it regardless of activation state.
+		execSync( `${ WP_ENV_RUN_CLI } wp user add-cap 1 manage_wp_sudo`, { stdio: 'ignore' } );
+
+		// Dedicated editor target (idempotent — reuse if a previous run left it).
+		const existing = cli(
+			`wp user get e2e_grant_target --field=ID 2>/dev/null || echo ''`
+		);
+		targetId = existing
+			? parseInt( existing, 10 )
+			: parseInt(
+					cli(
+						'wp user create e2e_grant_target e2e_grant@example.com ' +
+							'--role=editor --user_pass=password --porcelain'
+					),
+					10
+			  );
+	} );
+
+	test.afterAll( () => {
+		execSync(
+			`${ WP_ENV_RUN_CLI } wp user delete ${ targetId } --yes --reassign=1`,
+			{ stdio: 'ignore' }
+		);
+	} );
+
+	test.beforeEach( () => {
+		// Clean slate: strip the cap and clear the Gate's blocked-action transients
+		// (which otherwise persist between runs and affect gating).
+		execSync(
+			`${ WP_ENV_RUN_CLI } wp user remove-cap ${ targetId } manage_wp_sudo`,
+			{ stdio: 'ignore' }
+		);
+		execSync(
+			`${ WP_ENV_RUN_CLI } wp transient delete --all --quiet 2>/dev/null || true`,
+			{ stdio: 'ignore' }
+		);
+	} );
+
+	test( 'ACCESS-01: grant is gated without an active sudo session', async ( {
+		page,
+		visitAdminPage,
+		context,
+	} ) => {
+		// The global storageState carries no sudo session.
+		const cookies = await context.cookies();
+		expect( cookies.some( ( c ) => c.name.startsWith( 'wp_sudo' ) ) ).toBe( false );
+
+		await visitAdminPage( 'options-general.php', ACCESS_QUERY );
+		await page.fill( '#wp-sudo-grant-user', String( targetId ) );
+		await page.selectOption( '#wp-sudo-grant-cap', 'manage_wp_sudo' );
+		await page.click( '#wp-sudo-grant-submit' );
+
+		// The Gate returns sudo_required; the JS surfaces data.message verbatim.
+		await expect( page.locator( '#wp-sudo-grant-result' ) ).toContainText(
+			/reauthentication|sudo session/i
+		);
+
+		// Nothing was granted.
+		expect( userCan( targetId, 'manage_wp_sudo' ) ).toBe( false );
+	} );
+
+	test( 'ACCESS-02: grant succeeds with an active sudo session', async ( {
+		page,
+		visitAdminPage,
+	} ) => {
+		await activateSudoSession( page );
+
+		await visitAdminPage( 'options-general.php', ACCESS_QUERY );
+		await page.fill( '#wp-sudo-grant-user', String( targetId ) );
+		await page.selectOption( '#wp-sudo-grant-cap', 'manage_wp_sudo' );
+		await page.click( '#wp-sudo-grant-submit' );
+
+		// Success feedback in the aria-live result span.
+		await expect( page.locator( '#wp-sudo-grant-result' ) ).toContainText(
+			/granted/i
+		);
+
+		// The capability landed on the target user.
+		expect( userCan( targetId, 'manage_wp_sudo' ) ).toBe( true );
+	} );
+} );


### PR DESCRIPTION
## Summary

**What changed?** Makes the Settings → Sudo **Access tab actually functional** and fixes a recovery-mode drift-detection inconsistency. Surfaced during manual UAT of PR #86.

**Branch is stacked on #86** (base = `gsd/phase-13-migration-safety-audit`) so this diff shows only the Access-tab work. Retarget to `main` once #86 merges.

### 1. Grant/Revoke/Manage buttons were dead (no JS)
The Access tab rendered Grant, Revoke, Revoke-Session, and drift "Grant manage_wp_sudo" buttons, and the server endpoints existed and were unit-tested — but **no client JavaScript ever wired them**, so clicking did nothing. Nothing caught it because the unit tests exercise the PHP handlers directly and there was no E2E click-through.

- New Access module in `admin/js/wp-sudo-admin.js` wires all four controls to `admin-ajax` via `fetch`, reading each element's per-element `wp_sudo_access` `data-nonce` (never the MU-plugin nonce).
- These actions are **gated** (`options.wp_sudo_access`), so without an active sudo session the Gate returns `sudo_required`. The JS surfaces `data.message` **verbatim** on every error path, so the 403 `sudo_required` (reauthenticate + retry), the 409 last-manager block, and the 429 revoke rate-limit all reach the operator. Gating is surfaced, never bypassed.
- Per-control DOM: grant form re-enables for repeated use; drift-grant removes the row; revoke-cap removes the cap (and the row if last); revoke-session disables + relabels. Client-side validates `user_id`. a11y via `wp.a11y.speak` (enqueue gains the `wp-a11y` dep).
- **Server authorization is unchanged** — handlers' nonce + `wp_sudo_can` + `GOVERNANCE_CAPS` checks untouched.

### 2. Drift panel hid the current user under recovery mode
`render_drift_detection_panel()` filtered by `! $user->has_cap('manage_wp_sudo')`. `has_cap()` routes through `map_meta_cap`, where the recovery-mode mapper remaps `manage_wp_sudo` → `manage_options` **for the current user**, so a drifted admin viewing their own Access tab during recovery mode was hidden from their own drift list. Now filters on `$user->allcaps` (raw stored primitives, immune to the remap).
- Integration test (`@runInSeparateProcess`) proves the regression: recovery ON, current user is a drift case → still self-lists (RED-proven against the old filter). Plus unit tests for the filter.

## Validation

- [x] `composer test:unit` — 812 tests, 2315 assertions, 0 failures.
- [x] `composer analyse` (PHPStan L6) — no errors.
- [x] Drift integration test passed against a real WP DB (and RED-proven without the fix).
- [ ] **Playwright E2E regression spec — TODO (tracked).** A click-through test (active session → grant lands; no session → `sudo_required`, no grant) is the deliberate next item: its absence is exactly what let the dead-button bug ship. Will add before this merges.
- [ ] **ROADMAP Access-tab polish — follow-up:** user picker (vs numeric ID) + plain-English capability labels.

## Checklist

- [x] Updated tests/docs/metrics for behavior changes.
- [x] No sensitive details disclosed.
- [x] No new authorization surface; existing gating/nonce/cap checks unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
