### PR TITLE
Fix #68: rename recovery dashboard label

### DIFF
--- a/includes/class-dashboard-widget.php
+++ b/includes/class-dashboard-widget.php
@@ -317,7 +317,7 @@ class Dashboard_Widget {
 		'action_allowed'  => 'Allowed',
 		'action_passed'   => 'Passed',
 		'action_replayed' => 'Replayed',
-		'recovery_mode'   => 'Recovery',
+		'recovery_mode'   => 'Break-glass',
 	);
 
 	/**

--- a/tests/Unit/DashboardWidgetTest.php
+++ b/tests/Unit/DashboardWidgetTest.php
@@ -163,6 +163,37 @@ class DashboardWidgetFakeWpdbWithEvents {
 }
 
 /**
+ * Fake wpdb that returns a recovery-mode event for label rendering tests.
+ */
+class DashboardWidgetFakeWpdbWithRecoveryEvent extends DashboardWidgetFakeWpdbWithEvents {
+
+	/**
+	 * Mock get_results() - returns a recovery-mode event row.
+	 *
+	 * @param string $query SQL query.
+	 * @return array<int, object>
+	 */
+	public function get_results( string $query ): array {
+		$this->last_get_results_query = $query;
+		if ( strpos( $query, 'wpsudo_events' ) !== false ) {
+			return [
+				(object) [
+					'id'         => 2,
+					'user_id'    => 1,
+					'event'      => 'recovery_mode',
+					'rule_id'    => '',
+					'surface'    => 'admin',
+					'created_at' => gmdate( 'Y-m-d H:i:s', time() - 60 ),
+				],
+			];
+		}
+
+		return [];
+	}
+
+}
+
+/**
  * Fake wpdb that returns a critical event for badge rendering tests.
  */
 class DashboardWidgetFakeWpdbWithCriticalEvent {
@@ -948,6 +979,44 @@ class DashboardWidgetTest extends TestCase {
 		$this->assertStringContainsString( 'title="Update options"', $output );
 		$this->assertStringContainsString( 'title="admin"', $output );
 		$this->assertStringContainsString( '<code class="wp-sudo-action-id" title="Technical action ID: options.update">options.update</code>', $output );
+
+		$this->restoreWpdb();
+	}
+
+	/**
+	 * Test recovery-mode events render the break-glass display label.
+	 *
+	 * @return void
+	 */
+	public function testRecoveryModeEventsRenderBreakGlassLabel(): void {
+		$this->setUpRenderStubs();
+		\WP_User_Query::$mock_total   = 0;
+		\WP_User_Query::$mock_results = [];
+		Functions\when( 'human_time_diff' )->justReturn( '1 min ago' );
+		Functions\when( 'get_option' )->justReturn( [] );
+		Functions\when( 'get_users' )->alias(
+			function ( array $args ): array {
+				if ( isset( $args['include'] ) ) {
+					$user             = (object) array();
+					$user->ID         = 1;
+					$user->user_login = 'testuser';
+					return array( $user );
+				}
+
+				return array();
+			}
+		);
+
+		$GLOBALS['wpdb'] = new DashboardWidgetFakeWpdbWithRecoveryEvent();
+
+		ob_start();
+		Dashboard_Widget::render();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'Break-glass', $output );
+		$this->assertStringContainsString( 'title="Break-glass"', $output );
+		$this->assertStringContainsString( 'data-event="recovery_mode"', $output );
+		$this->assertStringNotContainsString( 'title="Recovery"', $output );
 
 		$this->restoreWpdb();
 	}


### PR DESCRIPTION
## Summary

- Rename the dashboard display label for `recovery_mode` events from `Recovery` to `Break-glass`.
- Keep the stored event key/API value as `recovery_mode`.
- Add unit coverage for the recovery-mode dashboard row so the label and stored key behavior stay intentional.

Fixes #68.

## Why

The dashboard should use the project’s break-glass terminology for this event so it is not confused with WordPress core recovery mode. This is only a human-readable display label change; stored event data and integrations continue to use `recovery_mode`.

## Validation

- [x] `vendor/bin/phpunit --configuration phpunit.xml.dist --filter DashboardWidgetTest`
- [x] `composer test`
- [x] `composer lint`
- [x] `composer analyse` partially verified:
  - PHPStan passed.
  - Psalm did not run locally because this machine has PHP 8.3.6 and the repo's Psalm requires PHP >= 8.3.16.

No e2e run was needed for this small dashboard label change; the rendered dashboard row is covered by the updated unit test.

## Checklist

- [x] Linked issue: #68
- [x] Updated test coverage for the behavior change
- [x] No stored event key, hook name, constant, or API symbol changed
- [x] No sensitive details disclosed publicly
