### PR TITLE
Docs: clarify break-glass recovery terminology

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -134,19 +134,21 @@ If you need to proceed despite the guard — for example, after a key person lea
 
 Break-glass recovery mode is an emergency escape hatch for the "last manager locked out" scenario. It is activated by adding the following line to `wp-config.php`:
 
+This is WP Sudo's break-glass governance recovery path, not WordPress core's `WP_Recovery_Mode`.
+
 ```php
 define( 'WP_SUDO_RECOVERY_MODE', true );
 ```
 
 When active:
-- The current user gains effective `manage_wp_sudo` access **only if they also hold site/network admin authority** — `manage_options` on single-site, `manage_network_options` on multisite. The recovery check is role-gated: a locked-out manager who kept their administrator role recovers, but subscribers, editors, and other non-admins gain nothing. (Multisite super admins always pass regardless.)
-- A **permanent, non-dismissible warning notice** is shown on the Sudo settings screen while recovery mode is active, and the `wp_sudo_recovery_mode_active` audit hook fires (recorded as a sampled `recovery_mode` event) so the usage is visible to logging tools.
+- The current user gains effective `manage_wp_sudo` access **only if they also hold site/network admin authority** — `manage_options` on single-site, `manage_network_options` on multisite. The break-glass recovery check is role-gated: a locked-out manager who kept their administrator role recovers, but subscribers, editors, and other non-admins gain nothing. (Multisite super admins always pass regardless.)
+- A **permanent, non-dismissible warning notice** is shown on the Sudo settings screen while break-glass recovery mode is active, and the `wp_sudo_recovery_mode_active` audit hook fires (recorded as a sampled `recovery_mode` event) so the usage is visible to logging tools.
 
-Recovery mode **does not** bypass the reauthentication challenge itself. A user in recovery mode must still complete the sudo challenge on gated actions — they just regain access to the Sudo settings and Access tab.
+Break-glass recovery mode **does not** bypass the reauthentication challenge itself. A user using break-glass recovery mode must still complete the sudo challenge on gated actions — they just regain access to the Sudo settings and Access tab.
 
 Defining the constant requires `wp-config.php` write access, so the practical risk is operator error rather than remote escalation. The role gate contains the blast radius, but while the constant is set **every administrator** (every `manage_options` holder) regains full Sudo governance — and can self-grant the other capabilities and change gating policy from the Access tab. **Remove the constant the moment normal access is restored.**
 
-One limitation: because the gate requires an admin capability, recovery mode does **not** rescue a Sudo manager who was deliberately granted `manage_wp_sudo` *without* a WordPress admin role. Recover such a user another way — for example `wp user add-cap <user> manage_wp_sudo` via WP-CLI, or temporarily grant them `manage_options`.
+One limitation: because the gate requires an admin capability, break-glass recovery mode does **not** rescue a Sudo manager who was deliberately granted `manage_wp_sudo` *without* a WordPress admin role. Recover such a user another way — for example `wp user add-cap <user> manage_wp_sudo` via WP-CLI, or temporarily grant them `manage_options`.
 
 ## Does this replace WordPress roles and capabilities?
 

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -44,7 +44,8 @@ directly to `user_can( $user_id, $cap )` with no `manage_options` fallback. See
 
 **Break-glass recovery — the sole remaining escape hatch:** if every holder of `manage_wp_sudo` is removed,
 `define('WP_SUDO_RECOVERY_MODE', true)` in `wp-config.php` grants temporary
-access. The recovery check is **role-gated**: while the constant is defined, the
+access. This refers to WP Sudo's break-glass governance recovery path, not WordPress core's `WP_Recovery_Mode`.
+The break-glass recovery check is **role-gated**: while the constant is defined, the
 current user receives effective `manage_wp_sudo` only if they *also* hold site
 or network admin authority (`manage_options` on single-site,
 `manage_network_options` on multisite). The governance model deliberately
@@ -64,9 +65,9 @@ change gating policy from the Access tab.
 Two safeguards make the window visible:
 
 - A **permanent, non-dismissible warning notice** appears on the Sudo settings
-  screen while recovery mode is active.
+  screen while break-glass recovery mode is active.
 - The `wp_sudo_recovery_mode_active` **audit hook** fires on every Sudo
-  admin-page load under recovery mode (unthrottled, for external loggers); the
+  admin-page load under break-glass recovery mode (unthrottled, for external loggers); the
   bundled recorder stores a sampled `recovery_mode` event (one per user per hour).
 
 Defining the constant requires `wp-config.php` write access, so the practical
@@ -74,9 +75,9 @@ risk is operator error — enabling it for break-glass and then leaving it on.
 **Remove the constant the moment normal access is restored.**
 
 > **Note (multisite and non-admin managers):** because the gate requires
-> `manage_network_options` on multisite, recovery effectively only matters
+> `manage_network_options` on multisite, break-glass recovery effectively only matters
 > alongside super-admin access there; and because it requires `manage_options`
-> everywhere, recovery does **not** rescue a Sudo manager who was deliberately
+> everywhere, break-glass recovery does **not** rescue a Sudo manager who was deliberately
 > granted `manage_wp_sudo` *without* a WordPress admin role. Recover such a user
 > another way — e.g. `wp user add-cap <user> manage_wp_sudo` via WP-CLI, or
 > temporarily granting them `manage_options`. A scoped recovery form

--- a/readme.md
+++ b/readme.md
@@ -133,9 +133,9 @@ WP Sudo gates specific operations on specific surfaces. It is not a firewall, ex
 
 WP Sudo integrates with the **Site Health** tool in WordPress core for rich security diagnostics and advisory notifications.
 
-### Break glass recovery scenario
+### Break-glass recovery scenario
 
-In a lost, last administrator scenario where no one has access to Sudo's settings, the break-glass mechanism is to set `WP_SUDO_RECOVERY_MODE` in `wp-config.php`. It requires filesystem access to activate, so it is not a remote-escalation vector. The grant is **role-gated**: while the constant is defined, the current user receives the master `manage_wp_sudo` capability only if they also hold `manage_options` (single-site) / `manage_network_options` (multisite), so a locked-out administrator recovers while non-admins gain nothing. A permanent non-dismissible notice appears on the Sudo settings screen while it is active, and the `wp_sudo_recovery_mode_active` audit hook fires so the usage is logged. The role gate does not eliminate the residual risk — every administrator regains full Sudo governance while the constant is set — so remove it the moment normal access is restored.
+In a lost, last administrator scenario where no one has access to Sudo's settings, the break-glass mechanism is to set `WP_SUDO_RECOVERY_MODE` in `wp-config.php`. This is WP Sudo's break-glass governance recovery path, not WordPress core's `WP_Recovery_Mode`. It requires filesystem access to activate, so it is not a remote-escalation vector. The grant is **role-gated**: while the constant is defined, the current user receives the master `manage_wp_sudo` capability only if they also hold `manage_options` (single-site) / `manage_network_options` (multisite), so a locked-out administrator recovers while non-admins gain nothing. A permanent non-dismissible notice appears on the Sudo settings screen while it is active, and the `wp_sudo_recovery_mode_active` audit hook fires so the usage is logged. The role gate does not eliminate the residual risk — every administrator regains full Sudo governance while the constant is set — so remove it the moment normal access is restored.
 
 ## For developers and integrators
 

--- a/readme.txt
+++ b/readme.txt
@@ -362,7 +362,7 @@ See the plugin's `CHANGELOG.md` for all versions.
 == Upgrade Notice ==
 
 = 4.0.0 =
-Breaking release. The deprecated `sudo_can()` function is removed — switch any calls to `wp_sudo_can()`. The `compatibility` governance mode is removed; it was a transitional bridge added in 3.2.0 for the dedicated-capability model and is no longer needed now that the model is established and `WP_SUDO_RECOVERY_MODE` covers lockout recovery. Governance is now always strict. If you used compatibility mode, the leftover `wp_sudo_governance_mode` option is removed automatically on upgrade (no manual cleanup) — you'll see a one-time dismissible confirmation notice, not a persistent warning. `WP_SUDO_RECOVERY_MODE` remains the only break-glass path. Minimum requirements are now WordPress 6.4 and PHP 8.2 — confirm your host meets them before upgrading.
+Breaking release. The deprecated `sudo_can()` function is removed — switch any calls to `wp_sudo_can()`. The `compatibility` governance mode is removed; it was a transitional bridge added in 3.2.0 for the dedicated-capability model and is no longer needed now that the model is established and `WP_SUDO_RECOVERY_MODE` covers break-glass lockout recovery. Governance is now always strict. If you used compatibility mode, the leftover `wp_sudo_governance_mode` option is removed automatically on upgrade (no manual cleanup) — you'll see a one-time dismissible confirmation notice, not a persistent warning. `WP_SUDO_RECOVERY_MODE` remains the only break-glass path. Minimum requirements are now WordPress 6.4 and PHP 8.2 — confirm your host meets them before upgrading.
 
 = 2.7.0 =
 New `wp_sudo_wpgraphql_bypass` filter for JWT authentication compatibility. No settings migration required.


### PR DESCRIPTION
## Summary

- Standardize user-facing docs on "break-glass recovery mode" for WP Sudo's `WP_SUDO_RECOVERY_MODE` feature.
- Add explicit disambiguation from WordPress core's `WP_Recovery_Mode` where the feature is introduced.
- Keep all code symbols, constants, hooks, and event types unchanged.

Fixes #69.

## Why

The docs used some unqualified "recovery mode" wording for WP Sudo's emergency governance path. Leading with "break-glass" makes the feature easier to distinguish from WordPress core recovery mode while preserving the existing technical names.

## Validation

- [x] Audited `docs/security-model.md`, `docs/FAQ.md`, `readme.md`, and `readme.txt`.
- [x] `rg -n -i --pcre2 "(?<!break-glass )recovery mode|Break glass|break glass" docs/security-model.md docs/FAQ.md readme.md readme.txt`
- [x] `git diff --check`
- [x] `composer lint`

This is a docs-only change, so no unit or e2e tests were run.

## Checklist

- [x] Linked issue: #69
- [x] Docs-only wording change
- [x] No code/constant/hook/event-type names changed
- [x] No sensitive details disclosed publicly
