### PR TITLE
Docs: add manual environment matrix

### DIFF
--- a/tests/MANUAL-TESTING.md
+++ b/tests/MANUAL-TESTING.md
@@ -19,6 +19,30 @@ wp-env, DDEV, etc.).
 > Use the multisite for network admin rules (section 13), WP-CLI, and
 > app-password `curl` tests.
 
+### Release Environment Matrix Checklist
+
+Before each release, run the core manual smoke set on at least one environment
+in each row below. Confirm the current supported WordPress floor in
+[`docs/release-status.md`](../docs/release-status.md) instead of copying a
+version number into this checklist.
+
+| Environment lane | Example targets | Core smoke set |
+|------------------|-----------------|----------------|
+| Apache stack | DDEV, MAMP, Local, or a staging host using Apache | Sections 1.1, 2.1, 2.9, 4.1, 5.2, 9.1 |
+| Managed WordPress host | Pressable, WP Engine, Cloudways, or equivalent trial/staging site | Sections 1.1, 2.1, 2.9, 9.1, 10.1 |
+| Minimum supported WordPress version | The current floor listed in `docs/release-status.md` | Sections 1.1, 2.1, 2.9, 4.1, 5.2, 9.1 |
+
+- [ ] Apache environment completed; record host/tool, PHP version, database,
+      browser, and any rewrite/auth-header notes.
+- [ ] Managed WordPress host completed; record host, plan/trial type, caching
+      or security features enabled, and any blocked filesystem or mu-plugin
+      operations.
+- [ ] Minimum supported WordPress version completed; record the exact WordPress
+      version from `docs/release-status.md`, PHP version, and whether this run
+      used single-site or multisite.
+- [ ] Any skipped core smoke item has a reason and a follow-up issue or release
+      note entry if it affects release confidence.
+
 ---
 
 ## Prerequisites


### PR DESCRIPTION
## Summary

- Add a release environment matrix checklist to `tests/MANUAL-TESTING.md`.
- Cover Apache, managed WordPress host, and minimum-supported-WordPress lanes.
- Link to `docs/release-status.md` for the current supported WordPress floor instead of hardcoding a volatile version.

Fixes #70.

## Why

The manual testing guide already covers single-site and multisite workflows, but it did not give release testers a concise cross-environment checklist. This adds the missing environment matrix promised by the testing infrastructure roadmap while keeping version values centralized in `docs/release-status.md`.

## Validation

- [x] Confirmed the checklist references `docs/release-status.md`.
- [x] Confirmed no hardcoded minimum WordPress version was added.
- [x] `git diff --check`
- [x] `composer lint`

This is a docs-only change, so no unit or e2e tests were run.

## Checklist

- [x] Linked issue: #70
- [x] Docs-only change
- [x] No code changes
- [x] No sensitive details disclosed publicly
