### PR TITLE
docs: sync displayed requirement floors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,7 @@ This file provides guidance to Codex (Codex.ai/code) when working with code in t
 
 WP Sudo is a WordPress plugin that provides action-gated reauthentication. Dangerous operations (plugin activation, user deletion, critical settings changes, etc.) require password confirmation before they proceed — regardless of user role.
 
-**Requirements:** WordPress 6.2+, PHP 8.0+
+**Requirements:** WordPress 6.4+, PHP 8.2+
 
 ## Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,7 @@ USER_COMMIT=1 git commit -m "message"
 
 WP Sudo is a WordPress plugin that provides action-gated reauthentication. Dangerous operations (plugin activation, user deletion, critical settings changes, etc.) require password confirmation before they proceed — regardless of user role.
 
-**Requirements:** WordPress 6.2+, PHP 8.0+
+**Requirements:** WordPress 6.4+, PHP 8.2+
 
 ## Commands
 

--- a/docs/vulnerability-testing-guide.md
+++ b/docs/vulnerability-testing-guide.md
@@ -55,7 +55,7 @@ These vulnerabilities typically occur via unauthenticated access or bypass WordP
 
 ### Recommended Approach:
 1. **Environment**: Use a local development stack (LocalWP, Docker/LAMP, or WP Playground) with network isolation
-2. **WordPress Version**: Test against the minimum supported line (WordPress 6.2+) and the current forward lane (WordPress 7.0 GA); include WPGraphQL only when that plugin is part of the scenario.
+2. **WordPress Version**: Test against the minimum supported line (WordPress 6.4+) and the current forward lane (WordPress 7.0 GA); include WPGraphQL only when that plugin is part of the scenario.
 3. **Plugin Versions**: Install exact vulnerable versions:
    - WordPress Review Plugin: ≤5.3.5
    - Newsletters: ≤4.9.9.9

--- a/readme.md
+++ b/readme.md
@@ -7,8 +7,8 @@
 Require password confirmation before high-risk changes go through on your WordPress site — even from an already-authenticated admin session. Sudo also lets site owners define the shape of their administrative attack surface across admin UI, AJAX, REST, WP-CLI, Cron, XML-RPC, Application Passwords, and WPGraphQL. Built-in activity visibility, audit hooks, and governance controls help administrators see who is attempting sensitive actions and decide which users can manage Sudo policy.
 
 [![License: GPL v2+](https://img.shields.io/badge/License-GPL%20v2%2B-blue.svg)](https://spdx.org/licenses/GPL-2.0-or-later.html) [![Security Policy](https://img.shields.io/badge/security-policy-4c1)](SECURITY.md) [![Docs](https://img.shields.io/badge/docs-available-0a7ea4.svg)](docs/) [![AI Authorship](https://img.shields.io/badge/AI%20authorship-disclosed-8a63d2.svg)](docs/ai-authorship.md)
-[![WordPress: 6.2+](https://img.shields.io/badge/WordPress-6.2%2B-0073aa.svg)](https://wordpress.org/)
-[![PHP: 8.0+](https://img.shields.io/badge/PHP-8.0%2B-777bb4.svg)](https://www.php.net/)
+[![WordPress: 6.4+](https://img.shields.io/badge/WordPress-6.4%2B-0073aa.svg)](https://wordpress.org/)
+[![PHP: 8.2+](https://img.shields.io/badge/PHP-8.2%2B-777bb4.svg)](https://www.php.net/)
 [![PHPUnit](https://github.com/dknauss/Sudo/actions/workflows/phpunit.yml/badge.svg)](https://github.com/dknauss/Sudo/actions/workflows/phpunit.yml)
 [![Psalm](https://github.com/dknauss/Sudo/actions/workflows/psalm.yml/badge.svg)](https://github.com/dknauss/Sudo/actions/workflows/psalm.yml)
 [![Playwright Tests](https://github.com/dknauss/Sudo/actions/workflows/e2e.yml/badge.svg)](https://github.com/dknauss/Sudo/actions/workflows/e2e.yml)
@@ -151,8 +151,8 @@ Sudo exposes a small, stable API. Custom gated rules are plain associative array
 
 ## Requirements
 
-- **WordPress:** 6.2+
-- **PHP:** 8.0+
+- **WordPress:** 6.4+
+- **PHP:** 8.2+
 - **Multisite:** supported
 
 For current release posture, supported lanes, and forward `main` notes, see [docs/release-status.md](docs/release-status.md).


### PR DESCRIPTION
## Summary

Updates remaining displayed requirement references to match the v4.0.0 floor:

- WordPress 6.4+
- PHP 8.2+

## What changed

- Updates the GitHub README badges and Requirements section in `readme.md`.
- Updates local agent guidance in `AGENTS.md` and `CLAUDE.md`.
- Updates the current minimum-supported-line reference in `docs/vulnerability-testing-guide.md`.

## Validation

- `git diff --check`
- Targeted grep confirmed the old displayed requirement strings no longer appear in `readme.md`, `AGENTS.md`, `CLAUDE.md`, or `docs/vulnerability-testing-guide.md`.

Docs-only change; reviewer-agent approval and test suite are skipped per project docs-only commit policy.