### PR TITLE
feat(gate): REST effect-level backstop + audit methodology (deferred #102 follow-ups)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,7 @@ No build step. No production dependencies — only dev dependencies (PHPUnit 9.6
 ## Documentation
 
 - `docs/security-model.md` — threat model, boundaries, environmental considerations.
+- `docs/security-audit-methodology.md` — **mandatory** security-audit process: "reason about the target first" before any sink-oriented scan. Required whenever auditing the gate, session, or any component that enforces, gates, binds, or issues a security decision.
 - `docs/developer-reference.md` — hook signatures, filters, custom rule structure.
 - `docs/FAQ.md` — all frequently asked questions.
 - `CHANGELOG.md` — full version history.

--- a/docs/current-metrics.md
+++ b/docs/current-metrics.md
@@ -9,21 +9,21 @@ Verification environment: local workspace, PHP 8.x
 
 | Metric | Value | Verification |
 |---|---:|---|
-| Unit tests | 834 tests | `composer test:unit` |
-| Unit assertions | 2399 assertions | `composer test:unit` |
+| Unit tests | 845 tests | `composer test:unit` |
+| Unit assertions | 2435 assertions | `composer test:unit` |
 | Integration tests in suite | 194 test methods | `rg -c "function test" tests/Integration/*.php | awk -F: '{sum+=$2} END{print sum}'` |
-| Unit test files | 26 | `ls tests/Unit/*.php | wc -l` |
+| Unit test files | 27 | `ls tests/Unit/*.php | wc -l` |
 | Integration test files | 26 | `ls tests/Integration/*.php | wc -l` |
 
 ## Size Metrics
 
 | Metric | Value | Verification |
 |---|---:|---|
-| Production PHP lines (`includes/`, `wp-sudo.php`, `uninstall.php`, `mu-plugin/`, `bridges/`) | 15,322 | `find ./includes ./wp-sudo.php ./uninstall.php ./mu-plugin ./bridges -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
-| Tests PHP lines (`tests/`) | 30,357 | `find ./tests -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
-| Production + tests PHP lines | 45,679 | sum of the two rows above |
-| Test-to-production ratio | 1.98:1 | `30357 / 15322` |
-| Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`) | 45,942 | `find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/vendor_test/*" ! -path "*/.tmp/*" ! -path "*/.git/*" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Production PHP lines (`includes/`, `wp-sudo.php`, `uninstall.php`, `mu-plugin/`, `bridges/`) | 15,481 | `find ./includes ./wp-sudo.php ./uninstall.php ./mu-plugin ./bridges -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Tests PHP lines (`tests/`) | 30,657 | `find ./tests -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Production + tests PHP lines | 46,138 | sum of the two rows above |
+| Test-to-production ratio | 1.98:1 | `30657 / 15481` |
+| Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`) | 46,401 | `find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/vendor_test/*" ! -path "*/.tmp/*" ! -path "*/.git/*" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
 
 ## Architectural Facts
 

--- a/docs/security-audit-methodology.md
+++ b/docs/security-audit-methodology.md
@@ -1,0 +1,100 @@
+# Security Audit Methodology
+
+This document codifies how WP Sudo is to be security-audited. It exists because
+a standard, sink-oriented audit pass returned this plugin **clean** while two
+real weaknesses were present in the code — they were found only after the audit
+was reframed around the target. The reframing, not new code, is what surfaced
+them (see the case study below).
+
+## Mandatory first step: Reason about the target first
+
+**Before** any sink-oriented scanning — before enumerating request handlers and
+hunting for injection, XSS, CSRF, broken access control, or missing nonces — you
+**MUST** first reason about the target as a security *asset*, and write the
+result down. A sink-oriented audit answers *"does this code contain a vulnerable
+sink?"* It correctly returns "clean" for a plugin like WP Sudo that has no such
+sinks, while it is structurally blind to the failures that only an asset-oriented
+framing reveals.
+
+This step is mandatory for every audit of this plugin and for any component whose
+job is to enforce, gate, bind, or issue a security decision.
+
+### What "reason about the target first" requires
+
+For each component under audit, complete the following **before** scanning:
+
+1. **Name the asset class.** Is this a security *control*, a *credential
+   issuer*, a *data store*, or an *entry point*? WP Sudo's gate is a **control**
+   (action-gated reauthentication); the sudo session is a **credential**.
+
+2. **State the security properties as invariants.** Write them as things that
+   must always hold, independent of any particular code path. For a control:
+   *"the gate cannot be bypassed on any surface that can reach a gated-equivalent
+   effect."* For a credential: *"the proof is bound to the login session and
+   principal that created it, and cannot be replayed from another session or
+   outlive it."*
+
+3. **Enumerate what violates each property — independent of any sink.** These
+   failure classes are properties, not sinks; a sink scan cannot see them:
+   - **Incomplete surface coverage.** The control fires on the handlers the
+     audit enumerated, but a non-enumerated or third-party handler (e.g. a custom
+     `admin-post.php` route, a custom REST route) reaches the same destructive
+     effect ungated.
+   - **Unbound credential.** The proof is accepted regardless of which login
+     session or principal presents it, so a captured cookie can be replayed, or
+     the window outlives the login that created it.
+   - **Policy/classification drift.** The same authorization decision is computed
+     in two places that can diverge (e.g. cookie-vs-headless classification).
+
+4. **Audit from the asset, not the code.** Ask the asset's own question —
+   *"can this control be bypassed, and is its credential sound?"* — and then
+   trace **every** path that could violate the stated invariant, **including
+   paths that contain no traditional vulnerable sink.** A handler that simply
+   *runs the effect* is in scope even when it is perfectly "secure" by sink
+   standards, because the weakness is the control's absence there, not a bug in
+   the handler.
+
+### Mandatory pre-scan checklist
+
+Complete and record this before starting the sink-oriented scan:
+
+- [ ] Named the asset class (control / credential / store / entry point).
+- [ ] Stated the security properties as explicit invariants.
+- [ ] Enumerated the property-violation classes independent of sinks.
+- [ ] **For a control:** checked surface completeness — every path that can reach
+      a gated-equivalent effect, including non-enumerated and third-party
+      handlers, on every entry point (admin, AJAX, REST, CLI, cron, XML-RPC,
+      WPGraphQL).
+- [ ] **For a credential:** checked binding — session, principal, replay, and
+      lifetime (logout / re-login / session destruction).
+- [ ] **For any duplicated decision:** checked that the two computation sites
+      cannot drift (or refactored them to a single shared classifier).
+
+Only after this checklist is complete may you proceed to the standard
+sink-oriented scan. The two passes are complementary: the sink scan catches
+implementation bugs; "reason about the target first" catches missing or unsound
+controls.
+
+## Case study (why this is mandatory)
+
+The two action-gating completeness findings fixed under coordinated disclosure
+were present in the shipped code and were **missed by a sink-oriented fleet
+audit** that — correctly, for its question — reported the plugin clean. They were
+found only when the audit was reframed with one prompt: *"Do you have any
+recommendations for doing a more deep look at the code vs the standard audit
+process?"* That reframing is exactly the asset-oriented framing above:
+
+- Finding 1 is *incomplete surface coverage* — a control gap, not a sink bug; the
+  handler that ran the effect was a third party's, and the gate simply never
+  fired there.
+- Finding 2 is *unbound credential* — a session-management property, invisible to
+  a sink scan.
+
+Both are the classes that **only** "reason about the target first" catches. The
+weaknesses were not new in the audited version — the relevant code was unchanged
+(byte-identical in the prior minor) — so the difference was methodology, not
+code.
+
+Canonical write-up, provenance, and affected versions:
+[`security-report-2026-06-gate-completeness.md`](security-report-2026-06-gate-completeness.md).
+Threat model and boundaries: [`security-model.md`](security-model.md).

--- a/includes/class-gate.php
+++ b/includes/class-gate.php
@@ -151,6 +151,12 @@ class Gate {
 		// REST API interception — fires after route matching, before callbacks.
 		add_filter( 'rest_request_before_callbacks', array( $this, 'intercept_rest' ), 10, 3 );
 
+		// REST effect-level backstop — same defense-in-depth as the admin
+		// backstop, for destructive effects invoked by a non-enumerated/custom
+		// REST route that intercept_rest() cannot match. Armed only during REST
+		// requests (rest_api_init fires before route dispatch).
+		add_action( 'rest_api_init', array( $this, 'register_rest_backstop' ), 0, 0 );
+
 		// WPGraphQL interception — hooks into WPGraphQL's own lifecycle.
 		// Fires after auth validation, before body reading, regardless of endpoint name.
 		/**
@@ -243,6 +249,95 @@ class Gate {
 			);
 		};
 
+		$this->arm_effect_guards( $guard );
+	}
+
+	/**
+	 * Arm the REST effect-level backstop.
+	 *
+	 * Mirrors the interactive backstop on the REST surface so a destructive
+	 * effect invoked by a non-enumerated/custom REST route — one that
+	 * intercept_rest() does not match — cannot run while no sudo window is open.
+	 * Enumerated REST routes are already handled by intercept_rest() at
+	 * rest_request_before_callbacks: with no sudo it returns a WP_Error before
+	 * the route callback (the effect never fires); with a sudo window active the
+	 * callback runs and this guard allows the effect silently.
+	 *
+	 * Unlike the admin guard, the REST guard honours the Application Password
+	 * policy via the shared rest_auth_mode() classification: an Unrestricted
+	 * headless client is allowed (audit only), while a cookie-authenticated
+	 * browser request or a Limited/Disabled app-password request is blocked.
+	 * Because an action hook cannot return a WP_Error, the block is delivered via
+	 * wp_die(), which WordPress renders as a JSON 403 during a REST request. The
+	 * two paths never fire for the same request (enumerated -> intercept_rest;
+	 * non-enumerated -> backstop), so the differing block shapes never collide.
+	 *
+	 * @since 4.1.0
+	 *
+	 * @return void
+	 */
+	public function register_rest_backstop(): void {
+		$user_id = get_current_user_id();
+
+		if ( ! $user_id ) {
+			return;
+		}
+
+		$guard = function ( string $rule_id, string $label ) use ( $user_id ): void {
+			// Sudo window open (or within grace) — allow, silently.
+			if ( Sudo_Session::is_active( $user_id ) || Sudo_Session::is_within_grace( $user_id ) ) {
+				return;
+			}
+
+			if ( 'cookie' === $this->rest_auth_mode() ) {
+				// Cookie-authenticated browser request — hard block. An effect
+				// hook cannot stash and replay the request the way intercept_rest()
+				// does for enumerated routes, so surface a blocked (not gated)
+				// audit on 'rest': no challenge will follow.
+				/** This action is documented in includes/class-gate.php */
+				do_action( 'wp_sudo_action_blocked', $user_id, $rule_id, 'rest' );
+				$this->die_rest_sudo_required( $label );
+			} else {
+				// Headless (app-password / bearer) — honour the App Password policy.
+				$policy = $this->get_app_password_policy();
+
+				// Unrestricted: pass through, audit only.
+				if ( self::POLICY_UNRESTRICTED === $policy ) {
+					/** This action is documented in includes/class-gate.php */
+					do_action( 'wp_sudo_action_allowed', $user_id, $rule_id, 'rest_app_password' );
+					return;
+				}
+
+				// Limited: block with logging. Disabled: block without logging.
+				if ( self::POLICY_LIMITED === $policy ) {
+					/** This action is documented in includes/class-gate.php */
+					do_action( 'wp_sudo_action_blocked', $user_id, $rule_id, 'rest_app_password' );
+				}
+
+				$this->die_rest_sudo_required( $label );
+			}
+		};
+
+		$this->arm_effect_guards( $guard );
+	}
+
+	/**
+	 * Register the destructive-effect guards shared by the backstops.
+	 *
+	 * The interactive (admin) and REST backstops cover exactly the same set of
+	 * file/record-destroying effects — actions whose hook fires only inside the
+	 * named effect function (wp_delete_user(), delete_plugins(), etc.) plus the
+	 * plugin/theme install/update operations classified from upgrader_pre_install.
+	 * Keeping the hook set in one place guarantees the two surfaces stay in sync;
+	 * each passes its own surface-specific guard closure.
+	 *
+	 * @since 4.1.0
+	 *
+	 * @param callable $guard fn(string $rule_id, string $label): void — the
+	 *                        surface guard to invoke when an effect fires.
+	 * @return void
+	 */
+	private function arm_effect_guards( callable $guard ): void {
 		add_action(
 			'activate_plugin',
 			function () use ( $guard ) {
@@ -304,6 +399,75 @@ class Gate {
 			0,
 			2
 		);
+	}
+
+	/**
+	 * Terminate a REST request that requires sudo with a 403.
+	 *
+	 * Used by the REST backstop, which fires inside an effect action hook and so
+	 * cannot return a WP_Error. During a REST request WordPress routes wp_die()
+	 * through the REST die handler, producing a JSON 403 response.
+	 *
+	 * @since 4.1.0
+	 *
+	 * @param string $label Human-readable action label.
+	 * @return void
+	 */
+	private function die_rest_sudo_required( string $label ): void {
+		wp_die(
+			esc_html(
+				sprintf(
+					/* translators: %s: action label */
+					__( 'This operation (%s) requires sudo and cannot be performed without an active sudo session.', 'wp-sudo' ),
+					$label
+				)
+			),
+			'',
+			array( 'response' => 403 )
+		);
+	}
+
+	/**
+	 * Classify the current REST request's authentication for gating.
+	 *
+	 * Returns 'cookie' when the request carries a valid wp_rest nonce AND is not
+	 * authenticated via an Application Password (a browser/cookie request);
+	 * returns 'app_password' otherwise (App Password, bearer, or any headless
+	 * credential). A request presenting BOTH a valid nonce AND an App Password is
+	 * classified as headless, so a headless client cannot bypass the App Password
+	 * policy by also sending a nonce (C2). WordPress core accepts the REST nonce
+	 * via the X-WP-Nonce header or the _wpnonce parameter (see
+	 * rest_cookie_check_errors() in wp-includes/rest-api.php).
+	 *
+	 * Shared by intercept_rest() (enumerated routes) and register_rest_backstop()
+	 * (non-enumerated routes) so the two paths cannot drift. The optional request
+	 * argument lets intercept_rest() read the nonce from the parsed
+	 * WP_REST_Request header; the backstop runs inside an effect hook without the
+	 * request object and falls back to the X-WP-Nonce header and _wpnonce
+	 * parameter from the superglobals.
+	 *
+	 * @since 4.1.0
+	 *
+	 * @param \WP_REST_Request|null $request The REST request, when available.
+	 * @return string 'cookie' or 'app_password'.
+	 */
+	private function rest_auth_mode( ?\WP_REST_Request $request = null ): string {
+		$nonce = '';
+		if ( $request instanceof \WP_REST_Request ) {
+			$nonce = (string) $request->get_header( 'X-WP-Nonce' );
+		}
+		if ( '' === $nonce ) {
+			$nonce = self::sanitize_input_string( $_SERVER['HTTP_X_WP_NONCE'] ?? '' ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Read-only classification; sanitized in helper.
+		}
+		if ( '' === $nonce ) {
+			$nonce = self::sanitize_input_string( $_REQUEST['_wpnonce'] ?? '' ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Read-only classification; sanitized in helper.
+		}
+
+		$is_cookie_auth = '' !== $nonce
+			&& wp_verify_nonce( $nonce, 'wp_rest' )
+			&& ! rest_get_authenticated_app_password();
+
+		return $is_cookie_auth ? 'cookie' : 'app_password';
 	}
 
 	/**
@@ -1295,19 +1459,9 @@ class Gate {
 			return $response;
 		}
 
-		// Distinguish cookie-auth (browser) from app-password/bearer (headless).
-		// WordPress core accepts the REST nonce via X-WP-Nonce header or _wpnonce
-		// request parameter (see rest_cookie_check_errors() in wp-includes/rest-api.php).
-		$nonce = $request->get_header( 'X-WP-Nonce' );
-		if ( ! $nonce ) {
-			$nonce = self::sanitize_input_string( $_REQUEST['_wpnonce'] ?? '' ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Read-only classification; sanitized in helper.
-		}
-		// A request that presents BOTH a valid nonce AND an App Password credential
-		// must be classified as headless. Without this guard a headless client
-		// including a nonce bypasses the App Password policy (C2).
-		$is_cookie_auth = $nonce
-			&& wp_verify_nonce( $nonce, 'wp_rest' )
-			&& ! rest_get_authenticated_app_password();
+		// Distinguish cookie-auth (browser) from app-password/bearer (headless)
+		// via the shared classifier (also used by the REST effect backstop).
+		$is_cookie_auth = 'cookie' === $this->rest_auth_mode( $request );
 
 		if ( ! $is_cookie_auth ) {
 			// Non-browser auth (app-password, bearer, etc.) — check policy.

--- a/includes/class-sudo-session.php
+++ b/includes/class-sudo-session.php
@@ -48,8 +48,12 @@ class Sudo_Session {
 	 * Stores a SHA-256 hash of the login-session token (the value returned by
 	 * wp_get_session_token()) captured when the sudo session was activated. The
 	 * Gate rejects a sudo proof whose stored bind no longer matches the current
-	 * login session, so a captured cookie cannot be replayed from another
-	 * session and the window does not outlive logout / destroy_all().
+	 * login session, so a captured cookie cannot be replayed from another login
+	 * session, and the window ends on logout (the plugin also hooks wp_logout).
+	 * Note: the bind compares the cookie's token *string*, which does not consult
+	 * the session-token store, so WP_Session_Tokens::destroy_all() takes effect
+	 * on the *next* request — when WordPress re-validates the auth cookie against
+	 * the now-empty store — not within the request that destroys the sessions.
 	 *
 	 * @since 4.1.0
 	 * @var string
@@ -939,9 +943,10 @@ class Sudo_Session {
 
 		// Enforce login-session binding when present. Sessions minted before this
 		// guard existed — or on cookie-less surfaces — store no bind value and
-		// skip the check, so upgrades need no migration. A non-empty bind that no
-		// longer matches the current login session (captured cookie replayed from
-		// another session, or a session destroyed via logout/destroy_all) fails.
+		// skip the check, so upgrades need no migration. A non-empty bind fails
+		// when it no longer matches the current login-session token — a captured
+		// cookie replayed from another session, or (across requests) once the
+		// bound session is gone and WordPress hands us a different token or none.
 		$bound_session = get_user_meta( $user_id, self::SESSION_BIND_META_KEY, true );
 		if ( is_string( $bound_session ) && '' !== $bound_session ) {
 			$current_session = self::current_session_token();

--- a/tests/Unit/RestBackstopTest.php
+++ b/tests/Unit/RestBackstopTest.php
@@ -1,0 +1,300 @@
+<?php
+/**
+ * Tests for the REST effect-level backstop (deferred #102 follow-up, Item 1).
+ *
+ * Mirrors the interactive admin backstop on the REST surface: a destructive,
+ * gated-equivalent effect invoked through a non-enumerated/custom REST route —
+ * one that intercept_rest() does not match — must be blocked at the effect
+ * boundary when no sudo window is active, while honouring the Application
+ * Password policy so legitimate headless clients are not over-blocked.
+ *
+ * @package WP_Sudo
+ */
+
+namespace WP_Sudo\Tests\Unit;
+
+use WP_Sudo\Gate;
+use WP_Sudo\Sudo_Session;
+use WP_Sudo\Request_Stash;
+use WP_Sudo\Tests\TestCase;
+use Brain\Monkey\Functions;
+use Brain\Monkey\Actions;
+use Brain\Monkey\Filters;
+
+/**
+ * @covers \WP_Sudo\Gate::register_rest_backstop
+ * @covers \WP_Sudo\Gate::arm_effect_guards
+ * @covers \WP_Sudo\Gate::rest_auth_mode
+ * @covers \WP_Sudo\Gate::die_rest_sudo_required
+ */
+class RestBackstopTest extends TestCase {
+
+	/**
+	 * Gate instance under test.
+	 *
+	 * @var Gate
+	 */
+	private Gate $gate;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->gate = new Gate(
+			\Mockery::mock( Sudo_Session::class ),
+			\Mockery::mock( Request_Stash::class )
+		);
+
+		Functions\when( 'esc_html' )->returnArg();
+		Functions\when( 'is_wp_error' )->justReturn( false );
+
+		$this->clear_request_state();
+	}
+
+	protected function tearDown(): void {
+		$this->clear_request_state();
+		parent::tearDown();
+	}
+
+	/**
+	 * Clear the request superglobals the backstop reads, to keep order-independent.
+	 */
+	private function clear_request_state(): void {
+		unset(
+			$_SERVER['HTTP_X_WP_NONCE'],
+			$_REQUEST['_wpnonce'],
+			$_COOKIE[ Sudo_Session::TOKEN_COOKIE ]
+		);
+	}
+
+	/**
+	 * Register the backstop and return the captured `delete_user` guard closure.
+	 *
+	 * @return callable
+	 */
+	private function capture_delete_user_guard(): callable {
+		$closure = null;
+		Actions\expectAdded( 'delete_user' )
+			->once()
+			->with(
+				\Mockery::on(
+					static function ( $candidate ) use ( &$closure ): bool {
+						$closure = $candidate;
+						return is_callable( $candidate );
+					}
+				),
+				0
+			);
+
+		$this->gate->register_rest_backstop();
+
+		$this->assertIsCallable( $closure );
+		return $closure;
+	}
+
+	/**
+	 * Invoke the private rest_auth_mode() classifier via reflection.
+	 *
+	 * @return string
+	 */
+	private function invoke_rest_auth_mode(): string {
+		$method = new \ReflectionMethod( Gate::class, 'rest_auth_mode' );
+		@$method->setAccessible( true ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+		return (string) $method->invoke( $this->gate, null );
+	}
+
+	// =====================================================================
+	// Arming
+	// =====================================================================
+
+	/**
+	 * The REST backstop does nothing for anonymous requests.
+	 */
+	public function test_rest_backstop_skips_when_not_logged_in(): void {
+		Functions\when( 'get_current_user_id' )->justReturn( 0 );
+
+		Actions\expectAdded( 'delete_user' )->never();
+
+		$this->gate->register_rest_backstop();
+	}
+
+	/**
+	 * The REST backstop arms exactly the same destructive effect set as the
+	 * admin backstop — and excludes the deferred user.create/user.promote hooks.
+	 */
+	public function test_rest_backstop_arms_same_effect_set(): void {
+		Functions\when( 'get_current_user_id' )->justReturn( 1 );
+
+		Actions\expectAdded( 'activate_plugin' )->once();
+		Actions\expectAdded( 'delete_plugin' )->once();
+		Actions\expectAdded( 'delete_theme' )->once();
+		Actions\expectAdded( 'delete_user' )->once();
+		Actions\expectAdded( 'export_wp' )->once();
+		Filters\expectAdded( 'upgrader_pre_install' )->once();
+
+		// Excluded by design (deferred increment / incidental writes).
+		Filters\expectAdded( 'wp_pre_insert_user_data' )->never();
+		Filters\expectAdded( 'update_user_metadata' )->never();
+
+		$this->gate->register_rest_backstop();
+	}
+
+	// =====================================================================
+	// Guard behaviour
+	// =====================================================================
+
+	/**
+	 * An active sudo window allows the effect silently — no block, no audit.
+	 */
+	public function test_rest_backstop_allows_when_sudo_active(): void {
+		$future = time() + 300;
+		$token  = 'valid-token';
+
+		Functions\when( 'get_current_user_id' )->justReturn( 1 );
+		Functions\when( 'get_user_meta' )->alias(
+			static function ( $uid, $key, $single ) use ( $future, $token ) {
+				if ( Sudo_Session::META_KEY === $key ) {
+					return $future;
+				}
+				if ( Sudo_Session::TOKEN_META_KEY === $key ) {
+					return hash( 'sha256', $token );
+				}
+				return '';
+			}
+		);
+		$_COOKIE[ Sudo_Session::TOKEN_COOKIE ] = $token;
+
+		Actions\expectDone( 'wp_sudo_action_blocked' )->never();
+		Actions\expectDone( 'wp_sudo_action_allowed' )->never();
+		Functions\expect( 'wp_die' )->never();
+
+		$guard = $this->capture_delete_user_guard();
+		$guard();
+	}
+
+	/**
+	 * A cookie-authenticated browser request with no sudo is hard-blocked, with
+	 * a blocked (not gated) audit on the 'rest' surface — no challenge follows.
+	 */
+	public function test_rest_backstop_blocks_cookie_auth_without_sudo(): void {
+		Functions\when( 'get_current_user_id' )->justReturn( 1 );
+		Functions\when( 'get_user_meta' )->justReturn( '' ); // is_active/grace false.
+
+		// Cookie auth: a valid REST nonce and no App Password credential.
+		$_SERVER['HTTP_X_WP_NONCE'] = 'valid';
+		Functions\when( 'wp_verify_nonce' )->justReturn( true );
+		Functions\when( 'rest_get_authenticated_app_password' )->justReturn( null );
+
+		Actions\expectDone( 'wp_sudo_action_blocked' )
+			->once()
+			->with( 1, 'user.delete', 'rest' );
+		Functions\expect( 'wp_die' )
+			->once()
+			->with( \Mockery::type( 'string' ), '', array( 'response' => 403 ) );
+
+		$guard = $this->capture_delete_user_guard();
+		$guard();
+	}
+
+	/**
+	 * An Unrestricted App Password request passes through (audit only).
+	 */
+	public function test_rest_backstop_allows_unrestricted_app_password(): void {
+		Functions\when( 'get_current_user_id' )->justReturn( 1 );
+		Functions\when( 'get_user_meta' )->justReturn( '' );
+
+		// No nonce => headless app-password path. Global policy: unrestricted.
+		Functions\when( 'get_option' )->justReturn( array( 'rest_app_password_policy' => 'unrestricted' ) );
+
+		Actions\expectDone( 'wp_sudo_action_allowed' )
+			->once()
+			->with( 1, 'user.delete', 'rest_app_password' );
+		Actions\expectDone( 'wp_sudo_action_blocked' )->never();
+		Functions\expect( 'wp_die' )->never();
+
+		$guard = $this->capture_delete_user_guard();
+		$guard();
+	}
+
+	/**
+	 * A Limited App Password request is blocked with a logged audit.
+	 */
+	public function test_rest_backstop_blocks_limited_app_password(): void {
+		Functions\when( 'get_current_user_id' )->justReturn( 1 );
+		Functions\when( 'get_user_meta' )->justReturn( '' );
+
+		// Default (empty settings) => limited policy.
+		Functions\when( 'get_option' )->justReturn( array() );
+
+		Actions\expectDone( 'wp_sudo_action_blocked' )
+			->once()
+			->with( 1, 'user.delete', 'rest_app_password' );
+		Functions\expect( 'wp_die' )->once();
+
+		$guard = $this->capture_delete_user_guard();
+		$guard();
+	}
+
+	/**
+	 * A Disabled App Password request is blocked WITHOUT logging.
+	 */
+	public function test_rest_backstop_disabled_app_password_blocks_without_log(): void {
+		Functions\when( 'get_current_user_id' )->justReturn( 1 );
+		Functions\when( 'get_user_meta' )->justReturn( '' );
+
+		Functions\when( 'get_option' )->justReturn( array( 'rest_app_password_policy' => 'disabled' ) );
+
+		Actions\expectDone( 'wp_sudo_action_blocked' )->never();
+		Actions\expectDone( 'wp_sudo_action_allowed' )->never();
+		Functions\expect( 'wp_die' )->once();
+
+		$guard = $this->capture_delete_user_guard();
+		$guard();
+	}
+
+	// =====================================================================
+	// rest_auth_mode() classification (shared with intercept_rest)
+	// =====================================================================
+
+	/**
+	 * A valid nonce with no App Password credential classifies as cookie auth.
+	 */
+	public function test_rest_auth_mode_cookie_when_valid_nonce_and_no_app_password(): void {
+		$_SERVER['HTTP_X_WP_NONCE'] = 'valid';
+		Functions\when( 'wp_verify_nonce' )->justReturn( true );
+		Functions\when( 'rest_get_authenticated_app_password' )->justReturn( null );
+
+		$this->assertSame( 'cookie', $this->invoke_rest_auth_mode() );
+	}
+
+	/**
+	 * A request presenting BOTH a valid nonce AND an App Password is headless —
+	 * the nonce cannot be used to bypass the App Password policy (C2).
+	 */
+	public function test_rest_auth_mode_app_password_when_credential_present_despite_nonce(): void {
+		$_SERVER['HTTP_X_WP_NONCE'] = 'valid';
+		Functions\when( 'wp_verify_nonce' )->justReturn( true );
+		Functions\when( 'rest_get_authenticated_app_password' )->justReturn( 'uuid-123' );
+
+		$this->assertSame( 'app_password', $this->invoke_rest_auth_mode() );
+	}
+
+	/**
+	 * No nonce at all classifies as headless (app-password / bearer).
+	 */
+	public function test_rest_auth_mode_app_password_when_no_nonce(): void {
+		Functions\when( 'wp_verify_nonce' )->justReturn( false );
+
+		$this->assertSame( 'app_password', $this->invoke_rest_auth_mode() );
+	}
+
+	/**
+	 * The _wpnonce request parameter is honoured when the header is absent.
+	 */
+	public function test_rest_auth_mode_reads_wpnonce_request_param(): void {
+		$_REQUEST['_wpnonce'] = 'param-nonce';
+		Functions\when( 'wp_verify_nonce' )->justReturn( true );
+		Functions\when( 'rest_get_authenticated_app_password' )->justReturn( null );
+
+		$this->assertSame( 'cookie', $this->invoke_rest_auth_mode() );
+	}
+}


### PR DESCRIPTION
Picks up the deferred follow-ups from #102. Scoped by a pre-implementation design review (per `CLAUDE.md`), which determined: **Item 1 → implement (with a shared-classifier refactor), Item 2 → defer, Item 3 → doc-accuracy fix.** You confirmed deferring Item 2.

## Item 1 — REST effect-level backstop ✅

A destructive, gated-equivalent effect invoked by a **non-enumerated / custom REST route** (one `intercept_rest()` doesn't match) previously ran unguarded when no sudo window was active. `register_rest_backstop()` (armed at `rest_api_init`) mirrors the shipped admin backstop on REST, arming session-aware guards on the same effects (`activate_plugin`, `delete_plugin`, `delete_theme`, `delete_user`, `export_wp`, `upgrader_pre_install`).

It honours the Application Password policy:

| Auth / policy | Outcome |
|---|---|
| active sudo / grace | allow silently |
| cookie-auth browser | `wp_sudo_action_blocked('rest')` + `wp_die(403)` |
| app-password Unrestricted | `wp_sudo_action_allowed('rest_app_password')` (allow) |
| app-password Limited | `wp_sudo_action_blocked('rest_app_password')` + 403 |
| app-password Disabled | 403, no logging |

**No double-fire for enumerated routes:** `intercept_rest()` returns a `WP_Error` before the callback when no sudo (effect never runs); with sudo active the callback runs and the guard allows silently.

**Anti-drift refactor (required by the design review):** the cookie-vs-app-password classification is extracted into a shared `rest_auth_mode()` used by *both* `intercept_rest()` and the backstop, so the two REST paths can't diverge; the armed effect set is factored into `arm_effect_guards()` shared by the admin and REST backstops. `user.create`/`user.promote` are deliberately excluded from both (Item 2).

## Item 2 — DEFERRED ⏸️

Per the design review and your confirmation: not adding `user.create`/`user.promote` to the admin backstop — those hooks fire on benign, high-frequency admin paths (WooCommerce/membership/programmatic provisioning) and would risk hard-403'ing legitimate non-enumerated user creation / role assignment.

## Item 3 — binding doc accuracy ✅

Tightened two `Sudo_Session` comments that overstated binding: the bind compares the login-session token **string** (`wp_get_session_token()`, no token-store lookup), so `destroy_all()` takes effect on the **next** request, not within the request that destroys sessions. (The binding lifecycle is already comprehensively unit-tested; a real-WP integration assertion needs the integration env and is left to a follow-up.)

## Audit methodology (your request)

Codifies **"reason about the target first"** as a mandatory pre-scan step — `docs/security-audit-methodology.md`, referenced from `CLAUDE.md`. This is the framing that surfaced both #102 findings (which a sink-oriented pass reported clean): name the asset, state its invariants, enumerate property-violation classes independent of sinks, and audit from the asset.

## Verification

- New `tests/Unit/RestBackstopTest.php` (11 tests): arming/same-effect-set, not-logged-in skip, allow-on-active-sudo, cookie-auth block, all three app-password tiers, `rest_auth_mode` classification.
- Full unit suite **845 pass**; PHPStan L6 **clean**; production PHPCS **clean**.
- Pre-commit reviewer: **APPROVED**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NvgBLDNajHatAH9eG59LVh

---
_Generated by [Claude Code](https://claude.ai/code/session_01NvgBLDNajHatAH9eG59LVh)_