### PR TITLE
test(session): login-session binding integration assertions + enforce architectural metrics

### DIFF
--- a/bin/verify-metrics.sh
+++ b/bin/verify-metrics.sh
@@ -68,6 +68,24 @@ ACTUAL_TOTAL_LINES="$(( ACTUAL_PROD_LINES + ACTUAL_TEST_LINES ))"
 ACTUAL_RATIO="$(awk -v tests="$ACTUAL_TEST_LINES" -v prod="$ACTUAL_PROD_LINES" 'BEGIN { printf "%.2f", tests / prod }')"
 ACTUAL_REPO_PHP="$(find "$REPO_ROOT" -type f -name '*.php' ! -path '*/vendor/*' ! -path '*/vendor_test/*' ! -path '*/.tmp/*' ! -path '*/.git/*' -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}')"
 
+# Architectural facts (security-relevant counts). These use the same commands
+# documented in the metric rows, so the gate and the doc stay self-consistent.
+REGISTRY_FILE="$REPO_ROOT/includes/class-action-registry.php"
+ACTUAL_GATED_SINGLE="$(grep "'id'" "$REGISTRY_FILE" | grep -v network | grep -v "rule\[" | wc -l | tr -d ' ')"
+ACTUAL_GATED_MULTI="$(grep "'id'" "$REGISTRY_FILE" | grep -c "network" || true)"
+ACTUAL_GATED_TOTAL="$(grep "'id'" "$REGISTRY_FILE" | grep -v "rule\[" | wc -l | tr -d ' ')"
+# Unique do_action() hook names across includes/class-*.php (multi-line aware),
+# excluding the render-only two-factor fields hook — identical to the doc method.
+ACTUAL_AUDIT_HOOKS="$(cd "$REPO_ROOT" && python3 - <<'PY'
+import pathlib, re
+hooks = set()
+for path in pathlib.Path('includes').glob('class-*.php'):
+    hooks.update(re.findall(r"do_action\(\s*'([^']+)'", path.read_text()))
+hooks.discard('wp_sudo_render_two_factor_fields')
+print(len(hooks))
+PY
+)"
+
 DOC_UNIT_TESTS="$(metric_number 'Unit tests')"
 DOC_UNIT_ASSERTIONS="$(metric_number 'Unit assertions')"
 DOC_INTEGRATION_METHODS="$(metric_number 'Integration tests in suite')"
@@ -78,6 +96,10 @@ DOC_TEST_LINES="$(metric_number 'Tests PHP lines (`tests/`)')"
 DOC_TOTAL_LINES="$(metric_number 'Production + tests PHP lines')"
 DOC_RATIO="$(metric_number 'Test-to-production ratio')"
 DOC_REPO_PHP="$(metric_number 'Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`)')"
+DOC_GATED_SINGLE="$(metric_number 'Gated rules (single-site)')"
+DOC_GATED_MULTI="$(metric_number 'Gated rules (multisite)')"
+DOC_GATED_TOTAL="$(metric_number 'Gated rules (total)')"
+DOC_AUDIT_HOOKS="$(metric_number 'Audit hooks')"
 
 FAILURES=""
 
@@ -91,6 +113,10 @@ FAILURES=""
 [ "$DOC_TOTAL_LINES" = "$ACTUAL_TOTAL_LINES" ] || add_failure "Production + tests PHP lines" "$DOC_TOTAL_LINES" "$ACTUAL_TOTAL_LINES"
 [ "$DOC_RATIO" = "$ACTUAL_RATIO" ] || add_failure "Test-to-production ratio" "$DOC_RATIO" "$ACTUAL_RATIO"
 [ "$DOC_REPO_PHP" = "$ACTUAL_REPO_PHP" ] || add_failure "Total repo PHP lines" "$DOC_REPO_PHP" "$ACTUAL_REPO_PHP"
+[ "$DOC_GATED_SINGLE" = "$ACTUAL_GATED_SINGLE" ] || add_failure "Gated rules (single-site)" "$DOC_GATED_SINGLE" "$ACTUAL_GATED_SINGLE"
+[ "$DOC_GATED_MULTI" = "$ACTUAL_GATED_MULTI" ] || add_failure "Gated rules (multisite)" "$DOC_GATED_MULTI" "$ACTUAL_GATED_MULTI"
+[ "$DOC_GATED_TOTAL" = "$ACTUAL_GATED_TOTAL" ] || add_failure "Gated rules (total)" "$DOC_GATED_TOTAL" "$ACTUAL_GATED_TOTAL"
+[ "$DOC_AUDIT_HOOKS" = "$ACTUAL_AUDIT_HOOKS" ] || add_failure "Audit hooks" "$DOC_AUDIT_HOOKS" "$ACTUAL_AUDIT_HOOKS"
 
 if [ -n "$FAILURES" ]; then
 	echo "Metrics drift detected in docs/current-metrics.md:"

--- a/docs/current-metrics.md
+++ b/docs/current-metrics.md
@@ -11,7 +11,7 @@ Verification environment: local workspace, PHP 8.x
 |---|---:|---|
 | Unit tests | 845 tests | `composer test:unit` |
 | Unit assertions | 2435 assertions | `composer test:unit` |
-| Integration tests in suite | 194 test methods | `rg -c "function test" tests/Integration/*.php | awk -F: '{sum+=$2} END{print sum}'` |
+| Integration tests in suite | 196 test methods | `rg -c "function test" tests/Integration/*.php | awk -F: '{sum+=$2} END{print sum}'` |
 | Unit test files | 27 | `ls tests/Unit/*.php | wc -l` |
 | Integration test files | 26 | `ls tests/Integration/*.php | wc -l` |
 
@@ -20,10 +20,10 @@ Verification environment: local workspace, PHP 8.x
 | Metric | Value | Verification |
 |---|---:|---|
 | Production PHP lines (`includes/`, `wp-sudo.php`, `uninstall.php`, `mu-plugin/`, `bridges/`) | 15,481 | `find ./includes ./wp-sudo.php ./uninstall.php ./mu-plugin ./bridges -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
-| Tests PHP lines (`tests/`) | 30,657 | `find ./tests -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
-| Production + tests PHP lines | 46,138 | sum of the two rows above |
-| Test-to-production ratio | 1.98:1 | `30657 / 15481` |
-| Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`) | 46,401 | `find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/vendor_test/*" ! -path "*/.tmp/*" ! -path "*/.git/*" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Tests PHP lines (`tests/`) | 30,729 | `find ./tests -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Production + tests PHP lines | 46,210 | sum of the two rows above |
+| Test-to-production ratio | 1.98:1 | `30729 / 15481` |
+| Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`) | 46,473 | `find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/vendor_test/*" ! -path "*/.tmp/*" ! -path "*/.git/*" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
 
 ## Architectural Facts
 
@@ -38,7 +38,7 @@ the count in prose without a verification command.
 | Gated rules (multisite) | 8 | `grep "'id'" includes/class-action-registry.php \| grep -c "network"` | v3.2.0 |
 | Gated rules (total) | 35 | `grep "'id'" includes/class-action-registry.php \| grep -v "rule\[" \| wc -l` | v3.2.0 |
 | Help tabs | 6 | `grep -c -- "->add_help_tab(" includes/class-admin.php` | v3.2.0 |
-| Audit hooks | 17 | `python3 - <<'PY'\nimport pathlib, re\nhooks = set()\nfor path in pathlib.Path('includes').glob('class-*.php'):\n    hooks.update(re.findall(r\"do_action\\(\\s*'([^']+)'\", path.read_text()))\nhooks.discard('wp_sudo_render_two_factor_fields')\nprint(len(hooks))\nPY` | v3.4.0 |
+| Audit hooks | 18 | `python3 - <<'PY'\nimport pathlib, re\nhooks = set()\nfor path in pathlib.Path('includes').glob('class-*.php'):\n    hooks.update(re.findall(r\"do_action\\(\\s*'([^']+)'\", path.read_text()))\nhooks.discard('wp_sudo_render_two_factor_fields')\nprint(len(hooks))\nPY` | v4.0.0 |
 | Settings fields (base) | 6 | 1 numeric (duration) + 1 preset chooser + 4 policy dropdowns (REST, CLI, Cron, XML-RPC) | v3.0.0 |
 | Settings fields (with WPGraphQL) | 7 | +1 conditional WPGraphQL policy dropdown | v3.0.0 |
 | E2E tests | 63 | `npx playwright test --config tests/e2e/playwright.config.ts --list` | v4.0.0 |

--- a/tests/Integration/SudoSessionTest.php
+++ b/tests/Integration/SudoSessionTest.php
@@ -212,4 +212,76 @@ class SudoSessionTest extends TestCase {
 		$this->assertTrue( Sudo_Session::is_active( $user->ID ) );
 		$this->assertSame( $before + 1, did_action( 'wp_sudo_activated' ), 'wp_sudo_activated should fire once.' );
 	}
+
+	/**
+	 * INTG-F2: a sudo proof bound to one login session is rejected once the
+	 * current login-session token differs (re-login / a different session).
+	 *
+	 * This is the real binding guarantee under live WordPress: activate() binds
+	 * the proof to the token returned by wp_get_session_token() (read from the
+	 * logged-in cookie). When that token changes, the unchanged sudo proof cookie
+	 * must no longer verify — a captured cookie cannot be replayed from another
+	 * login session.
+	 */
+	public function test_binding_rejects_when_login_session_token_changes(): void {
+		$user = $this->make_admin();
+		wp_set_current_user( $user->ID );
+
+		$expiration = time() + DAY_IN_SECONDS;
+		$manager    = \WP_Session_Tokens::get_instance( $user->ID );
+
+		// Establish login session A and the logged-in cookie wp_get_session_token() reads.
+		$token_a                     = $manager->create( $expiration );
+		$_COOKIE[ LOGGED_IN_COOKIE ] = wp_generate_auth_cookie( $user->ID, $expiration, 'logged_in', $token_a );
+		$this->assertSame( $token_a, wp_get_session_token(), 'Precondition: cookie resolves login token A.' );
+
+		// Activate sudo — binds the proof to token A.
+		Sudo_Session::activate( $user->ID );
+		Sudo_Session::reset_cache();
+		$this->assertTrue( Sudo_Session::is_active( $user->ID ), 'Active within the binding session.' );
+		$this->assertSame(
+			hash( 'sha256', $token_a ),
+			get_user_meta( $user->ID, Sudo_Session::SESSION_BIND_META_KEY, true ),
+			'The stored bind is the SHA-256 of the login-session token.'
+		);
+
+		// Switch to a different login session (token B). The sudo proof cookie is
+		// unchanged; only the login-session token differs.
+		$token_b                     = $manager->create( $expiration );
+		$_COOKIE[ LOGGED_IN_COOKIE ] = wp_generate_auth_cookie( $user->ID, $expiration, 'logged_in', $token_b );
+		Sudo_Session::reset_cache();
+
+		$this->assertFalse(
+			Sudo_Session::is_active( $user->ID ),
+			'A proof bound to session A must not verify under session B.'
+		);
+	}
+
+	/**
+	 * INTG-F2: logging out ends the sudo window. The plugin hooks wp_logout to
+	 * deactivate, so a bound proof does not outlive the login that created it.
+	 */
+	public function test_logout_deactivates_bound_session(): void {
+		$user = $this->make_admin();
+		wp_set_current_user( $user->ID );
+
+		$expiration                  = time() + DAY_IN_SECONDS;
+		$manager                     = \WP_Session_Tokens::get_instance( $user->ID );
+		$token                       = $manager->create( $expiration );
+		$_COOKIE[ LOGGED_IN_COOKIE ] = wp_generate_auth_cookie( $user->ID, $expiration, 'logged_in', $token );
+
+		Sudo_Session::activate( $user->ID );
+		Sudo_Session::reset_cache();
+		$this->assertTrue( Sudo_Session::is_active( $user->ID ), 'Active before logout.' );
+
+		// The plugin's wp_logout handler must clear the sudo session.
+		do_action( 'wp_logout', $user->ID );
+		Sudo_Session::reset_cache();
+
+		$this->assertFalse( Sudo_Session::is_active( $user->ID ), 'Logout must end the sudo window.' );
+		$this->assertEmpty(
+			get_user_meta( $user->ID, Sudo_Session::TOKEN_META_KEY, true ),
+			'Logout clears the sudo token meta.'
+		);
+	}
 }


### PR DESCRIPTION
Completes the deferred **binding-lifecycle integration assertion** (follow-up to #102/#104) and closes a **silent metrics-drift gap** found while doing it.

## Integration tests (the real F2 guarantee)

The unit suite can only *stub* `wp_get_session_token()`; these run under live WordPress with a genuine login-session token (`WP_Session_Tokens` + `wp_generate_auth_cookie`):

- **`test_binding_rejects_when_login_session_token_changes`** — activate sudo bound to login token A, then swap the logged-in cookie to token B (sudo proof cookie unchanged) → `is_active()` becomes **false**. Proves a captured sudo cookie can't be replayed under a different login session. Also pins the stored bind to `sha256(token A)`.
- **`test_logout_deactivates_bound_session`** — `wp_logout` ends the window and clears the token meta (`Plugin::deactivate_session_on_logout`).

(The literal "`destroy_all()` immediately deactivates" assertion is intentionally **not** added — binding compares the cookie's token *string*, so `destroy_all()` only takes effect on the next request; this was corrected in the #104 doc fix.)

## Metrics gate hardening (your call: "extend gate: rules + hooks")

While syncing counts I found the **audit-hooks count had silently drifted** — doc said 17, actual is 18 (`wp_sudo_inert_governance_mode_detected`, added at v4.0.0). Root cause: `verify:metrics` enforced size/test counts but **not** the architectural facts.

- **`bin/verify-metrics.sh`** now also enforces **Gated rules** (single/multi/total) and **Audit hooks** (the security-relevant, deterministically-countable facts), using the same commands the doc rows prescribe. Negative-tested: the new checks fail on drift and pass when in sync.
- **`docs/current-metrics.md`** — corrected the stale audit-hooks row (17→18, v3.4.0→v4.0.0; attribution verified by counting hooks at the v3.4.0 and v4.0.0 tags) and synced the test/line-count rows.

## Verification

- Unit suite **845 green**; PHPStan L6 **clean**; `verify:metrics` **in sync** (now incl. rules + hooks).
- Integration test validated by CI's integration lanes (can't run locally — no MySQL/WP-test-suite in the dev sandbox).
- Pre-commit reviewer: **APPROVED** (confirmed the binding assertions are non-vacuous — they fail specifically at the login-session bind comparison).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NvgBLDNajHatAH9eG59LVh

---
_Generated by [Claude Code](https://claude.ai/code/session_01NvgBLDNajHatAH9eG59LVh)_