### PR TITLE
refactor(gate): bool REST auth classifier + unified sudo-die helper

### DIFF
--- a/docs/current-metrics.md
+++ b/docs/current-metrics.md
@@ -19,11 +19,11 @@ Verification environment: local workspace, PHP 8.x
 
 | Metric | Value | Verification |
 |---|---:|---|
-| Production PHP lines (`includes/`, `wp-sudo.php`, `uninstall.php`, `mu-plugin/`, `bridges/`) | 15,481 | `find ./includes ./wp-sudo.php ./uninstall.php ./mu-plugin ./bridges -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Production PHP lines (`includes/`, `wp-sudo.php`, `uninstall.php`, `mu-plugin/`, `bridges/`) | 15,469 | `find ./includes ./wp-sudo.php ./uninstall.php ./mu-plugin ./bridges -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
 | Tests PHP lines (`tests/`) | 30,729 | `find ./tests -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
-| Production + tests PHP lines | 46,210 | sum of the two rows above |
-| Test-to-production ratio | 1.98:1 | `30729 / 15481` |
-| Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`) | 46,473 | `find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/vendor_test/*" ! -path "*/.tmp/*" ! -path "*/.git/*" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Production + tests PHP lines | 46,198 | sum of the two rows above |
+| Test-to-production ratio | 1.99:1 | `30729 / 15469` |
+| Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`) | 46,461 | `find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/vendor_test/*" ! -path "*/.tmp/*" ! -path "*/.git/*" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
 
 ## Architectural Facts
 

--- a/includes/class-gate.php
+++ b/includes/class-gate.php
@@ -236,17 +236,7 @@ class Gate {
 			/** This action is documented in includes/class-gate.php */
 			do_action( 'wp_sudo_action_blocked', $user_id, $rule_id, 'admin' );
 
-			wp_die(
-				esc_html(
-					sprintf(
-						/* translators: %s: action label */
-						__( 'This operation (%s) requires sudo. Activate a sudo session and try again.', 'wp-sudo' ),
-						$label
-					)
-				),
-				'',
-				array( 'response' => 403 )
-			);
+			$this->die_sudo_required( $label );
 		};
 
 		$this->arm_effect_guards( $guard );
@@ -264,7 +254,7 @@ class Gate {
 	 * callback runs and this guard allows the effect silently.
 	 *
 	 * Unlike the admin guard, the REST guard honours the Application Password
-	 * policy via the shared rest_auth_mode() classification: an Unrestricted
+	 * policy via the shared is_rest_cookie_auth() classification: an Unrestricted
 	 * headless client is allowed (audit only), while a cookie-authenticated
 	 * browser request or a Limited/Disabled app-password request is blocked.
 	 * Because an action hook cannot return a WP_Error, the block is delivered via
@@ -289,14 +279,14 @@ class Gate {
 				return;
 			}
 
-			if ( 'cookie' === $this->rest_auth_mode() ) {
+			if ( $this->is_rest_cookie_auth() ) {
 				// Cookie-authenticated browser request — hard block. An effect
 				// hook cannot stash and replay the request the way intercept_rest()
 				// does for enumerated routes, so surface a blocked (not gated)
 				// audit on 'rest': no challenge will follow.
 				/** This action is documented in includes/class-gate.php */
 				do_action( 'wp_sudo_action_blocked', $user_id, $rule_id, 'rest' );
-				$this->die_rest_sudo_required( $label );
+				$this->die_sudo_required( $label );
 			} else {
 				// Headless (app-password / bearer) — honour the App Password policy.
 				$policy = $this->get_app_password_policy();
@@ -314,7 +304,7 @@ class Gate {
 					do_action( 'wp_sudo_action_blocked', $user_id, $rule_id, 'rest_app_password' );
 				}
 
-				$this->die_rest_sudo_required( $label );
+				$this->die_sudo_required( $label );
 			}
 		};
 
@@ -402,23 +392,24 @@ class Gate {
 	}
 
 	/**
-	 * Terminate a REST request that requires sudo with a 403.
+	 * Terminate a request that requires sudo with a 403.
 	 *
-	 * Used by the REST backstop, which fires inside an effect action hook and so
-	 * cannot return a WP_Error. During a REST request WordPress routes wp_die()
-	 * through the REST die handler, producing a JSON 403 response.
+	 * Shared by the interactive (admin) and REST effect-level backstops, which
+	 * fire inside effect hooks and so cannot return a WP_Error. wp_die() renders
+	 * an HTML page on the admin surface and a JSON error during a REST request —
+	 * WordPress selects the handler from the request context.
 	 *
 	 * @since 4.1.0
 	 *
 	 * @param string $label Human-readable action label.
 	 * @return void
 	 */
-	private function die_rest_sudo_required( string $label ): void {
+	private function die_sudo_required( string $label ): void {
 		wp_die(
 			esc_html(
 				sprintf(
 					/* translators: %s: action label */
-					__( 'This operation (%s) requires sudo and cannot be performed without an active sudo session.', 'wp-sudo' ),
+					__( 'This operation (%s) requires sudo. Activate a sudo session and try again.', 'wp-sudo' ),
 					$label
 				)
 			),
@@ -428,16 +419,15 @@ class Gate {
 	}
 
 	/**
-	 * Classify the current REST request's authentication for gating.
+	 * Whether the current REST request is cookie-authenticated (a browser request).
 	 *
-	 * Returns 'cookie' when the request carries a valid wp_rest nonce AND is not
-	 * authenticated via an Application Password (a browser/cookie request);
-	 * returns 'app_password' otherwise (App Password, bearer, or any headless
-	 * credential). A request presenting BOTH a valid nonce AND an App Password is
-	 * classified as headless, so a headless client cannot bypass the App Password
-	 * policy by also sending a nonce (C2). WordPress core accepts the REST nonce
-	 * via the X-WP-Nonce header or the _wpnonce parameter (see
-	 * rest_cookie_check_errors() in wp-includes/rest-api.php).
+	 * Returns true when the request carries a valid wp_rest nonce AND is not
+	 * authenticated via an Application Password; false otherwise (App Password,
+	 * bearer, or any headless credential). A request presenting BOTH a valid nonce
+	 * AND an App Password is treated as headless, so a headless client cannot
+	 * bypass the App Password policy by also sending a nonce (C2). WordPress core
+	 * accepts the REST nonce via the X-WP-Nonce header or the _wpnonce parameter
+	 * (see rest_cookie_check_errors() in wp-includes/rest-api.php).
 	 *
 	 * Shared by intercept_rest() (enumerated routes) and register_rest_backstop()
 	 * (non-enumerated routes) so the two paths cannot drift. The optional request
@@ -449,9 +439,9 @@ class Gate {
 	 * @since 4.1.0
 	 *
 	 * @param \WP_REST_Request|null $request The REST request, when available.
-	 * @return string 'cookie' or 'app_password'.
+	 * @return bool True for cookie/browser auth, false for any headless credential.
 	 */
-	private function rest_auth_mode( ?\WP_REST_Request $request = null ): string {
+	private function is_rest_cookie_auth( ?\WP_REST_Request $request = null ): bool {
 		$nonce = '';
 		if ( $request instanceof \WP_REST_Request ) {
 			$nonce = (string) $request->get_header( 'X-WP-Nonce' );
@@ -463,11 +453,9 @@ class Gate {
 			$nonce = self::sanitize_input_string( $_REQUEST['_wpnonce'] ?? '' ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Read-only classification; sanitized in helper.
 		}
 
-		$is_cookie_auth = '' !== $nonce
+		return '' !== $nonce
 			&& wp_verify_nonce( $nonce, 'wp_rest' )
 			&& ! rest_get_authenticated_app_password();
-
-		return $is_cookie_auth ? 'cookie' : 'app_password';
 	}
 
 	/**
@@ -1461,7 +1449,7 @@ class Gate {
 
 		// Distinguish cookie-auth (browser) from app-password/bearer (headless)
 		// via the shared classifier (also used by the REST effect backstop).
-		$is_cookie_auth = 'cookie' === $this->rest_auth_mode( $request );
+		$is_cookie_auth = $this->is_rest_cookie_auth( $request );
 
 		if ( ! $is_cookie_auth ) {
 			// Non-browser auth (app-password, bearer, etc.) — check policy.

--- a/tests/Unit/RestBackstopTest.php
+++ b/tests/Unit/RestBackstopTest.php
@@ -24,8 +24,8 @@ use Brain\Monkey\Filters;
 /**
  * @covers \WP_Sudo\Gate::register_rest_backstop
  * @covers \WP_Sudo\Gate::arm_effect_guards
- * @covers \WP_Sudo\Gate::rest_auth_mode
- * @covers \WP_Sudo\Gate::die_rest_sudo_required
+ * @covers \WP_Sudo\Gate::is_rest_cookie_auth
+ * @covers \WP_Sudo\Gate::die_sudo_required
  */
 class RestBackstopTest extends TestCase {
 
@@ -92,14 +92,14 @@ class RestBackstopTest extends TestCase {
 	}
 
 	/**
-	 * Invoke the private rest_auth_mode() classifier via reflection.
+	 * Invoke the private is_rest_cookie_auth() classifier via reflection.
 	 *
-	 * @return string
+	 * @return bool
 	 */
-	private function invoke_rest_auth_mode(): string {
-		$method = new \ReflectionMethod( Gate::class, 'rest_auth_mode' );
+	private function invoke_is_rest_cookie_auth(): bool {
+		$method = new \ReflectionMethod( Gate::class, 'is_rest_cookie_auth' );
 		@$method->setAccessible( true ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
-		return (string) $method->invoke( $this->gate, null );
+		return (bool) $method->invoke( $this->gate, null );
 	}
 
 	// =====================================================================
@@ -252,49 +252,49 @@ class RestBackstopTest extends TestCase {
 	}
 
 	// =====================================================================
-	// rest_auth_mode() classification (shared with intercept_rest)
+	// is_rest_cookie_auth() classification (shared with intercept_rest)
 	// =====================================================================
 
 	/**
 	 * A valid nonce with no App Password credential classifies as cookie auth.
 	 */
-	public function test_rest_auth_mode_cookie_when_valid_nonce_and_no_app_password(): void {
+	public function test_is_rest_cookie_auth_true_when_valid_nonce_and_no_app_password(): void {
 		$_SERVER['HTTP_X_WP_NONCE'] = 'valid';
 		Functions\when( 'wp_verify_nonce' )->justReturn( true );
 		Functions\when( 'rest_get_authenticated_app_password' )->justReturn( null );
 
-		$this->assertSame( 'cookie', $this->invoke_rest_auth_mode() );
+		$this->assertTrue( $this->invoke_is_rest_cookie_auth() );
 	}
 
 	/**
 	 * A request presenting BOTH a valid nonce AND an App Password is headless —
 	 * the nonce cannot be used to bypass the App Password policy (C2).
 	 */
-	public function test_rest_auth_mode_app_password_when_credential_present_despite_nonce(): void {
+	public function test_is_rest_cookie_auth_false_when_credential_present_despite_nonce(): void {
 		$_SERVER['HTTP_X_WP_NONCE'] = 'valid';
 		Functions\when( 'wp_verify_nonce' )->justReturn( true );
 		Functions\when( 'rest_get_authenticated_app_password' )->justReturn( 'uuid-123' );
 
-		$this->assertSame( 'app_password', $this->invoke_rest_auth_mode() );
+		$this->assertFalse( $this->invoke_is_rest_cookie_auth() );
 	}
 
 	/**
 	 * No nonce at all classifies as headless (app-password / bearer).
 	 */
-	public function test_rest_auth_mode_app_password_when_no_nonce(): void {
+	public function test_is_rest_cookie_auth_false_when_no_nonce(): void {
 		Functions\when( 'wp_verify_nonce' )->justReturn( false );
 
-		$this->assertSame( 'app_password', $this->invoke_rest_auth_mode() );
+		$this->assertFalse( $this->invoke_is_rest_cookie_auth() );
 	}
 
 	/**
 	 * The _wpnonce request parameter is honoured when the header is absent.
 	 */
-	public function test_rest_auth_mode_reads_wpnonce_request_param(): void {
+	public function test_is_rest_cookie_auth_reads_wpnonce_request_param(): void {
 		$_REQUEST['_wpnonce'] = 'param-nonce';
 		Functions\when( 'wp_verify_nonce' )->justReturn( true );
 		Functions\when( 'rest_get_authenticated_app_password' )->justReturn( null );
 
-		$this->assertSame( 'cookie', $this->invoke_rest_auth_mode() );
+		$this->assertTrue( $this->invoke_is_rest_cookie_auth() );
 	}
 }


### PR DESCRIPTION
Cleanups from the philosophy review — **behavior-preserving**. Two of the three review nits (the third, the `WP_SUDO_VERSION`/`@since` gap, is filed as #106).

> **Stacked on #105** (`claude/binding-integration-assertions`) to avoid a `current-metrics.md` / metrics-gate conflict. Once #105 merges, retarget this PR's base to `main` (the diff will reduce to just these commits).

## Changes

1. **`rest_auth_mode(): string` → `is_rest_cookie_auth(): bool`** — the distinction is binary (cookie/browser vs headless), so a bool models it directly and removes the stringly-typed `'cookie'`/`'app_password'` mapping. Classification logic is unchanged; `intercept_rest()` and `register_rest_backstop()` updated.
2. **Unified 403 path** — the admin backstop's inline `wp_die` and the REST-only `die_rest_sudo_required()` are replaced by a single **`die_sudo_required()`** used by both. `wp_die()` renders HTML on the admin surface and JSON during REST, so one helper/message serves both.

## Behavior preserved

Admin and REST backstops still hard-block with **403** and the same audit hooks; the only change is the REST 403 **message text** now matches the admin wording. The unrelated diagnostic request-tester symbols (`normalize_diagnostic_rest_auth_mode`, the `rest_auth_mode` form field) are untouched.

## Verification

- Unit **845 green**; PHPStan L6 **clean**; PHPCS clean; `verify:metrics` **in sync** (production lines 15,481→15,469).
- No stale references to the old symbols.
- Pre-commit reviewer: **APPROVED** (confirmed the bool refactor is byte-identical classification and the unified message doesn't break admin-backstop tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NvgBLDNajHatAH9eG59LVh

---
_Generated by [Claude Code](https://claude.ai/code/session_01NvgBLDNajHatAH9eG59LVh)_