### PR TITLE
chore(release): reconcile version to 4.1.0 across sync points (closes #106)

### DIFF
--- a/docs/release-status.md
+++ b/docs/release-status.md
@@ -1,6 +1,6 @@
 # Release Status (Canonical Current State)
 
-Last verified: 2026-06-21
+Last verified: 2026-06-23
 
 This file is the canonical source for **current release state** in this repository:
 
@@ -18,9 +18,10 @@ This file is the canonical source for **current release state** in this reposito
 
 ## Current `main` release target
 
-- **Latest release:** `4.0.0` — milestone **v4.0.0 (Pre-Public Hardening Baseline)**, **tagged `v4.0.0` 2026-06-21**. Breaking release (see Unreleased/shipped work below). All phases (11, 12, 13, 13.1, 14, 15) merged to `main`; PR [#99](https://github.com/dknauss/Sudo/pull/99) (Phase 14, WordPress.org readiness) merged as `7b7b85a`.
-- **Runtime version constant:** `4.0.0` on `main` and at the `v4.0.0` tag. `WP_SUDO_VERSION` is set in `wp-sudo.php` (header + constant), `tests/bootstrap.php`, and `phpstan-bootstrap.php`; `readme.txt` Stable tag is `4.0.0`. All five in sync.
-- **Current package metadata (on `main`):** `readme.txt` Stable tag `4.0.0` == header Version (no `stable_tag_mismatch`); `Requires at least 6.4`, `Requires PHP 8.2`, `Tested up to 7.0`. WordPress.org listing name: **"Sudo – Admin Action Gating"** (UI brand "Sudo"; slug/text-domain stay `wp-sudo` — lock the slug at submission).
+- **Current `main` development version:** `4.1.0` (**unreleased — not yet tagged**). `WP_SUDO_VERSION` was bumped from `4.0.0` to `4.1.0` on `main` to open the 4.1.0 line, matching the `@since 4.1.0` annotations and the `## 4.1.0 - unreleased` CHANGELOG section for the post-4.0.0 gate-completeness work (PRs #102, #104, #105, #107). The latest **tagged** release remains `v4.0.0` (2026-06-21); `v4.1.0` will be tagged when the 4.1.0 line is cut.
+- **Latest tagged release:** `4.0.0` — milestone **v4.0.0 (Pre-Public Hardening Baseline)**, **tagged `v4.0.0` 2026-06-21**. Breaking release. All phases (11, 12, 13, 13.1, 14, 15) merged to `main`; PR [#99](https://github.com/dknauss/Sudo/pull/99) (Phase 14, WordPress.org readiness) merged as `7b7b85a`.
+- **Runtime version constant:** `4.1.0` on `main`. `WP_SUDO_VERSION` is set in `wp-sudo.php` (header + constant), `tests/bootstrap.php`, and `phpstan-bootstrap.php`; `readme.txt` Stable tag is `4.1.0`. All five in sync. (Stable tag is package/zip metadata for the unreleased 4.1.0 line; see WordPress.org publication status below — the plugin is not published.)
+- **Current package metadata (on `main`):** `readme.txt` Stable tag `4.1.0` == header Version (no `stable_tag_mismatch`); `Requires at least 6.4`, `Requires PHP 8.2`, `Tested up to 7.0`. WordPress.org listing name: **"Sudo – Admin Action Gating"** (UI brand "Sudo"; slug/text-domain stay `wp-sudo` — lock the slug at submission).
 - **Last archived release checklist:** `docs/archive/release-3.0.0-checklist.md`
 
 ## WordPress.org publication status
@@ -97,10 +98,15 @@ cut after Phases 14–15 land.
   dashboard activity, recovery-mode screens); README copy clarified re: the sudo
   window. Historical planning docs moved under `docs/archive/`.
 
+> **Note:** the v4.0.0 narrative above is historical — `v4.0.0` was tagged
+> 2026-06-21. `main` has since advanced to the unreleased `4.1.0` line (see
+> "Current `main` release target").
+
 **Pre-tag checklist reminder:** `WP_SUDO_VERSION` (three code constants + plugin
-header) and `readme.txt` stable tag are already at `4.0.0` on PR #86. Before
-tagging `4.0.0`, confirm those are still in sync, re-verify external claims, and
-update this file's "Latest tagged release" once the tag is cut.
+header) and `readme.txt` stable tag are at `4.1.0` on `main` (the unreleased
+4.1.0 line). Before tagging `v4.1.0`, confirm those five are still in sync,
+re-verify external claims, and update this file's "Latest tagged release" once
+the tag is cut.
 
 ## WordPress release posture
 

--- a/phpstan-bootstrap.php
+++ b/phpstan-bootstrap.php
@@ -10,7 +10,7 @@
  */
 
 // Plugin constants (defined in wp-sudo.php at runtime).
-define( 'WP_SUDO_VERSION', '4.0.0' );
+define( 'WP_SUDO_VERSION', '4.1.0' );
 define( 'WP_SUDO_PLUGIN_DIR', __DIR__ . '/' );
 define( 'WP_SUDO_PLUGIN_URL', 'https://example.com/wp-content/plugins/wp-sudo/' );
 define( 'WP_SUDO_PLUGIN_BASENAME', 'wp-sudo/wp-sudo.php' );

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags:              reauthentication, access control, admin protection, multisite
 Requires at least: 6.4
 Tested up to:      7.0
 Requires PHP:      8.2
-Stable tag:        4.0.0
+Stable tag:        4.1.0
 License:           GPL-2.0-or-later
 License URI:       https://spdx.org/licenses/GPL-2.0-or-later.html
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -19,7 +19,7 @@ define( 'WPMU_PLUGIN_DIR', WP_CONTENT_DIR . '/mu-plugins' );
 define( 'WPMU_PLUGIN_URL', 'https://example.com/wp-content/mu-plugins' );
 
 // ── Plugin constants (normally defined in wp-sudo.php) ───────────────
-define( 'WP_SUDO_VERSION', '4.0.0' );
+define( 'WP_SUDO_VERSION', '4.1.0' );
 define( 'WP_SUDO_PLUGIN_DIR', dirname( __DIR__ ) . '/' );
 define( 'WP_SUDO_PLUGIN_URL', 'https://example.com/wp-content/plugins/wp-sudo/' );
 define( 'WP_SUDO_PLUGIN_BASENAME', 'wp-sudo/wp-sudo.php' );

--- a/wp-sudo.php
+++ b/wp-sudo.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Sudo – Admin Action Gating
  * Plugin URI:        https://github.com/dknauss/Sudo
  * Description:       Action-gated reauthentication for WordPress. Dangerous operations require password confirmation before they proceed — regardless of user role.
- * Version:           4.0.0
+ * Version:           4.1.0
  * Requires at least: 6.4
  * Requires PHP:      8.2
  * Author:            Dan Knauss
@@ -27,7 +27,7 @@ require_once __DIR__ . '/includes/functions-governance.php';
 add_filter( 'map_meta_cap', 'wp_sudo_map_governance_meta_cap', 10, 4 );
 
 // Plugin version.
-define( 'WP_SUDO_VERSION', '4.0.0' );
+define( 'WP_SUDO_VERSION', '4.1.0' );
 
 // Plugin directory path.
 define( 'WP_SUDO_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );


### PR DESCRIPTION
Closes #106.

Reconciles `WP_SUDO_VERSION` with the `@since 4.1.0` tags already present in shipped code. `v4.0.0` is the latest tag (2026-06-21); since then PRs #102/#104/#105/#107 landed on `main` carrying `@since 4.1.0`, and both `CHANGELOG.md` (`## 4.1.0 - unreleased`) and `readme.txt` (a `= 4.1.0 =` changelog entry) already describe the 4.1.0 line. **Only the numeric version pointers lagged at 4.0.0.**

## Changes — all five version-sync points → 4.1.0 (per `CLAUDE.md` checklist)

1. `wp-sudo.php` plugin header `Version:`
2. `wp-sudo.php` `define( 'WP_SUDO_VERSION', '4.1.0' )`
3. `phpstan-bootstrap.php` `WP_SUDO_VERSION`
4. `tests/bootstrap.php` `WP_SUDO_VERSION`
5. `readme.txt` `Stable tag: 4.1.0` (== header Version → no `stable_tag_mismatch`)

Plus `docs/release-status.md`: records `main` as the **unreleased 4.1.0** dev line (latest **tagged** release stays `4.0.0`), refreshes the Last-verified date, and updates the now-stale pre-tag reminder.

## Notes

- **No upgrade routine added.** The 4.1.0 work is additive (gate-completeness + binding) and needs no data migration, so the `UPGRADES` map still ends at `4.0.0`/`upgrade_4_0_0`. `UpgraderTest`'s `'4.0.0'`-is-last assertion is unrelated to the runtime constant and still passes.
- Stable tag is package/zip metadata for the unreleased 4.1.0 line; the plugin is not yet published to WordPress.org.

## Verification

Unit **845 green**, PHPStan L6 **clean**, `verify:metrics` **in sync**. Pre-commit reviewer **APPROVED** (confirmed the five points are consistent and the UPGRADES map / `@since 4.0.0` literals are correctly left alone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NvgBLDNajHatAH9eG59LVh

---
_Generated by [Claude Code](https://claude.ai/code/session_01NvgBLDNajHatAH9eG59LVh)_