### PR TITLE
feat(security): role-aware admin-escalation guard with App-Password policy deference

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1070,6 +1070,22 @@ SBOM, accessibility roadmap) are documented in the [CHANGELOG](../CHANGELOG.md).
 **~~Public `wp_sudo_check()` / `wp_sudo_require()` API~~** — implemented on `main` for v2.12.0 for third-party action gating integrations.
 **~~Multi-Dimensional Rate Limiting (IP + User)~~** — shipped v2.13.0. Per-IP tracking via transients alongside per-user tracking, combined lockout policy, and the triggering IP address added as the third `wp_sudo_lockout` hook argument.
 
+### Open — Escalation guard follow-ups
+
+**Orphaned-user sweep (optional, opt-in)** — When the admin-escalation guard
+(`wp_sudo_guard_escalation`, opt-in / default OFF) blocks a one-shot administrator
+*creation*, the user row is inserted before the role is applied, so the blocked
+request can leave a **roleless, powerless** user record (never an admin). Per the
+escalation-guard analysis §11 "Orphan-cleanup decision (Option A)"
+(`admin-escalation-guard-analysis.md`), we deliberately do **not** delete that row
+in-hook — mid-request `wp_delete_user()` on a possibly-unauthenticated request
+carries real risks (admin-file loading, multisite `wpmu_delete_user`, deletion /
+post-reassignment hooks firing during an attack). Backlog: design an **optional,
+opt-in sweep** (scheduled or `shutdown`-time) that reclaims never-completed roleless
+users left by a blocked escalation — scoped to rows provably created-and-left-roleless
+in a blocked request, reversible, and off by default. Only relevant once the guard
+ships and is enabled.
+
 ### Open — High Priority Security Bridge Coverage
 
 **Two Factor lifecycle bridge**

--- a/docs/admin-escalation-guard-analysis.md
+++ b/docs/admin-escalation-guard-analysis.md
@@ -93,7 +93,8 @@ over-block.
   *after* the user row exists → an **orphaned, roleless user**. → **Creation must
   be excluded** from the admin guard; admin *creation* still surfaces as an
   administrator capabilities write and is caught there as a *promotion*, at the
-  cost of the orphan caveat (mitigated by short-circuit, §6).
+  cost of the orphan caveat (mitigated by excluding creation + halting before the
+  write, §6/§9).
 - **Multisite super-admin is NOT in capabilities meta.** `grant_super_admin()` /
   `revoke_super_admin()` store status in the network `site_admins` site option
   (`update_site_option( 'site_admins', … )`) and fire the `grant_super_admin`
@@ -311,7 +312,8 @@ unauth/low-priv paths where these exploits live. This is the same hook the CLI
 new machinery. **The recommended design is this effect-level guard, not a set of
 per-surface guards.** One consequence: on non-interactive surfaces there is no
 human to send to the challenge, so the only available response is a **hard block**
-(short-circuit the write), not a reauth prompt (§6, §8).
+(halt the request before the write — §6/§9, not a short-circuit return), not a
+reauth prompt (§6, §8).
 
 ## 6. Implementation shape (if approved)
 
@@ -331,13 +333,42 @@ human to send to the challenge, so the only available response is a **hard block
   and low false positives. A capability-based check (gaining `manage_options` /
   `promote_users` / `edit_users`) would catch custom admin-equivalent roles but
   raises false positives; defer unless a concrete bypass is shown.
-- **Block mechanism:** prefer **short-circuit-return** from the metadata filter
-  (return the `$check` short-circuit value to *prevent* the capabilities write)
-  over `wp_die()` mid-write, to avoid half-applied state; pair with the standard
-  `wp_sudo_action_blocked` audit (surface `admin`) so the block is observable.
-  *(Open question for the design review: a silent short-circuit may confuse an
-  operator who sees no error; a redirect-to-challenge is not possible this deep
-  in the write. Weigh short-circuit+audit vs. `wp_die` with a clear 403.)*
+- **Block mechanism (corrected by design review — §9):** **halt the request**
+  (`wp_die()` for HTTP surfaces with a clear 403; `exit` for cron, mirroring the
+  existing CLI guard's cron handling) **before** the capabilities write proceeds —
+  *not* a short-circuit return. Short-circuit-returning a non-null value from
+  `add_user_metadata`/`update_user_metadata` is **unsound**: it makes core treat
+  the write as *succeeded* (the in-memory `WP_User::$caps`/`$roles` update and
+  downstream actions still fire) → a **half-applied** state worse than the orphan
+  it was meant to avoid; and a `false` return is indistinguishable from a
+  legitimate "value unchanged" no-op. Halting before the write is the only clean
+  stop and is consistent with the existing CLI `user.promote` guard on the same
+  hook. Pair with the `wp_sudo_action_blocked` audit so the block is observable.
+- **Coexist with the existing CLI guard on the same hook.** The CLI
+  `user.promote` guard already hooks `add_user_metadata`/`update_user_metadata`.
+  Two guards on one filter must not double-fire, emit contradictory audit signals,
+  or race on registration order — the escalation guard must be a no-op whenever the
+  CLI guard already owns the block for that surface.
+- **Respect the operator's entry-point policy (do not override it).** The guard is
+  surface-agnostic, but a site that explicitly set CLI/Cron/REST/App-Password to
+  **Unrestricted** has opted those surfaces *out* of gating. The escalation guard
+  must **consult that policy and defer** on an Unrestricted surface, or it silently
+  contradicts a setting the operator already chose.
+- **Constant / WP-CLI bypass is checked FIRST**, before any session or caps read,
+  so deployment / migration / sole-admin recovery is never hard-blocked.
+- **Multisite key matching must be pattern-based.** `is_user_capabilities_meta_key()`
+  currently builds a fixed list from the *current* blog prefix; secondary-blog keys
+  are `{base_prefix}{blog_id}_capabilities` (e.g. `wp_2_capabilities`). Match via a
+  regex (`/^{base_prefix}(\d+_)?capabilities$/`). NOTE: this also changes the
+  **shipped CLI `user.promote` guard's** match surface → needs its own regression
+  test, not just a new-guard test.
+- **`grant_super_admin` idempotency.** The action can fire for an already-super
+  user; read `get_super_admins()` and treat already-present as *not newly granted*,
+  mirroring the single-site "newly grants" rule.
+- **Exception-free by construction.** The guard must use plain array reads /
+  `in_array` and **no** `try/catch( \Throwable )` — a swallowed exception fails
+  *open* (grant proceeds), violating `CLAUDE.md`; an unhandled throw in a meta
+  filter fails *closed* and bricks all role writes. Neither is acceptable.
 - **Default-OFF filter:** `wp_sudo_guard_escalation` (name TBD), **default
   `false`** (OFF) per the recorded decision — security-conscious sites opt in;
   SSO/provisioning sites are unaffected by default. See §8 for the path to a
@@ -371,6 +402,25 @@ human to send to the challenge, so the only available response is a **hard block
    request (`current_user` = 0) and via a *low-privilege* authenticated user
    (subscriber), filter ON → **blocked** in both, since neither can hold a sudo
    session. This exercises the effect-level/all-surfaces property from §1/§5.
+9. **Sole-admin self-edit with password change (regression for the §9 BLOCKER).**
+   An administrator (no active sudo) updates their own profile in a request that
+   *also* changes the password and re-asserts the `administrator` role; the
+   plugin's `profile_update`/`after_password_reset` hooks deactivate the session
+   mid-request → the re-assert is an **idempotent** re-grant (admin already in
+   current caps) → **allowed, no half-apply**. Proves the current-caps read is
+   evaluated against pre-mutation state.
+10. **Policy deference.** With CLI (or Cron/REST/App-Password) set to
+    **Unrestricted**, an admin grant on that surface with no sudo, filter ON →
+    **allowed** (the guard defers to the operator's explicit policy).
+11. **Constant bypass first.** With the bypass constant defined, an admin grant
+    with no sudo, filter ON → **allowed** (bypass is checked before session/caps).
+12. **Multisite secondary blog.** `add_user_to_blog( $blog2, $uid, 'administrator' )`
+    (key `wp_2_capabilities`), no sudo, filter ON → **blocked** (proves the
+    blog-prefixed key regex). Plus a **regression** asserting the existing CLI
+    `user.promote` guard still matches after the key-matching change.
+13. **Coexistence.** On a CLI request where the CLI guard already owns the block,
+    the escalation guard does **not** double-fire or emit a second/contradictory
+    `wp_sudo_action_blocked`.
 
 ## 8. Recommendation
 
@@ -399,10 +449,50 @@ mechanism.
   a defensible — arguably correct — default; it simply has to *earn* that default
   rather than ship with it.
 
-A formal Pre-Implementation Design Review (per `CLAUDE.md`) and the §7 TDD
-scenarios remain prerequisites to writing code; the design review should
-specifically weigh the short-circuit-vs-`wp_die` block mechanism (§6) and the
-residual mid-session bypass (§1).
+The Pre-Implementation Design Review (per `CLAUDE.md`) has now been **run** — its
+findings are incorporated in §9 and have already corrected §6 (block mechanism)
+and §7 (added scenarios 9–13). The §7 TDD scenarios remain prerequisites to
+writing code.
+
+## 9. Design review findings (incorporated)
+
+A pre-implementation design review of §1–§8 surfaced three **BLOCKERs** and
+several concerns. The design above has been updated to reflect them; this section
+records them so the rationale is not lost.
+
+1. **Block mechanism was unsound (fixed in §6).** Short-circuit-returning from
+   `add_user_metadata`/`update_user_metadata` does **not** cleanly prevent the
+   write — core treats it as success (in-memory caps/roles update and downstream
+   actions still fire → *half-applied* state), and a `false` return is
+   indistinguishable from a legitimate no-op. Resolution: **halt the request**
+   (`wp_die`/`exit`) before the write, consistent with the existing CLI guard on
+   the same hook. The original "short-circuit avoids half-apply" premise was
+   inverted.
+2. **Sole-admin self-edit can be blocked (fixed via §6 trigger + §7 scenario 9).**
+   The plugin's own `profile_update`/`after_password_reset` hooks deactivate the
+   sudo session *mid-request*, so a sole admin changing their own password while
+   re-asserting their role could lose the session and be blocked/half-applied.
+   Resolution: the "newly grants" rule must evaluate current caps **before** any
+   in-request mutation; an idempotent re-grant of `administrator` to a user who
+   already has it is **never** blocked, independent of session state.
+3. **Surface-agnostic guard silently overrode the operator's entry-point policy
+   (fixed in §6).** A site with CLI/Cron/REST set to **Unrestricted** would still
+   be blocked, contradicting an explicit operator choice. Resolution: the guard
+   **consults the existing policy and defers** on Unrestricted surfaces; the
+   constant bypass is checked first.
+
+Concerns also folded in (§6/§7): coexistence with the existing CLI guard on the
+same filter (no double-fire / contradictory audit); pattern-based multisite
+capability-key matching (`{base_prefix}{blog_id}_capabilities`), which also
+changes the shipped CLI guard's match surface and needs a regression test;
+`grant_super_admin` idempotency; exception-free construction (no `try/catch` —
+fail-open violates `CLAUDE.md`, fail-closed bricks role writes); and documenting
+the `user_has_cap` runtime-filter blind spot (§3) in the shipped FAQ, since it
+narrows the security claim to *meta-backed* role grants.
+
+**Status:** design corrected; not approved for code. The three BLOCKERs are
+resolved at the design level here, but each must be proven by its §7 TDD scenario
+before and during implementation.
 
 ## Verification sources
 

--- a/docs/admin-escalation-guard-analysis.md
+++ b/docs/admin-escalation-guard-analysis.md
@@ -90,11 +90,13 @@ over-block.
   **not** carry the role; the role is applied afterward via the capabilities meta
   write. Consequence: an admin-surface guard cannot see "is this a new admin?" at
   pre-insert time, and blocking at the later capabilities write would `wp_die()`
-  *after* the user row exists → an **orphaned, roleless user**. → **Creation must
-  be excluded** from the admin guard; admin *creation* still surfaces as an
-  administrator capabilities write and is caught there as a *promotion*, at the
-  cost of the orphan caveat (mitigated by excluding creation + halting before the
-  write, §6/§9).
+  *after* the user row exists → a roleless user row. → Because the block halts
+  **before** the administrator role persists, no admin capability is ever written;
+  the only residual on the *creation* path is a brand-new user left **roleless and
+  powerless** (never an admin). The guard deletes that just-created roleless row
+  in-hook (the user ID is known), or a scheduled sweep removes it. **Promotions of
+  existing users have no orphan risk** — the prior role is simply retained. See §10
+  for the plain-language resolution.
 - **Multisite super-admin is NOT in capabilities meta.** `grant_super_admin()` /
   `revoke_super_admin()` store status in the network `site_admins` site option
   (`update_site_option( 'site_admins', … )`) and fire the `grant_super_admin`
@@ -380,8 +382,11 @@ reauth prompt (§6, §8).
     policy) for deployment, migration, and first-admin bootstrapping;
   - **audit events on every block** (`wp_sudo_action_blocked`) so a silent
     short-circuit is diagnosable rather than a mystery.
-- **Exclude `user.create`** from the guard (orphan problem, §3); admin *creation*
-  is still caught as the subsequent administrator capabilities write.
+- **Creation path is guarded too** (revises the earlier "exclude creation"
+  caution). A blocked one-shot admin-create leaves at most a **roleless, powerless**
+  user row — never an admin — which the hook deletes in place (user ID is known) or
+  a scheduled sweep removes. Promotions of existing users retain their prior role
+  (no orphan). Rationale and plain-language walkthrough in §10.
 
 ## 7. Required TDD scenarios (before any implementation)
 
@@ -493,6 +498,91 @@ narrows the security claim to *meta-backed* role grants.
 **Status:** design corrected; not approved for code. The three BLOCKERs are
 resolved at the design level here, but each must be proven by its §7 TDD scenario
 before and during implementation.
+
+## 10. Plain-language summary
+
+### What attack does this block?
+
+**Privilege escalation through broken access control** — the most common serious
+WordPress plugin vulnerability class. A buggy or malicious plugin exposes an
+endpoint (a REST route, an AJAX action, a form handler) that **creates a new
+administrator, or promotes an existing user to administrator, without properly
+checking who is allowed to**. An unauthenticated visitor, or a logged-in
+low-privilege user (a subscriber, a customer), triggers it and walks away with
+full control of the site.
+
+This guard adds a second, independent lock: granting administrator (or
+super-admin) requires that whoever is doing it has **recently re-confirmed their
+identity** (an active WP Sudo session). The attacker in these exploits is
+unauthenticated or low-privilege, so they *cannot* hold that session — the grant
+is denied **even though the vulnerable plugin's own permission check failed**. It
+is protection that works on code you did not write and cannot audit.
+
+### How do we avoid leaving "orphaned" users in the database?
+
+The guard stops the role change at the exact moment it would be saved — and (per
+WordPress internals) that is *before* the administrator role is ever persisted.
+
+- **Promoting an existing user** (the common case): we prevent the new role from
+  saving; the user simply keeps the role they already had. Nothing is half-written.
+- **Creating a brand-new admin in one request:** WordPress inserts the user row
+  first, then assigns the role second. If we block the role step, the row can be
+  left with *no* role. That leftover is **powerless** — zero capabilities, not an
+  administrator, can do nothing. Because the guard knows the user ID at block time,
+  the implementation **deletes that just-created roleless row** in the same step
+  (or a scheduled sweep removes it).
+
+The guarantee: **the worst possible leftover is an empty, powerless record — never
+a privileged one, and never a half-applied admin.**
+
+### How do we avoid illicit admin capabilities being written to the database?
+
+Administrator power becomes "real" only when it is written to the `wp_usermeta`
+capabilities row. The guard intercepts **that write** and halts the request
+*before* it lands, so the illicit capability is never persisted — the next request
+reads a clean database. WordPress had updated its in-memory copy, but that copy is
+discarded when the request ends.
+
+*Honest limit:* if a plugin grants admin powers a different way — computing them
+per-request via the `user_has_cap` filter, or writing raw SQL straight to the
+database — that bypasses the hook we watch, and this guard cannot see it. Those are
+uncommon for real "rogue admin" *persistence* (which needs the stored capability),
+and chasing them would cause heavy false positives, so we document the boundary
+rather than over-reach.
+
+### How do we make sure a legitimate admin is never locked out of changing roles?
+
+Three layers, and a legitimate admin trips none of them:
+
+1. **Re-saving your own role does nothing.** WordPress itself skips the database
+   write entirely when you assign a role someone already has, so an admin editing
+   their own profile or re-asserting their own admin role never reaches the guard.
+2. **Only *new* admin grants count.** The guard fires only when administrator is
+   being *added* to someone who does not currently have it. Demotions, role swaps,
+   and any edit to a user who is already an admin pass straight through.
+3. **A re-confirmed admin is always allowed.** With an active sudo session every
+   grant proceeds. Plus two escape hatches checked first: an **allowlist** for
+   trusted automation (SSO, directory sync, importers) and a **bypass constant**
+   for deployment, migrations, WP-CLI, and sole-admin recovery.
+
+So the only thing ever stopped is a *brand-new administrator grant by someone who
+has not recently proven who they are* — exactly the attack, never normal admin
+work. (The earlier worry that an admin changing their own password mid-request
+could lock themselves out is fully resolved by layer 1: re-asserting your existing
+admin role is a no-op WordPress skips before the guard can see it.)
+
+### The feature and its benefit (marketing framing)
+
+**Feature — Admin-Escalation Shield.** WP Sudo refuses to grant administrator or
+super-admin access unless the person doing it has just re-confirmed their identity.
+
+**Benefit.** It neutralizes the #1 class of serious WordPress plugin
+vulnerabilities — privilege escalation through broken access control — **even when
+the flaw is in someone else's plugin**. One vulnerable plugin can no longer hand
+your whole site to an attacker. In plain terms: **if any plugin tries to quietly
+hand out admin access to someone who hasn't proven who they are, WP Sudo slams the
+door.** A safety net for code you can't audit — off by default, opt-in, with
+escape hatches for the automation that legitimately provisions admins.
 
 ## Verification sources
 

--- a/docs/admin-escalation-guard-analysis.md
+++ b/docs/admin-escalation-guard-analysis.md
@@ -93,10 +93,14 @@ over-block.
   *after* the user row exists → a roleless user row. → Because the block halts
   **before** the administrator role persists, no admin capability is ever written;
   the only residual on the *creation* path is a brand-new user left **roleless and
-  powerless** (never an admin). The guard deletes that just-created roleless row
-  in-hook (the user ID is known), or a scheduled sweep removes it. **Promotions of
-  existing users have no orphan risk** — the prior role is simply retained. See §10
-  for the plain-language resolution.
+  powerless** (never an admin). That row is **left in place** — a no-privilege
+  record — rather than deleted mid-request: calling `wp_delete_user()` inside the
+  capabilities meta filter, on a possibly-unauthenticated request, carries its own
+  risks (admin-file loading, multisite `wpmu_delete_user`, post-reassignment and
+  deletion hooks firing during an attack request, and attacker-driven
+  create-then-block deletion loops). See the §11 decision. An optional future sweep
+  may remove such rows. **Promotions of existing users have no orphan risk** — the
+  prior role is simply retained. See §10 for the plain-language resolution.
 - **Multisite super-admin is NOT in capabilities meta.** `grant_super_admin()` /
   `revoke_super_admin()` store status in the network `site_admins` site option
   (`update_site_option( 'site_admins', … )`) and fire the `grant_super_admin`
@@ -384,9 +388,10 @@ reauth prompt (§6, §8).
     short-circuit is diagnosable rather than a mystery.
 - **Creation path is guarded too** (revises the earlier "exclude creation"
   caution). A blocked one-shot admin-create leaves at most a **roleless, powerless**
-  user row — never an admin — which the hook deletes in place (user ID is known) or
-  a scheduled sweep removes. Promotions of existing users retain their prior role
-  (no orphan). Rationale and plain-language walkthrough in §10.
+  user row — never an admin. That row is **left in place** (no in-hook deletion —
+  see the §11 decision on why mid-request `wp_delete_user()` in a security hot path
+  is avoided); an optional future sweep may remove it. Promotions of existing users
+  retain their prior role (no orphan). Rationale and walkthrough in §10.
 
 ## 7. Required TDD scenarios (before any implementation)
 
@@ -528,9 +533,11 @@ WordPress internals) that is *before* the administrator role is ever persisted.
 - **Creating a brand-new admin in one request:** WordPress inserts the user row
   first, then assigns the role second. If we block the role step, the row can be
   left with *no* role. That leftover is **powerless** — zero capabilities, not an
-  administrator, can do nothing. Because the guard knows the user ID at block time,
-  the implementation **deletes that just-created roleless row** in the same step
-  (or a scheduled sweep removes it).
+  administrator, can do nothing. We **leave it in place** rather than delete a user
+  mid-request: doing `wp_delete_user()` inside the block, on a possibly-unauthenticated
+  request, would load admin files, branch on multisite, and fire deletion/post-
+  reassignment hooks during an attack — risks that outweigh tidying a harmless row
+  (the §11 decision). An optional future sweep may clean these rows.
 
 The guarantee: **the worst possible leftover is an empty, powerless record — never
 a privileged one, and never a half-applied admin.**
@@ -643,6 +650,21 @@ creation and deletes," because deletion is already covered:
   attacker-scoped throttle** (extend the existing rate-limit lockout to repeated
   escalation attempts), never a site-wide policy change, and only as explicit
   opt-in.
+
+### Orphan-cleanup decision (Option A — document, do not delete in-hook)
+
+A blocked one-shot admin *creation* can leave a **roleless, powerless** user row
+(the row is inserted before the role is applied; the block halts before the
+administrator role persists). Decision: **do not delete that row in-hook.** Calling
+`wp_delete_user()` from inside the capabilities meta filter — on a
+possibly-unauthenticated request — would load `wp-admin/includes`, branch on
+multisite (`wpmu_delete_user`), and fire deletion / post-reassignment hooks *during
+an attack request*; an attacker could also drive repeated create-then-block loops
+to cause deletions. Those risks outweigh tidying a row that is, by construction,
+**harmless** (zero capabilities, cannot act). The row is left in place and
+documented; an **optional, opt-in future sweep** of never-completed roleless users
+is the safe place to reclaim them. Rejected: in-hook deletion (risk above) and a
+mandatory background sweep (complexity for a harmless artifact).
 
 ## Verification sources
 

--- a/docs/admin-escalation-guard-analysis.md
+++ b/docs/admin-escalation-guard-analysis.md
@@ -584,6 +584,66 @@ hand out admin access to someone who hasn't proven who they are, WP Sudo slams t
 door.** A safety net for code you can't audit — off by default, opt-in, with
 escape hatches for the automation that legitimately provisions admins.
 
+## 11. Build scope (code-grounded, after mapping `class-gate.php`)
+
+Mapping the live Gate refined the scope — the build is narrower than "guard
+creation and deletes," because deletion is already covered:
+
+- **Deletion is already guarded** on every real surface. `arm_effect_guards()`
+  hooks `delete_user`→`user.delete` (interactive `admin_init` + REST backstops),
+  and `register_function_hooks()` covers CLI/cron/XML-RPC — all **role-agnostic**
+  (any user deletion already requires sudo). **We do not change what deletion
+  blocks.** We only **add severity**: when the deleted target is an
+  administrator/super-admin, also fire the high-severity escalation event (below).
+- **The genuine gap is admin grant + admin creation on the *interactive* and
+  *REST* surfaces.** `user.create` and `user.promote` are deliberately **excluded**
+  from `arm_effect_guards()` (documented in the `register_interactive_backstop`
+  docblock) because hooking them unconditionally fires on every benign,
+  high-frequency role assignment. Only CLI/cron/XML-RPC guard them today. The fix
+  is the analysis thesis: **re-introduce them on interactive + REST, but
+  role-aware** — block only when the write **newly grants `administrator`** (or
+  super-admin), so the benign low-privilege assignments still pass.
+- **Scope decision: admin-targets only** (chosen). Create/grant guards fire only
+  for `administrator`/super-admin; all lower roles and normal signups are
+  untouched. Deletion stays role-agnostic (already shipped, more protective than
+  admin-only — we do not weaken it).
+
+### Reuse (the design-review blockers are already solved in-tree)
+
+- **Block mechanism:** reuse `Gate::die_sudo_required()` (`wp_die` 403; cron path
+  `exit`) — exactly the "halt before the write" mechanism §6/§9 prescribes. No
+  short-circuit.
+- **Session + policy:** reuse the existing backstop closures — `Sudo_Session::is_active()/is_within_grace()`,
+  and the REST backstop's `get_app_password_policy()` consultation (so an
+  Unrestricted headless surface defers, per §6).
+- **Hook point:** the role-aware closure lives on `add_user_metadata` /
+  `update_user_metadata` for the capabilities key (the same hook
+  `register_function_hooks` already uses); admin *creation* surfaces as the
+  post-insert capabilities write, so create + grant share one closure. Super-admin
+  uses `grant_super_admin`. Multisite key matching must move to the regex form
+  (§6) — a change that also touches the existing CLI guard's match surface
+  (regression test required).
+
+### Alerting (decided)
+
+- **Distinct high-severity event** `wp_sudo_escalation_blocked` (separate from the
+  routine `wp_sudo_action_blocked`), fired only on the dangerous case — an admin
+  create/grant/delete blocked on a non-enumerated path with no session. `Event_Recorder`
+  records it high-severity; the activity dashboard surfaces it prominently.
+  External tools (SIEM/Slack/security plugins) hook this one event to alert.
+- **Notification default:** event + dashboard only. A built-in admin email is a
+  later **opt-in** toggle (default off) — the plugin ships no email today.
+- **Adaptive response — recommend, do NOT auto-activate.** After a threshold of
+  high-severity blocks, show a dismissible admin notice (and, with opt-in email, a
+  link) recommending the Hardened policy preset, one-click apply. **Do not
+  auto-flip global presets:** an attacker who can trip the signal could force the
+  site into a restrictive posture and break legitimate REST/CLI/cron integrations
+  (defense weaponization / self-DoS); it also changes surfaces unrelated to the
+  blocked attack. If any automatic response is added later, prefer a **localized,
+  attacker-scoped throttle** (extend the existing rate-limit lockout to repeated
+  escalation attempts), never a site-wide policy change, and only as explicit
+  opt-in.
+
 ## Verification sources
 
 - WooCommerce `wc_create_new_customer()` role: `woocommerce/trunk` →

--- a/docs/current-metrics.md
+++ b/docs/current-metrics.md
@@ -9,8 +9,8 @@ Verification environment: local workspace, PHP 8.x
 
 | Metric | Value | Verification |
 |---|---:|---|
-| Unit tests | 862 tests | `composer test:unit` |
-| Unit assertions | 2483 assertions | `composer test:unit` |
+| Unit tests | 865 tests | `composer test:unit` |
+| Unit assertions | 2492 assertions | `composer test:unit` |
 | Integration tests in suite | 196 test methods | `rg -c "function test" tests/Integration/*.php | awk -F: '{sum+=$2} END{print sum}'` |
 | Unit test files | 27 | `ls tests/Unit/*.php | wc -l` |
 | Integration test files | 26 | `ls tests/Integration/*.php | wc -l` |
@@ -19,11 +19,11 @@ Verification environment: local workspace, PHP 8.x
 
 | Metric | Value | Verification |
 |---|---:|---|
-| Production PHP lines (`includes/`, `wp-sudo.php`, `uninstall.php`, `mu-plugin/`, `bridges/`) | 15,651 | `find ./includes ./wp-sudo.php ./uninstall.php ./mu-plugin ./bridges -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
-| Tests PHP lines (`tests/`) | 31,082 | `find ./tests -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
-| Production + tests PHP lines | 46,733 | sum of the two rows above |
-| Test-to-production ratio | 1.99:1 | `31082 / 15651` |
-| Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`) | 46,996 | `find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/vendor_test/*" ! -path "*/.tmp/*" ! -path "*/.git/*" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Production PHP lines (`includes/`, `wp-sudo.php`, `uninstall.php`, `mu-plugin/`, `bridges/`) | 15,716 | `find ./includes ./wp-sudo.php ./uninstall.php ./mu-plugin ./bridges -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Tests PHP lines (`tests/`) | 31,149 | `find ./tests -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Production + tests PHP lines | 46,865 | sum of the two rows above |
+| Test-to-production ratio | 1.98:1 | `31149 / 15716` |
+| Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`) | 47,128 | `find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/vendor_test/*" ! -path "*/.tmp/*" ! -path "*/.git/*" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
 
 ## Architectural Facts
 

--- a/docs/current-metrics.md
+++ b/docs/current-metrics.md
@@ -9,8 +9,8 @@ Verification environment: local workspace, PHP 8.x
 
 | Metric | Value | Verification |
 |---|---:|---|
-| Unit tests | 856 tests | `composer test:unit` |
-| Unit assertions | 2463 assertions | `composer test:unit` |
+| Unit tests | 862 tests | `composer test:unit` |
+| Unit assertions | 2483 assertions | `composer test:unit` |
 | Integration tests in suite | 196 test methods | `rg -c "function test" tests/Integration/*.php | awk -F: '{sum+=$2} END{print sum}'` |
 | Unit test files | 27 | `ls tests/Unit/*.php | wc -l` |
 | Integration test files | 26 | `ls tests/Integration/*.php | wc -l` |
@@ -19,11 +19,11 @@ Verification environment: local workspace, PHP 8.x
 
 | Metric | Value | Verification |
 |---|---:|---|
-| Production PHP lines (`includes/`, `wp-sudo.php`, `uninstall.php`, `mu-plugin/`, `bridges/`) | 15,608 | `find ./includes ./wp-sudo.php ./uninstall.php ./mu-plugin ./bridges -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
-| Tests PHP lines (`tests/`) | 30,956 | `find ./tests -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
-| Production + tests PHP lines | 46,564 | sum of the two rows above |
-| Test-to-production ratio | 1.98:1 | `30956 / 15608` |
-| Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`) | 46,827 | `find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/vendor_test/*" ! -path "*/.tmp/*" ! -path "*/.git/*" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Production PHP lines (`includes/`, `wp-sudo.php`, `uninstall.php`, `mu-plugin/`, `bridges/`) | 15,651 | `find ./includes ./wp-sudo.php ./uninstall.php ./mu-plugin ./bridges -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Tests PHP lines (`tests/`) | 31,082 | `find ./tests -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Production + tests PHP lines | 46,733 | sum of the two rows above |
+| Test-to-production ratio | 1.99:1 | `31082 / 15651` |
+| Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`) | 46,996 | `find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/vendor_test/*" ! -path "*/.tmp/*" ! -path "*/.git/*" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
 
 ## Architectural Facts
 

--- a/docs/current-metrics.md
+++ b/docs/current-metrics.md
@@ -9,8 +9,8 @@ Verification environment: local workspace, PHP 8.x
 
 | Metric | Value | Verification |
 |---|---:|---|
-| Unit tests | 869 tests | `composer test:unit` |
-| Unit assertions | 2506 assertions | `composer test:unit` |
+| Unit tests | 870 tests | `composer test:unit` |
+| Unit assertions | 2513 assertions | `composer test:unit` |
 | Integration tests in suite | 196 test methods | `rg -c "function test" tests/Integration/*.php | awk -F: '{sum+=$2} END{print sum}'` |
 | Unit test files | 27 | `ls tests/Unit/*.php | wc -l` |
 | Integration test files | 26 | `ls tests/Integration/*.php | wc -l` |
@@ -19,11 +19,11 @@ Verification environment: local workspace, PHP 8.x
 
 | Metric | Value | Verification |
 |---|---:|---|
-| Production PHP lines (`includes/`, `wp-sudo.php`, `uninstall.php`, `mu-plugin/`, `bridges/`) | 15,716 | `find ./includes ./wp-sudo.php ./uninstall.php ./mu-plugin ./bridges -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
-| Tests PHP lines (`tests/`) | 31,232 | `find ./tests -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
-| Production + tests PHP lines | 46,948 | sum of the two rows above |
-| Test-to-production ratio | 1.99:1 | `31232 / 15716` |
-| Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`) | 47,211 | `find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/vendor_test/*" ! -path "*/.tmp/*" ! -path "*/.git/*" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Production PHP lines (`includes/`, `wp-sudo.php`, `uninstall.php`, `mu-plugin/`, `bridges/`) | 15,747 | `find ./includes ./wp-sudo.php ./uninstall.php ./mu-plugin ./bridges -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Tests PHP lines (`tests/`) | 31,260 | `find ./tests -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Production + tests PHP lines | 47,007 | sum of the two rows above |
+| Test-to-production ratio | 1.99:1 | `31260 / 15747` |
+| Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`) | 47,270 | `find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/vendor_test/*" ! -path "*/.tmp/*" ! -path "*/.git/*" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
 
 ## Architectural Facts
 

--- a/docs/current-metrics.md
+++ b/docs/current-metrics.md
@@ -2,15 +2,15 @@
 
 This file is the single source of truth for current repository counts.
 
-Last verified: 2026-06-20
+Last verified: 2026-06-24
 Verification environment: local workspace, PHP 8.x
 
 ## Test Metrics
 
 | Metric | Value | Verification |
 |---|---:|---|
-| Unit tests | 845 tests | `composer test:unit` |
-| Unit assertions | 2435 assertions | `composer test:unit` |
+| Unit tests | 856 tests | `composer test:unit` |
+| Unit assertions | 2463 assertions | `composer test:unit` |
 | Integration tests in suite | 196 test methods | `rg -c "function test" tests/Integration/*.php | awk -F: '{sum+=$2} END{print sum}'` |
 | Unit test files | 27 | `ls tests/Unit/*.php | wc -l` |
 | Integration test files | 26 | `ls tests/Integration/*.php | wc -l` |
@@ -19,11 +19,11 @@ Verification environment: local workspace, PHP 8.x
 
 | Metric | Value | Verification |
 |---|---:|---|
-| Production PHP lines (`includes/`, `wp-sudo.php`, `uninstall.php`, `mu-plugin/`, `bridges/`) | 15,469 | `find ./includes ./wp-sudo.php ./uninstall.php ./mu-plugin ./bridges -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
-| Tests PHP lines (`tests/`) | 30,729 | `find ./tests -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
-| Production + tests PHP lines | 46,198 | sum of the two rows above |
-| Test-to-production ratio | 1.99:1 | `30729 / 15469` |
-| Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`) | 46,461 | `find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/vendor_test/*" ! -path "*/.tmp/*" ! -path "*/.git/*" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Production PHP lines (`includes/`, `wp-sudo.php`, `uninstall.php`, `mu-plugin/`, `bridges/`) | 15,608 | `find ./includes ./wp-sudo.php ./uninstall.php ./mu-plugin ./bridges -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Tests PHP lines (`tests/`) | 30,956 | `find ./tests -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Production + tests PHP lines | 46,564 | sum of the two rows above |
+| Test-to-production ratio | 1.98:1 | `30956 / 15608` |
+| Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`) | 46,827 | `find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/vendor_test/*" ! -path "*/.tmp/*" ! -path "*/.git/*" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
 
 ## Architectural Facts
 
@@ -38,7 +38,7 @@ the count in prose without a verification command.
 | Gated rules (multisite) | 8 | `grep "'id'" includes/class-action-registry.php \| grep -c "network"` | v3.2.0 |
 | Gated rules (total) | 35 | `grep "'id'" includes/class-action-registry.php \| grep -v "rule\[" \| wc -l` | v3.2.0 |
 | Help tabs | 6 | `grep -c -- "->add_help_tab(" includes/class-admin.php` | v3.2.0 |
-| Audit hooks | 18 | `python3 - <<'PY'\nimport pathlib, re\nhooks = set()\nfor path in pathlib.Path('includes').glob('class-*.php'):\n    hooks.update(re.findall(r\"do_action\\(\\s*'([^']+)'\", path.read_text()))\nhooks.discard('wp_sudo_render_two_factor_fields')\nprint(len(hooks))\nPY` | v4.0.0 |
+| Audit hooks | 19 | `python3 - <<'PY'\nimport pathlib, re\nhooks = set()\nfor path in pathlib.Path('includes').glob('class-*.php'):\n    hooks.update(re.findall(r\"do_action\\(\\s*'([^']+)'\", path.read_text()))\nhooks.discard('wp_sudo_render_two_factor_fields')\nprint(len(hooks))\nPY` | v4.1.0 (wp_sudo_escalation_blocked) |
 | Settings fields (base) | 6 | 1 numeric (duration) + 1 preset chooser + 4 policy dropdowns (REST, CLI, Cron, XML-RPC) | v3.0.0 |
 | Settings fields (with WPGraphQL) | 7 | +1 conditional WPGraphQL policy dropdown | v3.0.0 |
 | E2E tests | 63 | `npx playwright test --config tests/e2e/playwright.config.ts --list` | v4.0.0 |

--- a/docs/current-metrics.md
+++ b/docs/current-metrics.md
@@ -9,8 +9,8 @@ Verification environment: local workspace, PHP 8.x
 
 | Metric | Value | Verification |
 |---|---:|---|
-| Unit tests | 870 tests | `composer test:unit` |
-| Unit assertions | 2513 assertions | `composer test:unit` |
+| Unit tests | 878 tests | `composer test:unit` |
+| Unit assertions | 2539 assertions | `composer test:unit` |
 | Integration tests in suite | 196 test methods | `rg -c "function test" tests/Integration/*.php | awk -F: '{sum+=$2} END{print sum}'` |
 | Unit test files | 27 | `ls tests/Unit/*.php | wc -l` |
 | Integration test files | 26 | `ls tests/Integration/*.php | wc -l` |
@@ -19,11 +19,11 @@ Verification environment: local workspace, PHP 8.x
 
 | Metric | Value | Verification |
 |---|---:|---|
-| Production PHP lines (`includes/`, `wp-sudo.php`, `uninstall.php`, `mu-plugin/`, `bridges/`) | 15,747 | `find ./includes ./wp-sudo.php ./uninstall.php ./mu-plugin ./bridges -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
-| Tests PHP lines (`tests/`) | 31,260 | `find ./tests -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
-| Production + tests PHP lines | 47,007 | sum of the two rows above |
-| Test-to-production ratio | 1.99:1 | `31260 / 15747` |
-| Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`) | 47,270 | `find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/vendor_test/*" ! -path "*/.tmp/*" ! -path "*/.git/*" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Production PHP lines (`includes/`, `wp-sudo.php`, `uninstall.php`, `mu-plugin/`, `bridges/`) | 15,812 | `find ./includes ./wp-sudo.php ./uninstall.php ./mu-plugin ./bridges -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Tests PHP lines (`tests/`) | 31,434 | `find ./tests -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Production + tests PHP lines | 47,246 | sum of the two rows above |
+| Test-to-production ratio | 1.99:1 | `31434 / 15812` |
+| Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`) | 47,509 | `find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/vendor_test/*" ! -path "*/.tmp/*" ! -path "*/.git/*" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
 
 ## Architectural Facts
 

--- a/docs/current-metrics.md
+++ b/docs/current-metrics.md
@@ -9,8 +9,8 @@ Verification environment: local workspace, PHP 8.x
 
 | Metric | Value | Verification |
 |---|---:|---|
-| Unit tests | 865 tests | `composer test:unit` |
-| Unit assertions | 2492 assertions | `composer test:unit` |
+| Unit tests | 869 tests | `composer test:unit` |
+| Unit assertions | 2506 assertions | `composer test:unit` |
 | Integration tests in suite | 196 test methods | `rg -c "function test" tests/Integration/*.php | awk -F: '{sum+=$2} END{print sum}'` |
 | Unit test files | 27 | `ls tests/Unit/*.php | wc -l` |
 | Integration test files | 26 | `ls tests/Integration/*.php | wc -l` |
@@ -20,10 +20,10 @@ Verification environment: local workspace, PHP 8.x
 | Metric | Value | Verification |
 |---|---:|---|
 | Production PHP lines (`includes/`, `wp-sudo.php`, `uninstall.php`, `mu-plugin/`, `bridges/`) | 15,716 | `find ./includes ./wp-sudo.php ./uninstall.php ./mu-plugin ./bridges -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
-| Tests PHP lines (`tests/`) | 31,149 | `find ./tests -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
-| Production + tests PHP lines | 46,865 | sum of the two rows above |
-| Test-to-production ratio | 1.98:1 | `31149 / 15716` |
-| Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`) | 47,128 | `find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/vendor_test/*" ! -path "*/.tmp/*" ! -path "*/.git/*" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Tests PHP lines (`tests/`) | 31,232 | `find ./tests -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Production + tests PHP lines | 46,948 | sum of the two rows above |
+| Test-to-production ratio | 1.99:1 | `31232 / 15716` |
+| Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`) | 47,211 | `find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/vendor_test/*" ! -path "*/.tmp/*" ! -path "*/.git/*" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
 
 ## Architectural Facts
 

--- a/includes/class-event-recorder.php
+++ b/includes/class-event-recorder.php
@@ -18,6 +18,7 @@ namespace WP_Sudo;
  * - wp_sudo_lockout (security: rate limit triggered)
  * - wp_sudo_action_gated (flow: user redirected to reauthentication)
  * - wp_sudo_action_blocked (policy: non-interactive request denied)
+ * - wp_sudo_escalation_blocked (security: high-severity admin-escalation alarm)
  * - wp_sudo_action_allowed (policy: non-interactive request permitted)
  * - wp_sudo_action_passed (feature: gated action succeeds during active session)
  * - wp_sudo_action_replayed (flow: stashed request replayed after reauth)
@@ -35,6 +36,7 @@ class Event_Recorder {
 		'wp_sudo_lockout'              => 3, // user_id, attempts, ip.
 		'wp_sudo_action_gated'         => 3, // user_id, rule_id, surface.
 		'wp_sudo_action_blocked'       => 3, // user_id, rule_id, surface.
+		'wp_sudo_escalation_blocked'   => 3, // user_id, rule_id, surface (high-severity admin-escalation alarm).
 		'wp_sudo_action_allowed'       => 3, // user_id, rule_id, surface.
 		'wp_sudo_action_passed'        => 3, // user_id, rule_id, surface.
 		'wp_sudo_action_replayed'      => 2, // user_id, rule_id.
@@ -232,6 +234,35 @@ class Event_Recorder {
 				'event'   => 'action_blocked',
 				'rule_id' => $rule_id,
 				'surface' => $surface,
+			)
+		);
+	}
+
+	/**
+	 * Handle wp_sudo_escalation_blocked event.
+	 *
+	 * Fired by the admin-escalation guard when a NEW administrator/super-admin
+	 * grant, admin creation, or admin deletion is blocked (or alarmed) because no
+	 * sudo session is active — a high-severity signal of a likely
+	 * privilege-escalation attempt. Recorded as a distinct `escalation_blocked`
+	 * event (with a high-severity context marker) so the activity dashboard and
+	 * external alerting can surface it apart from routine policy denials.
+	 *
+	 * @since 4.1.0
+	 *
+	 * @param int    $user_id Target user being granted/deleted.
+	 * @param string $rule_id One of user.promote, user.super_admin, user.delete.
+	 * @param string $surface Detected request surface.
+	 * @return void
+	 */
+	public static function on_escalation_blocked( int $user_id, string $rule_id, string $surface ): void {
+		self::enqueue(
+			array(
+				'user_id' => $user_id,
+				'event'   => 'escalation_blocked',
+				'rule_id' => $rule_id,
+				'surface' => $surface,
+				'context' => array( 'severity' => 'high' ),
 			)
 		);
 	}

--- a/includes/class-gate.php
+++ b/includes/class-gate.php
@@ -157,6 +157,13 @@ class Gate {
 		// requests (rest_api_init fires before route dispatch).
 		add_action( 'rest_api_init', array( $this, 'register_rest_backstop' ), 0, 0 );
 
+		// Role-aware admin-escalation guard (opt-in via wp_sudo_guard_escalation,
+		// default OFF). Effect-level capabilities-meta guard that blocks a NEW
+		// administrator grant when no sudo session is active, across surfaces
+		// (CLI/Cron/XML-RPC defer to the non-interactive policy layer). See
+		// docs/admin-escalation-guard-analysis.md.
+		$this->arm_escalation_guard();
+
 		// WPGraphQL interception — hooks into WPGraphQL's own lifecycle.
 		// Fires after auth validation, before body reading, regardless of endpoint name.
 		/**
@@ -892,6 +899,138 @@ class Gate {
 			},
 			0
 		);
+	}
+
+	/**
+	 * Arm the role-aware admin-escalation guard (opt-in, default OFF).
+	 *
+	 * Closes the gap left by the interactive/REST effect backstops, which
+	 * deliberately exclude user.create/user.promote because hooking them
+	 * unconditionally fires on every benign role assignment. This guard hooks the
+	 * capabilities meta write but blocks ONLY when the write **newly grants
+	 * administrator** to a user who does not already hold it (see
+	 * newly_grants_administrator()), so low-privilege assignments, demotions, and
+	 * idempotent self-edits pass untouched.
+	 *
+	 * Surface coverage: the metadata filters fire on every surface, but
+	 * CLI/Cron/XML-RPC are already governed by the non-interactive policy layer
+	 * (register_function_hooks); this guard defers there to avoid double-firing.
+	 *
+	 * Block mechanism is die_sudo_required() (wp_die 403 / JSON), i.e. the request
+	 * is halted before the capabilities write persists — never a short-circuit
+	 * return. See docs/admin-escalation-guard-analysis.md §6/§9.
+	 *
+	 * @since 4.1.0
+	 *
+	 * @return void
+	 */
+	public function arm_escalation_guard(): void {
+		$guard = function ( $check, $user_id, $meta_key, $meta_value, $prev_value ) {
+			unset( $prev_value );
+
+			// Opt-in; default OFF. Security-conscious sites enable it; SSO and
+			// provisioning sites are unaffected unless they opt in.
+			if ( ! apply_filters( 'wp_sudo_guard_escalation', false ) ) {
+				return $check;
+			}
+
+			// Recovery / deployment / migration bypass — checked FIRST, before any
+			// session or capability read, so a sole-admin recovery path is never
+			// hard-blocked.
+			if ( defined( 'WP_SUDO_ALLOW_ESCALATION' ) && WP_SUDO_ALLOW_ESCALATION ) {
+				return $check;
+			}
+
+			if ( ! $this->is_user_capabilities_meta_key( (string) $meta_key ) ) {
+				return $check;
+			}
+
+			// CLI/Cron/XML-RPC are owned by register_function_hooks() (policy
+			// layer); defer there so the two guards never double-fire.
+			$surface = $this->detect_surface();
+			if ( in_array( $surface, array( 'cli', 'cron', 'xmlrpc' ), true ) ) {
+				return $check;
+			}
+
+			$target_id    = (int) $user_id;
+			$current_caps = get_user_meta( $target_id, (string) $meta_key, true );
+
+			if ( ! $this->newly_grants_administrator( $meta_value, is_array( $current_caps ) ? $current_caps : array() ) ) {
+				return $check;
+			}
+
+			/**
+			 * Allow a trusted provisioner to opt a specific administrator grant
+			 * out of the escalation guard (e.g. an allowlisted SSO/sync flow).
+			 *
+			 * @since 4.1.0
+			 *
+			 * @param bool  $allow      Whether to allow the grant. Default false.
+			 * @param int   $target_id  Target user being granted administrator.
+			 * @param mixed $meta_value Incoming capabilities value.
+			 */
+			if ( apply_filters( 'wp_sudo_allow_escalation', false, $target_id, $meta_value ) ) {
+				return $check;
+			}
+
+			// A re-confirmed actor (active or in-grace sudo session) may grant
+			// administrator. An unauthenticated (0) or low-privilege actor cannot
+			// hold a session, so the grant is blocked.
+			$actor = (int) get_current_user_id();
+			if ( $actor && ( Sudo_Session::is_active( $actor ) || Sudo_Session::is_within_grace( $actor ) ) ) {
+				return $check;
+			}
+
+			/**
+			 * Fires when an administrator grant is blocked because no sudo session
+			 * is active — a high-severity signal of a likely privilege-escalation
+			 * attempt. Distinct from wp_sudo_action_blocked so external alerting can
+			 * subscribe to only this case.
+			 *
+			 * @since 4.1.0
+			 *
+			 * @param int    $target_id Target user being granted administrator.
+			 * @param string $rule_id   Always 'user.promote'.
+			 * @param string $surface   Detected request surface.
+			 */
+			do_action( 'wp_sudo_escalation_blocked', $target_id, 'user.promote', $surface );
+
+			$this->die_sudo_required( __( 'Grant administrator', 'wp-sudo' ) );
+
+			return $check;
+		};
+
+		add_filter( 'add_user_metadata', $guard, 0, 5 );
+		add_filter( 'update_user_metadata', $guard, 0, 5 );
+	}
+
+	/**
+	 * Whether a capabilities meta value newly grants the administrator role.
+	 *
+	 * Returns true only when the incoming capabilities map grants `administrator`
+	 * AND the user's currently persisted capabilities do not already include it.
+	 * Re-asserting an administrator a user already holds (an idempotent self-edit)
+	 * and assigning any lower-privilege role both return false, so the escalation
+	 * guard never fires on benign, high-frequency role assignments — this is what
+	 * keeps WooCommerce/membership/LMS provisioning and sole-admin self-edits
+	 * unaffected. See docs/admin-escalation-guard-analysis.md §6.
+	 *
+	 * @since 4.1.0
+	 *
+	 * @param mixed                $new_caps     Incoming capabilities value (role => bool map).
+	 * @param array<string, mixed> $current_caps The user's currently persisted capabilities map.
+	 * @return bool True when administrator is present in the new value but absent
+	 *              from the current value.
+	 */
+	private function newly_grants_administrator( $new_caps, array $current_caps ): bool {
+		if ( ! is_array( $new_caps ) ) {
+			return false;
+		}
+
+		$now_admin = ! empty( $new_caps['administrator'] );
+		$was_admin = ! empty( $current_caps['administrator'] );
+
+		return $now_admin && ! $was_admin;
 	}
 
 	/**

--- a/includes/class-gate.php
+++ b/includes/class-gate.php
@@ -1002,6 +1002,51 @@ class Gate {
 
 		add_filter( 'add_user_metadata', $guard, 0, 5 );
 		add_filter( 'update_user_metadata', $guard, 0, 5 );
+
+		// Multisite super-admin grants are NOT stored in the capabilities meta;
+		// grant_super_admin() writes the network `site_admins` option. Guard that
+		// action separately, with the same opt-in/bypass/defer/allowlist/session
+		// rules. The action fires BEFORE the grant completes, so is_super_admin()
+		// still reflects the prior state — an already-super target is an idempotent
+		// re-grant and passes untouched.
+		$super_guard = function ( $user_id ) {
+			if ( ! apply_filters( 'wp_sudo_guard_escalation', false ) ) {
+				return;
+			}
+
+			if ( defined( 'WP_SUDO_ALLOW_ESCALATION' ) && WP_SUDO_ALLOW_ESCALATION ) {
+				return;
+			}
+
+			$surface = $this->detect_surface();
+			if ( in_array( $surface, array( 'cli', 'cron', 'xmlrpc' ), true ) ) {
+				return;
+			}
+
+			$target_id = (int) $user_id;
+
+			// Idempotent re-grant: already a super admin → not a new grant.
+			if ( is_super_admin( $target_id ) ) {
+				return;
+			}
+
+			/** This filter is documented above in arm_escalation_guard(). */
+			if ( apply_filters( 'wp_sudo_allow_escalation', false, $target_id, 'super-admin' ) ) {
+				return;
+			}
+
+			$actor = (int) get_current_user_id();
+			if ( $actor && ( Sudo_Session::is_active( $actor ) || Sudo_Session::is_within_grace( $actor ) ) ) {
+				return;
+			}
+
+			/** This action is documented above in arm_escalation_guard(). */
+			do_action( 'wp_sudo_escalation_blocked', $target_id, 'user.super_admin', $surface );
+
+			$this->die_sudo_required( __( 'Grant super admin', 'wp-sudo' ) );
+		};
+
+		add_action( 'grant_super_admin', $super_guard, 0 );
 	}
 
 	/**
@@ -1036,9 +1081,14 @@ class Gate {
 	/**
 	 * Determine whether a user meta key stores WordPress role capabilities.
 	 *
-	 * WordPress stores user roles in a site-scoped capabilities meta key such
-	 * as `wp_capabilities` or `wp_2_capabilities`. Matching exact keys avoids
-	 * treating unrelated plugin metadata as a role mutation.
+	 * WordPress stores user roles in a site-scoped capabilities meta key:
+	 * `{base_prefix}capabilities` on the main/single site and
+	 * `{base_prefix}{blog_id}_capabilities` on secondary multisite blogs (e.g.
+	 * `wp_capabilities`, `wp_2_capabilities`). A regex anchored on the base prefix
+	 * matches every blog's key while rejecting unrelated metadata that merely
+	 * contains "capabilities" (e.g. `wp_capabilities_backup`). This shared matcher
+	 * governs both the non-interactive `user.promote` guard and the role-aware
+	 * escalation guard, so it must cover all blogs on multisite.
 	 *
 	 * @param string $meta_key User meta key.
 	 * @return bool True when the key stores role capabilities.
@@ -1046,21 +1096,14 @@ class Gate {
 	private function is_user_capabilities_meta_key( string $meta_key ): bool {
 		global $wpdb;
 
-		$keys = array( 'wp_capabilities' );
+		$base = isset( $wpdb->base_prefix ) ? (string) $wpdb->base_prefix : 'wp_';
 
-		$keys[] = (string) $wpdb->get_blog_prefix() . 'capabilities';
-
-		if ( isset( $wpdb->prefix ) ) {
-			$keys[] = (string) $wpdb->prefix . 'capabilities';
+		if ( 1 === preg_match( '/^' . preg_quote( $base, '/' ) . '(?:\d+_)?capabilities$/', $meta_key ) ) {
+			return true;
 		}
 
-		if ( isset( $wpdb->base_prefix ) ) {
-			$keys[] = (string) $wpdb->base_prefix . 'capabilities';
-		}
-
-		$keys = array_values( array_unique( $keys ) );
-
-		return in_array( $meta_key, $keys, true );
+		// The literal default key, in case base_prefix differs from 'wp_'.
+		return 'wp_capabilities' === $meta_key;
 	}
 
 	/**

--- a/includes/class-gate.php
+++ b/includes/class-gate.php
@@ -959,6 +959,17 @@ class Gate {
 				return $check;
 			}
 
+			// An operator who set REST App Password = Unrestricted has explicitly
+			// opted that headless surface out of gating; defer (audit-only) rather
+			// than contradict the setting. Placed after the newly-grants check so
+			// the allowed audit fires only on genuine administrator escalations.
+			// See docs/admin-escalation-guard-analysis.md §6/§11.
+			if ( $this->escalation_deferred_by_app_password_policy() ) {
+				/** This action is documented in includes/class-gate.php */
+				do_action( 'wp_sudo_action_allowed', (int) get_current_user_id(), 'user.promote', 'rest_app_password' );
+				return $check;
+			}
+
 			/**
 			 * Allow a trusted provisioner to opt a specific administrator grant
 			 * out of the escalation guard (e.g. an allowlisted SSO/sync flow).
@@ -1030,6 +1041,14 @@ class Gate {
 				return;
 			}
 
+			// Defer on an Unrestricted REST App-Password surface (audit-only), as
+			// the single-site promote path does. See arm_escalation_guard() above.
+			if ( $this->escalation_deferred_by_app_password_policy() ) {
+				/** This action is documented in includes/class-gate.php */
+				do_action( 'wp_sudo_action_allowed', (int) get_current_user_id(), 'user.super_admin', 'rest_app_password' );
+				return;
+			}
+
 			/** This filter is documented above in arm_escalation_guard(). */
 			if ( apply_filters( 'wp_sudo_allow_escalation', false, $target_id, 'super-admin' ) ) {
 				return;
@@ -1049,11 +1068,14 @@ class Gate {
 		add_action( 'grant_super_admin', $super_guard, 0 );
 
 		// Deleting an administrator/super-admin with no active session is a
-		// high-severity signal. Deletion is ALREADY blocked for every user by the
-		// effect backstops (arm_effect_guards); this guard does not change that —
-		// it only ADDS the distinct escalation event for administrator targets, and
-		// runs at priority -1 so the alarm is recorded before the backstop halts the
-		// request. It never dies itself.
+		// high-severity signal. Deletion is blocked for every user by the effect
+		// backstops (arm_effect_guards) on every gated surface EXCEPT one the
+		// operator set to Unrestricted; this guard does not change that — it only
+		// ADDS the distinct escalation event for administrator targets, and runs at
+		// priority -1 so the alarm is recorded before the backstop halts the
+		// request. On an Unrestricted REST App-Password surface the backstop lets
+		// the deletion through, so this guard defers there too (no false alarm). It
+		// never dies itself.
 		$delete_guard = function ( $user_id = 0 ) {
 			if ( ! apply_filters( 'wp_sudo_guard_escalation', false ) ) {
 				return;
@@ -1070,6 +1092,15 @@ class Gate {
 
 			$target_id = (int) $user_id;
 			if ( ! $this->target_is_administrator( $target_id ) ) {
+				return;
+			}
+
+			// On an Unrestricted REST App-Password surface the effect backstop lets
+			// the deletion through, so firing the high-severity escalation_blocked
+			// event would be a false alarm; defer (audit-only) to stay consistent.
+			if ( $this->escalation_deferred_by_app_password_policy() ) {
+				/** This action is documented in includes/class-gate.php */
+				do_action( 'wp_sudo_action_allowed', (int) get_current_user_id(), 'user.delete', 'rest_app_password' );
 				return;
 			}
 
@@ -1169,6 +1200,40 @@ class Gate {
 
 		// The literal default key, in case base_prefix differs from 'wp_'.
 		return 'wp_capabilities' === $meta_key;
+	}
+
+	/**
+	 * Whether the escalation guard should defer because the request is a genuine
+	 * Application-Password REST request whose effective App Password policy is
+	 * Unrestricted — the one surface the operator has explicitly opted out of
+	 * gating (analysis §6/§11, design-review BLOCKER #3).
+	 *
+	 * Keying off rest_get_authenticated_app_password() — not detect_surface() or
+	 * the policy value alone — is deliberate and load-bearing:
+	 * get_app_password_policy() falls back to the GLOBAL rest_app_password_policy
+	 * setting even when no Application Password is present, so reading the policy
+	 * unconditionally would wrongly defer a cookie-authenticated browser REST
+	 * request whenever that global happens to be Unrestricted — a fail-open. The
+	 * truthiness gate closes that: on admin/ajax/cron/cli/unknown (and bearer or
+	 * cookie REST) the function returns empty, so this returns false and the guard
+	 * still blocks.
+	 *
+	 * This is intentionally STRICTER than register_rest_backstop()'s headless
+	 * branch, which also passes generic bearer credentials through on Unrestricted:
+	 * here only a genuine Application Password defers; any other headless
+	 * credential is blocked, because minting an administrator is higher-stakes than
+	 * the file/record effects the backstop governs.
+	 *
+	 * @since 4.1.0
+	 *
+	 * @return bool True only for an Unrestricted Application-Password REST request.
+	 */
+	private function escalation_deferred_by_app_password_policy(): bool {
+		if ( ! rest_get_authenticated_app_password() ) {
+			return false;
+		}
+
+		return self::POLICY_UNRESTRICTED === $this->get_app_password_policy();
 	}
 
 	/**

--- a/includes/class-gate.php
+++ b/includes/class-gate.php
@@ -1047,6 +1047,47 @@ class Gate {
 		};
 
 		add_action( 'grant_super_admin', $super_guard, 0 );
+
+		// Deleting an administrator/super-admin with no active session is a
+		// high-severity signal. Deletion is ALREADY blocked for every user by the
+		// effect backstops (arm_effect_guards); this guard does not change that —
+		// it only ADDS the distinct escalation event for administrator targets, and
+		// runs at priority -1 so the alarm is recorded before the backstop halts the
+		// request. It never dies itself.
+		$delete_guard = function ( $user_id = 0 ) {
+			if ( ! apply_filters( 'wp_sudo_guard_escalation', false ) ) {
+				return;
+			}
+
+			if ( defined( 'WP_SUDO_ALLOW_ESCALATION' ) && WP_SUDO_ALLOW_ESCALATION ) {
+				return;
+			}
+
+			$surface = $this->detect_surface();
+			if ( in_array( $surface, array( 'cli', 'cron', 'xmlrpc' ), true ) ) {
+				return;
+			}
+
+			$target_id = (int) $user_id;
+			if ( ! $this->target_is_administrator( $target_id ) ) {
+				return;
+			}
+
+			/** This filter is documented above in arm_escalation_guard(). */
+			if ( apply_filters( 'wp_sudo_allow_escalation', false, $target_id, 'delete' ) ) {
+				return;
+			}
+
+			$actor = (int) get_current_user_id();
+			if ( $actor && ( Sudo_Session::is_active( $actor ) || Sudo_Session::is_within_grace( $actor ) ) ) {
+				return;
+			}
+
+			/** This action is documented above in arm_escalation_guard(). */
+			do_action( 'wp_sudo_escalation_blocked', $target_id, 'user.delete', $surface );
+		};
+
+		add_action( 'delete_user', $delete_guard, -1 );
 	}
 
 	/**
@@ -1076,6 +1117,30 @@ class Gate {
 		$was_admin = ! empty( $current_caps['administrator'] );
 
 		return $now_admin && ! $was_admin;
+	}
+
+	/**
+	 * Whether a user is an administrator or super-admin (a high-value deletion
+	 * target). Used by the escalation guard to raise the high-severity alarm only
+	 * when an admin is being deleted, not on routine user churn.
+	 *
+	 * @since 4.1.0
+	 *
+	 * @param int $user_id Target user ID.
+	 * @return bool True when the user is a super-admin or holds the administrator role.
+	 */
+	private function target_is_administrator( int $user_id ): bool {
+		if ( $user_id <= 0 ) {
+			return false;
+		}
+
+		if ( is_super_admin( $user_id ) ) {
+			return true;
+		}
+
+		$user = get_userdata( $user_id );
+
+		return $user instanceof \WP_User && in_array( 'administrator', (array) $user->roles, true );
 	}
 
 	/**

--- a/tests/Unit/EventRecorderTest.php
+++ b/tests/Unit/EventRecorderTest.php
@@ -178,6 +178,10 @@ class EventRecorderTest extends TestCase {
 			->once()
 			->with( [ Event_Recorder::class, 'on_action_blocked' ], 10, 3 );
 
+		Actions\expectAdded( 'wp_sudo_escalation_blocked' )
+			->once()
+			->with( [ Event_Recorder::class, 'on_escalation_blocked' ], 10, 3 );
+
 		Actions\expectAdded( 'wp_sudo_action_allowed' )
 			->once()
 			->with( [ Event_Recorder::class, 'on_action_allowed' ], 10, 3 );
@@ -394,6 +398,30 @@ class EventRecorderTest extends TestCase {
 		$this->assertSame( 'action_blocked', $data['event'] );
 		$this->assertSame( 'users.delete', $data['rule_id'] );
 		$this->assertSame( 'cli', $data['surface'] );
+
+		$this->restoreWpdb();
+	}
+
+	/**
+	 * Test on_escalation_blocked() records a distinct high-severity event.
+	 *
+	 * @return void
+	 */
+	public function testOnEscalationBlockedInsertsHighSeverityEvent(): void {
+		$this->setUpFakeWpdb();
+
+		Event_Recorder::on_escalation_blocked( 7, 'user.promote', 'admin' );
+
+		$this->assertCount( 1, $this->fake_wpdb->inserts );
+
+		$data = $this->fake_wpdb->inserts[0]['data'];
+		$this->assertSame( 7, $data['user_id'] );
+		$this->assertSame( 'escalation_blocked', $data['event'] );
+		$this->assertSame( 'user.promote', $data['rule_id'] );
+		$this->assertSame( 'admin', $data['surface'] );
+
+		$context = is_string( $data['context'] ) ? json_decode( $data['context'], true ) : $data['context'];
+		$this->assertSame( 'high', $context['severity'] );
 
 		$this->restoreWpdb();
 	}

--- a/tests/Unit/GateTest.php
+++ b/tests/Unit/GateTest.php
@@ -4211,6 +4211,10 @@ class GateTest extends TestCase {
 		Functions\when( '__' )->returnArg();
 		Functions\when( 'esc_html' )->returnArg();
 		Functions\when( 'get_current_user_id' )->justReturn( 0 );
+		// Default: not an Application-Password request, so the app-password defer
+		// helper returns false and the guard behaves as on any cookie surface.
+		// App-password defer tests override this.
+		Functions\when( 'rest_get_authenticated_app_password' )->justReturn( null );
 		Functions\when( 'wp_doing_ajax' )->justReturn( false );
 		Functions\when( 'wp_doing_cron' )->justReturn( false );
 		Functions\when( 'is_admin' )->justReturn( true );
@@ -4613,5 +4617,175 @@ class GateTest extends TestCase {
 
 		$guard = $this->capture_delete_escalation_guard();
 		$guard( 9 );
+	}
+
+	// ── Slice 6: App-Password entry-point policy deference ────────────────
+	// The guard must honour an operator who set REST App Password = Unrestricted
+	// (analysis §6/§11, design-review BLOCKER #3, TDD scenario 10): on that
+	// surface an admin grant/delete defers (audit-only) instead of over-blocking
+	// or firing a false high-severity alarm. Deference is keyed on a genuine
+	// Application Password, NOT the global policy fallback, so a cookie-auth REST
+	// request still blocks even when the global policy is Unrestricted.
+
+	/**
+	 * Stub a genuine Application-Password request whose effective policy is the
+	 * given value (set on the global rest_app_password_policy, no per-password
+	 * override).
+	 *
+	 * @param string $policy Policy value: 'unrestricted', 'limited', 'disabled'.
+	 * @return void
+	 */
+	private function prime_app_password_policy( string $policy ): void {
+		Functions\when( 'rest_get_authenticated_app_password' )->justReturn( 'app-pass-uuid' );
+		Functions\when( 'get_option' )->justReturn( array( 'rest_app_password_policy' => $policy ) );
+	}
+
+	/**
+	 * A new administrator grant over an Unrestricted Application-Password REST
+	 * request defers: no high-severity alarm, no wp_die, and an allowed audit on
+	 * the rest_app_password surface (mirroring register_rest_backstop).
+	 */
+	public function test_escalation_guard_defers_promote_on_unrestricted_app_password(): void {
+		$this->prime_escalation_env( true );
+		Functions\when( 'get_user_meta' )->justReturn( array() ); // no current admin → newly grants.
+		Functions\when( 'get_current_user_id' )->justReturn( 9 ); // app-password actor, no session.
+		$this->prime_app_password_policy( 'unrestricted' );
+
+		Actions\expectDone( 'wp_sudo_escalation_blocked' )->never();
+		Actions\expectDone( 'wp_sudo_action_allowed' )
+			->once()
+			->with( 9, 'user.promote', 'rest_app_password' );
+		Functions\expect( 'wp_die' )->never();
+
+		$guard  = $this->capture_escalation_guard();
+		$result = $guard( null, 7, 'wp_capabilities', array( 'administrator' => true ), '' );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * Regression guard against a fail-open: a cookie-authenticated REST request
+	 * (NO application password) must still be BLOCKED even when the GLOBAL
+	 * rest_app_password_policy is Unrestricted. The deference keys off
+	 * rest_get_authenticated_app_password(), not the policy fallback.
+	 */
+	public function test_escalation_guard_blocks_non_app_password_despite_global_unrestricted(): void {
+		$this->prime_escalation_env( true );
+		Functions\when( 'get_user_meta' )->justReturn( array() );
+		Functions\when( 'get_current_user_id' )->justReturn( 9 ); // logged-in, no sudo session.
+		// Global policy is Unrestricted, but the request is NOT app-password authed.
+		Functions\when( 'rest_get_authenticated_app_password' )->justReturn( null );
+		Functions\when( 'get_option' )->justReturn( array( 'rest_app_password_policy' => 'unrestricted' ) );
+
+		Actions\expectDone( 'wp_sudo_escalation_blocked' )
+			->once()
+			->with( 7, 'user.promote', 'admin' );
+		Functions\expect( 'wp_die' )->once();
+
+		$guard = $this->capture_escalation_guard();
+		$guard( null, 7, 'wp_capabilities', array( 'administrator' => true ), '' );
+	}
+
+	/**
+	 * Limited App-Password policy still blocks the admin grant — deference is
+	 * Unrestricted-only, not "any app-password request".
+	 */
+	public function test_escalation_guard_blocks_promote_on_limited_app_password(): void {
+		$this->prime_escalation_env( true );
+		Functions\when( 'get_user_meta' )->justReturn( array() );
+		Functions\when( 'get_current_user_id' )->justReturn( 9 );
+		$this->prime_app_password_policy( 'limited' );
+
+		// Surface label is the stub env's detect_surface() result ('admin'); the
+		// point of this test is that a Limited app-password policy still BLOCKS.
+		Actions\expectDone( 'wp_sudo_escalation_blocked' )
+			->once()
+			->with( 7, 'user.promote', 'admin' );
+		Functions\expect( 'wp_die' )->once();
+
+		$guard = $this->capture_escalation_guard();
+		$guard( null, 7, 'wp_capabilities', array( 'administrator' => true ), '' );
+	}
+
+	/**
+	 * A super-admin grant over an Unrestricted Application-Password request
+	 * defers (audit-only), like the single-site promote path.
+	 */
+	public function test_super_admin_guard_defers_on_unrestricted_app_password(): void {
+		$this->prime_escalation_env( true );
+		Functions\when( 'is_super_admin' )->justReturn( false ); // not idempotent.
+		Functions\when( 'get_current_user_id' )->justReturn( 9 );
+		$this->prime_app_password_policy( 'unrestricted' );
+
+		Actions\expectDone( 'wp_sudo_escalation_blocked' )->never();
+		Actions\expectDone( 'wp_sudo_action_allowed' )
+			->once()
+			->with( 9, 'user.super_admin', 'rest_app_password' );
+		Functions\expect( 'wp_die' )->never();
+
+		$guard = $this->capture_super_admin_guard();
+		$guard( 7 );
+	}
+
+	/**
+	 * The delete alarm defers on an Unrestricted Application-Password request:
+	 * the backstop lets the deletion through there, so firing the high-severity
+	 * escalation_blocked event would be a false alarm. An allowed audit fires
+	 * instead.
+	 */
+	public function test_delete_guard_defers_on_unrestricted_app_password(): void {
+		$this->prime_escalation_env( true );
+		Functions\when( 'is_super_admin' )->justReturn( false );
+		Functions\when( 'get_userdata' )->justReturn( new \WP_User( 9, array( 'administrator' ) ) );
+		Functions\when( 'get_current_user_id' )->justReturn( 9 );
+		$this->prime_app_password_policy( 'unrestricted' );
+
+		Actions\expectDone( 'wp_sudo_escalation_blocked' )->never();
+		Actions\expectDone( 'wp_sudo_action_allowed' )
+			->once()
+			->with( 9, 'user.delete', 'rest_app_password' );
+
+		$guard = $this->capture_delete_escalation_guard();
+		$guard( 9 );
+	}
+
+	/**
+	 * The defer helper returns false when the request carries no Application
+	 * Password (e.g. admin/ajax/cookie surfaces), so the guard still blocks.
+	 */
+	public function test_app_password_defer_helper_false_without_app_password(): void {
+		$this->prime_escalation_env( true );
+		Functions\when( 'rest_get_authenticated_app_password' )->justReturn( null );
+		Functions\when( 'get_option' )->justReturn( array( 'rest_app_password_policy' => 'unrestricted' ) );
+
+		$this->assertFalse(
+			$this->invoke_gate( 'escalation_deferred_by_app_password_policy' )
+		);
+	}
+
+	/**
+	 * The defer helper returns true for a genuine Application-Password request
+	 * whose effective policy is Unrestricted.
+	 */
+	public function test_app_password_defer_helper_true_when_unrestricted(): void {
+		$this->prime_escalation_env( true );
+		$this->prime_app_password_policy( 'unrestricted' );
+
+		$this->assertTrue(
+			$this->invoke_gate( 'escalation_deferred_by_app_password_policy' )
+		);
+	}
+
+	/**
+	 * The defer helper returns false for an Application-Password request whose
+	 * effective policy is Limited.
+	 */
+	public function test_app_password_defer_helper_false_when_limited(): void {
+		$this->prime_escalation_env( true );
+		$this->prime_app_password_policy( 'limited' );
+
+		$this->assertFalse(
+			$this->invoke_gate( 'escalation_deferred_by_app_password_policy' )
+		);
 	}
 }

--- a/tests/Unit/GateTest.php
+++ b/tests/Unit/GateTest.php
@@ -4464,4 +4464,71 @@ class GateTest extends TestCase {
 		$guard = $this->capture_super_admin_guard();
 		$guard( 7 );
 	}
+
+	// ── Slice 3: high-severity event when an administrator is deleted ─────
+
+	/**
+	 * Capture the closure arm_escalation_guard() registers on delete_user.
+	 *
+	 * @return callable
+	 */
+	private function capture_delete_escalation_guard(): callable {
+		$callback = null;
+		Actions\expectAdded( 'delete_user' )
+			->once()
+			->whenHappen(
+				static function ( $cb ) use ( &$callback ) {
+					$callback = $cb;
+				}
+			);
+		$this->gate->arm_escalation_guard();
+		$this->assertIsCallable( $callback );
+		return $callback;
+	}
+
+	/**
+	 * Deleting an administrator with no active session fires the distinct
+	 * high-severity escalation event (the alarm signal). Deletion itself is
+	 * already blocked by the effect backstops; this only ADDS the alarm.
+	 */
+	public function test_delete_guard_fires_event_for_admin_target(): void {
+		$this->prime_escalation_env( true );
+		Functions\when( 'is_super_admin' )->justReturn( false );
+		Functions\when( 'get_userdata' )->justReturn( new \WP_User( 9, array( 'administrator' ) ) );
+
+		Actions\expectDone( 'wp_sudo_escalation_blocked' )
+			->once()
+			->with( 9, 'user.delete', 'admin' );
+
+		$guard = $this->capture_delete_escalation_guard();
+		$guard( 9 );
+	}
+
+	/**
+	 * Deleting a non-administrator does not raise the high-severity alarm.
+	 */
+	public function test_delete_guard_silent_for_non_admin_target(): void {
+		$this->prime_escalation_env( true );
+		Functions\when( 'is_super_admin' )->justReturn( false );
+		Functions\when( 'get_userdata' )->justReturn( new \WP_User( 9, array( 'editor' ) ) );
+
+		Actions\expectDone( 'wp_sudo_escalation_blocked' )->never();
+
+		$guard = $this->capture_delete_escalation_guard();
+		$guard( 9 );
+	}
+
+	/**
+	 * With the guard filter OFF, deleting an administrator raises no alarm.
+	 */
+	public function test_delete_guard_inert_when_filter_off(): void {
+		$this->prime_escalation_env( false );
+		Functions\when( 'is_super_admin' )->justReturn( false );
+		Functions\when( 'get_userdata' )->justReturn( new \WP_User( 9, array( 'administrator' ) ) );
+
+		Actions\expectDone( 'wp_sudo_escalation_blocked' )->never();
+
+		$guard = $this->capture_delete_escalation_guard();
+		$guard( 9 );
+	}
 }

--- a/tests/Unit/GateTest.php
+++ b/tests/Unit/GateTest.php
@@ -4338,4 +4338,130 @@ class GateTest extends TestCase {
 		$guard = $this->capture_escalation_guard();
 		$guard( null, 7, 'wp_capabilities', array( 'administrator' => true ), '' );
 	}
+
+	// ── Slice 2: multisite caps-key regex, allowlist, super-admin path ────
+
+	/**
+	 * The capabilities-key matcher must recognise secondary-blog keys
+	 * (`{base_prefix}{blog_id}_capabilities`) on multisite, not just the main
+	 * `{base_prefix}capabilities` — design-review coverage requirement.
+	 */
+	public function test_is_user_capabilities_meta_key_matches_secondary_blog(): void {
+		$GLOBALS['wpdb'] = new class() {
+			public string $prefix      = 'wp_';
+			public string $base_prefix = 'wp_';
+			public function get_blog_prefix(): string {
+				return 'wp_';
+			}
+		};
+		$this->assertTrue( $this->invoke_gate( 'is_user_capabilities_meta_key', 'wp_2_capabilities' ) );
+		$this->assertTrue( $this->invoke_gate( 'is_user_capabilities_meta_key', 'wp_capabilities' ) );
+	}
+
+	/**
+	 * Unrelated keys that merely contain "capabilities" must not match.
+	 */
+	public function test_is_user_capabilities_meta_key_rejects_unrelated_key(): void {
+		$GLOBALS['wpdb'] = new class() {
+			public string $prefix      = 'wp_';
+			public string $base_prefix = 'wp_';
+			public function get_blog_prefix(): string {
+				return 'wp_';
+			}
+		};
+		$this->assertFalse( $this->invoke_gate( 'is_user_capabilities_meta_key', 'wp_capabilities_backup' ) );
+		$this->assertFalse( $this->invoke_gate( 'is_user_capabilities_meta_key', 'wp_usermeta' ) );
+	}
+
+	/**
+	 * An allowlisted grant (wp_sudo_allow_escalation === true) passes untouched —
+	 * the trusted-provisioner escape hatch.
+	 */
+	public function test_escalation_guard_allows_when_allowlisted(): void {
+		$this->prime_escalation_env( true );
+		Functions\when( 'get_user_meta' )->justReturn( array() );
+		Functions\when( 'apply_filters' )->alias(
+			static function ( $hook, $value = null ) {
+				if ( 'wp_sudo_guard_escalation' === $hook ) {
+					return true;
+				}
+				if ( 'wp_sudo_allow_escalation' === $hook ) {
+					return true;
+				}
+				return $value;
+			}
+		);
+
+		Actions\expectDone( 'wp_sudo_escalation_blocked' )->never();
+		Functions\expect( 'wp_die' )->never();
+
+		$guard = $this->capture_escalation_guard();
+		$guard( null, 7, 'wp_capabilities', array( 'administrator' => true ), '' );
+	}
+
+	/**
+	 * Capture the closure arm_escalation_guard() registers on grant_super_admin.
+	 *
+	 * @return callable
+	 */
+	private function capture_super_admin_guard(): callable {
+		$callback = null;
+		Actions\expectAdded( 'grant_super_admin' )
+			->once()
+			->whenHappen(
+				static function ( $cb ) use ( &$callback ) {
+					$callback = $cb;
+				}
+			);
+		$this->gate->arm_escalation_guard();
+		$this->assertIsCallable( $callback );
+		return $callback;
+	}
+
+	/**
+	 * Granting super admin to a user who is not already one, with no session,
+	 * blocks and fires the high-severity event (multisite escalation).
+	 */
+	public function test_super_admin_guard_blocks_new_grant_without_session(): void {
+		$this->prime_escalation_env( true );
+		Functions\when( 'is_super_admin' )->justReturn( false );
+
+		Actions\expectDone( 'wp_sudo_escalation_blocked' )
+			->once()
+			->with( 7, 'user.super_admin', 'admin' );
+		Functions\expect( 'wp_die' )
+			->once()
+			->with( \Mockery::type( 'string' ), '', array( 'response' => 403 ) );
+
+		$guard = $this->capture_super_admin_guard();
+		$guard( 7 );
+	}
+
+	/**
+	 * Re-granting super admin to an existing super admin is idempotent — allowed.
+	 */
+	public function test_super_admin_guard_allows_existing_super_admin(): void {
+		$this->prime_escalation_env( true );
+		Functions\when( 'is_super_admin' )->justReturn( true );
+
+		Actions\expectDone( 'wp_sudo_escalation_blocked' )->never();
+		Functions\expect( 'wp_die' )->never();
+
+		$guard = $this->capture_super_admin_guard();
+		$guard( 7 );
+	}
+
+	/**
+	 * With the guard filter OFF, the super-admin closure is inert.
+	 */
+	public function test_super_admin_guard_inert_when_filter_off(): void {
+		$this->prime_escalation_env( false );
+		Functions\when( 'is_super_admin' )->justReturn( false );
+
+		Actions\expectDone( 'wp_sudo_escalation_blocked' )->never();
+		Functions\expect( 'wp_die' )->never();
+
+		$guard = $this->capture_super_admin_guard();
+		$guard( 7 );
+	}
 }

--- a/tests/Unit/GateTest.php
+++ b/tests/Unit/GateTest.php
@@ -4111,4 +4111,231 @@ class GateTest extends TestCase {
 
 		Action_Registry::reset_cache();
 	}
+
+	// ── Role-aware escalation detection (admin-escalation guard) ──────────
+
+	/**
+	 * Invoke a private Gate method via reflection (PHP 8.0/8.5-safe).
+	 *
+	 * @param string $method Method name.
+	 * @param mixed  ...$args Arguments.
+	 * @return mixed
+	 */
+	private function invoke_gate( string $method, ...$args ) {
+		$ref = new \ReflectionMethod( Gate::class, $method );
+		@$ref->setAccessible( true ); // phpcs:ignore -- 8.5 no-op, 8.0 required.
+		return $ref->invoke( $this->gate, ...$args );
+	}
+
+	/**
+	 * Adding administrator to a user who lacks it is a new grant.
+	 */
+	public function test_newly_grants_administrator_true_when_admin_added(): void {
+		$this->assertTrue(
+			$this->invoke_gate( 'newly_grants_administrator', array( 'administrator' => true ), array() )
+		);
+	}
+
+	/**
+	 * Re-asserting administrator a user already holds is idempotent, not a new
+	 * grant — the sole-admin self-edit safety property.
+	 */
+	public function test_newly_grants_administrator_false_when_already_admin(): void {
+		$this->assertFalse(
+			$this->invoke_gate(
+				'newly_grants_administrator',
+				array( 'administrator' => true ),
+				array( 'administrator' => true )
+			)
+		);
+	}
+
+	/**
+	 * Assigning a low-privilege role is never an admin grant (no over-block of
+	 * WooCommerce/membership/LMS flows).
+	 */
+	public function test_newly_grants_administrator_false_for_low_privilege_role(): void {
+		$this->assertFalse(
+			$this->invoke_gate( 'newly_grants_administrator', array( 'editor' => true ), array() )
+		);
+	}
+
+	/**
+	 * Administrator added alongside other roles is still a new grant.
+	 */
+	public function test_newly_grants_administrator_true_when_admin_added_among_roles(): void {
+		$this->assertTrue(
+			$this->invoke_gate(
+				'newly_grants_administrator',
+				array(
+					'editor'        => true,
+					'administrator' => true,
+				),
+				array( 'editor' => true )
+			)
+		);
+	}
+
+	/**
+	 * A demotion away from administrator is not a grant.
+	 */
+	public function test_newly_grants_administrator_false_on_demotion(): void {
+		$this->assertFalse(
+			$this->invoke_gate(
+				'newly_grants_administrator',
+				array( 'subscriber' => true ),
+				array( 'administrator' => true )
+			)
+		);
+	}
+
+	/**
+	 * A non-array capabilities value is never a grant (defensive).
+	 */
+	public function test_newly_grants_administrator_false_for_non_array(): void {
+		$this->assertFalse(
+			$this->invoke_gate( 'newly_grants_administrator', 'not-an-array', array() )
+		);
+	}
+
+	// ── Escalation guard wiring (arm_escalation_guard) ───────────────────
+
+	/**
+	 * Stub the WordPress globals/functions the escalation guard closure reaches,
+	 * with the guard filter ON and an 'admin' surface by default.
+	 *
+	 * @param bool $guard_on Whether wp_sudo_guard_escalation returns true.
+	 * @return void
+	 */
+	private function prime_escalation_env( bool $guard_on = true ): void {
+		Functions\when( '__' )->returnArg();
+		Functions\when( 'esc_html' )->returnArg();
+		Functions\when( 'get_current_user_id' )->justReturn( 0 );
+		Functions\when( 'wp_doing_ajax' )->justReturn( false );
+		Functions\when( 'wp_doing_cron' )->justReturn( false );
+		Functions\when( 'is_admin' )->justReturn( true );
+		Functions\when( 'apply_filters' )->alias(
+			static function ( $hook, $value = null ) use ( $guard_on ) {
+				if ( 'wp_sudo_guard_escalation' === $hook ) {
+					return $guard_on;
+				}
+				return $value;
+			}
+		);
+		$GLOBALS['wpdb'] = new class() {
+			public string $prefix      = 'wp_';
+			public string $base_prefix = 'wp_';
+			public function get_blog_prefix(): string {
+				return 'wp_';
+			}
+		};
+	}
+
+	/**
+	 * Capture the closure arm_escalation_guard() registers on update_user_metadata.
+	 *
+	 * @return callable
+	 */
+	private function capture_escalation_guard(): callable {
+		$callback = null;
+		Filters\expectAdded( 'update_user_metadata' )
+			->once()
+			->with(
+				\Mockery::on(
+					static function ( $candidate ) use ( &$callback ): bool {
+						$callback = $candidate;
+						return is_callable( $candidate );
+					}
+				),
+				0,
+				5
+			);
+		$this->gate->arm_escalation_guard();
+		$this->assertIsCallable( $callback );
+		return $callback;
+	}
+
+	/**
+	 * A new administrator grant with no sudo session (unauthenticated actor) is
+	 * blocked: the high-severity event fires and the request is halted via wp_die.
+	 */
+	public function test_escalation_guard_blocks_new_admin_grant_without_session(): void {
+		$this->prime_escalation_env( true );
+		Functions\when( 'get_user_meta' )->justReturn( array() );
+
+		Actions\expectDone( 'wp_sudo_escalation_blocked' )
+			->once()
+			->with( 7, 'user.promote', 'admin' );
+		Functions\expect( 'wp_die' )
+			->once()
+			->with( \Mockery::type( 'string' ), '', array( 'response' => 403 ) );
+
+		$guard  = $this->capture_escalation_guard();
+		$result = $guard( null, 7, 'wp_capabilities', array( 'administrator' => true ), '' );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * With the guard filter OFF (default), the closure is inert regardless of role.
+	 */
+	public function test_escalation_guard_inert_when_filter_off(): void {
+		$this->prime_escalation_env( false );
+		Functions\when( 'get_user_meta' )->justReturn( array() );
+
+		Actions\expectDone( 'wp_sudo_escalation_blocked' )->never();
+		Functions\expect( 'wp_die' )->never();
+
+		$guard  = $this->capture_escalation_guard();
+		$result = $guard( null, 7, 'wp_capabilities', array( 'administrator' => true ), '' );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * Assigning a low-privilege role never trips the guard (no over-block of
+	 * WooCommerce/membership signups).
+	 */
+	public function test_escalation_guard_allows_low_privilege_role(): void {
+		$this->prime_escalation_env( true );
+		Functions\when( 'get_user_meta' )->justReturn( array() );
+
+		Actions\expectDone( 'wp_sudo_escalation_blocked' )->never();
+		Functions\expect( 'wp_die' )->never();
+
+		$guard = $this->capture_escalation_guard();
+		$guard( null, 7, 'wp_capabilities', array( 'editor' => true ), '' );
+	}
+
+	/**
+	 * Re-asserting administrator on a user who already has it is idempotent and
+	 * never blocked — the sole-admin self-edit safety property, independent of
+	 * session state.
+	 */
+	public function test_escalation_guard_allows_idempotent_admin_regrant(): void {
+		$this->prime_escalation_env( true );
+		Functions\when( 'get_user_meta' )->justReturn( array( 'administrator' => true ) );
+
+		Actions\expectDone( 'wp_sudo_escalation_blocked' )->never();
+		Functions\expect( 'wp_die' )->never();
+
+		$guard = $this->capture_escalation_guard();
+		$guard( null, 7, 'wp_capabilities', array( 'administrator' => true ), '' );
+	}
+
+	/**
+	 * On CLI/Cron/XML-RPC the guard defers to the non-interactive policy layer
+	 * (register_function_hooks) and does not fire, avoiding a double block.
+	 */
+	public function test_escalation_guard_defers_on_non_interactive_surface(): void {
+		$this->prime_escalation_env( true );
+		Functions\when( 'wp_doing_cron' )->justReturn( true ); // surface = 'cron'.
+		Functions\when( 'get_user_meta' )->justReturn( array() );
+
+		Actions\expectDone( 'wp_sudo_escalation_blocked' )->never();
+		Functions\expect( 'wp_die' )->never();
+
+		$guard = $this->capture_escalation_guard();
+		$guard( null, 7, 'wp_capabilities', array( 'administrator' => true ), '' );
+	}
 }

--- a/tests/Unit/GateTest.php
+++ b/tests/Unit/GateTest.php
@@ -4531,4 +4531,87 @@ class GateTest extends TestCase {
 		$guard = $this->capture_delete_escalation_guard();
 		$guard( 9 );
 	}
+
+	// ── Slice 4: allow-path coverage for the super-admin & delete guards ──
+
+	/**
+	 * An allowlisted super-admin grant passes untouched.
+	 */
+	public function test_super_admin_guard_allows_when_allowlisted(): void {
+		$this->prime_escalation_env( true );
+		Functions\when( 'is_super_admin' )->justReturn( false );
+		Functions\when( 'apply_filters' )->alias(
+			static function ( $hook, $value = null ) {
+				if ( 'wp_sudo_guard_escalation' === $hook ) {
+					return true;
+				}
+				if ( 'wp_sudo_allow_escalation' === $hook ) {
+					return true;
+				}
+				return $value;
+			}
+		);
+
+		Actions\expectDone( 'wp_sudo_escalation_blocked' )->never();
+		Functions\expect( 'wp_die' )->never();
+
+		$guard = $this->capture_super_admin_guard();
+		$guard( 7 );
+	}
+
+	/**
+	 * On a non-interactive surface the super-admin guard defers to the policy
+	 * layer and does not fire.
+	 */
+	public function test_super_admin_guard_defers_on_non_interactive_surface(): void {
+		$this->prime_escalation_env( true );
+		Functions\when( 'wp_doing_cron' )->justReturn( true ); // surface = 'cron'.
+		Functions\when( 'is_super_admin' )->justReturn( false );
+
+		Actions\expectDone( 'wp_sudo_escalation_blocked' )->never();
+		Functions\expect( 'wp_die' )->never();
+
+		$guard = $this->capture_super_admin_guard();
+		$guard( 7 );
+	}
+
+	/**
+	 * An allowlisted administrator deletion raises no alarm.
+	 */
+	public function test_delete_guard_allows_when_allowlisted(): void {
+		$this->prime_escalation_env( true );
+		Functions\when( 'is_super_admin' )->justReturn( false );
+		Functions\when( 'get_userdata' )->justReturn( new \WP_User( 9, array( 'administrator' ) ) );
+		Functions\when( 'apply_filters' )->alias(
+			static function ( $hook, $value = null ) {
+				if ( 'wp_sudo_guard_escalation' === $hook ) {
+					return true;
+				}
+				if ( 'wp_sudo_allow_escalation' === $hook ) {
+					return true;
+				}
+				return $value;
+			}
+		);
+
+		Actions\expectDone( 'wp_sudo_escalation_blocked' )->never();
+
+		$guard = $this->capture_delete_escalation_guard();
+		$guard( 9 );
+	}
+
+	/**
+	 * On a non-interactive surface the delete alarm defers to the policy layer.
+	 */
+	public function test_delete_guard_defers_on_non_interactive_surface(): void {
+		$this->prime_escalation_env( true );
+		Functions\when( 'wp_doing_cron' )->justReturn( true ); // surface = 'cron'.
+		Functions\when( 'is_super_admin' )->justReturn( false );
+		Functions\when( 'get_userdata' )->justReturn( new \WP_User( 9, array( 'administrator' ) ) );
+
+		Actions\expectDone( 'wp_sudo_escalation_blocked' )->never();
+
+		$guard = $this->capture_delete_escalation_guard();
+		$guard( 9 );
+	}
 }


### PR DESCRIPTION
## Summary

Implements the **role-aware admin-escalation guard** for issue #110 (opt-in, **default OFF**), then completes its entry-point-policy deference. Closes the gap left by the interactive/REST effect backstops, which deliberately exclude `user.create`/`user.promote`: this guard hooks the capabilities-meta write (and `grant_super_admin`) but blocks **only** when a write **newly grants `administrator`/super-admin** to a user who does not already hold it — so low-privilege assignments, demotions, and idempotent self-edits pass untouched.

Began as the design-review/analysis doc (`docs/admin-escalation-guard-analysis.md`) and grew through implementation slices 1–5 plus the App-Password deference fix below. Ships behind the `wp_sudo_guard_escalation` filter (default `false`) with escape hatches (`wp_sudo_allow_escalation` allowlist, `WP_SUDO_ALLOW_ESCALATION` constant) for SSO/provisioning/recovery.

## What's implemented

- **Effect-level guard, surface-agnostic** on `add_user_metadata`/`update_user_metadata` (caps key) + `grant_super_admin`; blocks via `die_sudo_required()` (halt before the write — never a short-circuit return), per design-review BLOCKER #1.
- **"Newly grants administrator"** evaluated against pre-mutation caps, so a sole-admin self-edit re-asserting their own role is never blocked (BLOCKER #2).
- **Pattern-based multisite caps-key matching** (`{base_prefix}{blog_id}_capabilities`) — also covers the shipped CLI `user.promote` guard (regression-tested).
- **High-severity alarm** `wp_sudo_escalation_blocked` → `Event_Recorder` records it distinct from routine `wp_sudo_action_blocked` for SIEM/dashboard surfacing.
- **App-Password entry-point policy deference (this PR's final fix, BLOCKER #3 completed).** The guard previously deferred only on `{cli,cron,xmlrpc}` and never consulted the REST App-Password policy, so on a surface an operator explicitly set to **Unrestricted** it over-blocked admin grants (403) and fired a false high-severity alarm on an admin deletion the REST backstop actually allows. New helper `escalation_deferred_by_app_password_policy()` defers (audit-only, firing `wp_sudo_action_allowed` on `rest_app_password`) only when a **genuine Application Password** is present **and** the effective policy is Unrestricted. The app-password gate is load-bearing: reading the policy unconditionally would defer a cookie-auth browser REST request whenever the global is Unrestricted (a fail-open) — closed by a fail-open regression test. Intentionally stricter than the backstop's headless branch (only a real app password defers, not generic bearer).

## Process

- Pre-implementation design review run (three BLOCKERs resolved); the final App-Password fix went through its own design review (rejected the initial silent-defer plan; audit symmetry, placement, stricter-than-backstop semantics, and the fail-open regression test all incorporated).
- TDD throughout; pre-commit reviewer approved.
- Gates green: 878 unit tests, full integration matrix, E2E, PHPStan L6 + Psalm clean, Plugin Check, `verify:metrics` in sync.

Closes #110.

🤖 Generated with [Claude Code](https://claude.com/claude-code)