### PR TITLE
docs(readme): point latest-release Playground link at v4.1.0

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,7 @@ Require password confirmation before high-risk changes go through on your WordPr
 [![CodeQL](https://github.com/dknauss/Sudo/actions/workflows/codeql.yml/badge.svg)](https://github.com/dknauss/Sudo/actions/workflows/codeql.yml)
 [![Codecov](https://codecov.io/gh/dknauss/Sudo/graph/badge.svg?branch=main)](https://codecov.io/gh/dknauss/Sudo)
 [![Type Coverage](https://shepherd.dev/github/dknauss/Sudo/coverage.svg)](https://shepherd.dev/github/dknauss/Sudo)
-[![Try latest release in Playground](https://img.shields.io/badge/Try%20release-Playground-3858e9?logo=wordpress&logoColor=white)](https://playground.wordpress.net/?blueprint-url=https%3A%2F%2Fraw.githubusercontent.com%2Fdknauss%2FSudo%2Fv4.0.0%2Fblueprint.json)
+[![Try latest release in Playground](https://img.shields.io/badge/Try%20release-Playground-3858e9?logo=wordpress&logoColor=white)](https://playground.wordpress.net/?blueprint-url=https%3A%2F%2Fraw.githubusercontent.com%2Fdknauss%2FSudo%2Fv4.1.0%2Fblueprint.json)
 [![Try main in Playground](https://img.shields.io/badge/Try%20main-Playground-23282d?logo=wordpress&logoColor=white)](https://playground.wordpress.net/?blueprint-url=https%3A%2F%2Fraw.githubusercontent.com%2Fdknauss%2FSudo%2Fmain%2Fblueprint-main.json)
 
 Playground demo credentials are `admin` / `password`. When Sudo asks for reauthentication, enter the same password: `password`.

--- a/readme.txt
+++ b/readme.txt
@@ -19,7 +19,7 @@ This is not role-based escalation. Every logged-in user is treated the same: att
 
 = Playground demo =
 
-* [Try the latest release in WordPress Playground](https://playground.wordpress.net/?blueprint-url=https%3A%2F%2Fraw.githubusercontent.com%2Fdknauss%2FSudo%2Fv4.0.0%2Fblueprint.json)
+* [Try the latest release in WordPress Playground](https://playground.wordpress.net/?blueprint-url=https%3A%2F%2Fraw.githubusercontent.com%2Fdknauss%2FSudo%2Fv4.1.0%2Fblueprint.json)
 * [Try current main in WordPress Playground](https://playground.wordpress.net/?blueprint-url=https%3A%2F%2Fraw.githubusercontent.com%2Fdknauss%2FSudo%2Fmain%2Fblueprint-main.json)
 
 Playground demo credentials are `admin` / `password`. When WP Sudo asks for reauthentication, enter the same password: `password`.


### PR DESCRIPTION
## Summary

Bumps the **"try latest release" Playground blueprint link** in `readme.md` and `readme.txt` from `v4.0.0` → `v4.1.0`, so the demo points at the new release.

## ⚠️ Merge ordering

**Do not merge this until the `v4.1.0` tag is published.** The link resolves the blueprint from `raw.githubusercontent.com/.../Sudo/v4.1.0/blueprint.json`, which 404s until the tag exists. Sequence:

1. `git push origin v4.1.0` (+ cut the GitHub Release) — see the handoff in the session.
2. Merge this PR.

Docs-only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NvgBLDNajHatAH9eG59LVh)_