### PR TITLE
docs(planning): 2FA-bridge + audit/visibility scopes; fix external-audit spec drift

### DIFF
--- a/.planning/post-4.1.0-dev-scopes-part2.md
+++ b/.planning/post-4.1.0-dev-scopes-part2.md
@@ -1,0 +1,156 @@
+# Post-4.1.0 Development Scopes — Part 2 (design-reviewed)
+
+Companion to [`post-4.1.0-dev-scopes.md`](post-4.1.0-dev-scopes.md). Two further
+candidate work items, each scoped from the code and run through the
+Pre-Implementation Design Review process (per `CLAUDE.md`); reviewer objections are
+incorporated. **No implementation has started.**
+
+This same change also **fixed the drift** in
+[`../docs/external-audit-mode-spec.md`](../docs/external-audit-mode-spec.md) that the
+Cluster 2 review surfaced (see Cluster 2 → 2a).
+
+Source of truth is the code (`includes/`), not these notes — re-verify symbol and
+line references before editing.
+
+---
+
+## Cluster 1 — Two Factor lifecycle bridge
+
+**Type:** new security feature (opt-in `bridges/` mu-plugin). **Effort:** Medium.
+**Status:** researched + design-reviewed; 7 required changes captured below.
+
+### Problem
+WP Sudo validates a second factor *during* the sudo challenge but does not gate
+**factor-management**. A compromised session + known/phished password can generate
+new recovery codes or reset TOTP that satisfy the *later* sudo 2FA step, defeating
+the gate. Goal: require an active sudo session before **creating or replacing**
+factors.
+
+### Research (verified against upstream `WordPress/two-factor` master; matches repo notes @ `38cd183`)
+The Two Factor providers fire **no dedicated `do_action` lifecycle hooks** — gate by
+**route + meta write**, not by event:
+- Recovery-code generation: `POST /two-factor/1.0/generate-backup-codes` →
+  `generate_codes()` writes `_two_factor_backup_codes`.
+- TOTP setup/delete: `POST`/`DELETE /two-factor/1.0/totp` →
+  `set_user_totp_key()`/`delete_user_totp_key()` write/delete `_two_factor_totp_key`.
+- Provider enable/disable: `profile.php`/`user-edit.php` `action=update` writes
+  `_two_factor_enabled_providers` / `_two_factor_provider`.
+- **Trap:** `_two_factor_backup_codes` is rewritten on code **consumption during
+  login** (`delete_code()`), not only on generation.
+
+### Approach (hybrid: route-gating + selective meta-gating)
+1. **REST-route rules** (via `wp_sudo_gated_actions`, gated by `intercept_rest` +
+   app-password policy): `POST /two-factor/1.0/generate-backup-codes`; `POST` and
+   `DELETE /two-factor/1.0/totp`. (`matches_rest()` regex-matches any namespace, so
+   `/two-factor/1.0/...` routes work.)
+2. **Effect-level meta-gating** for the **safe** keys only — `_two_factor_totp_key`,
+   `_two_factor_enabled_providers`, `_two_factor_provider` (written only on deliberate
+   config, never during auth) — to catch the profile-form path the REST rules miss.
+3. **EXCLUDE `_two_factor_backup_codes` from meta-gating** (consumption rewrites it;
+   gating would block 2FA sign-in). Generation is covered by the route rule in (1).
+
+### Required design changes (from review) — before TDD
+1. **🔴 BLOCKER — actor-session / target-audit.** The meta guard MUST check the
+   **actor's** session (`get_current_user_id()`) and use the meta `$user_id` only as
+   the target/audit subject — exactly like `arm_escalation_guard()`. Checking the
+   *target's* session fails open on the admin-resets-another-user path.
+2. **Idempotence check.** `profile.php` round-trips `_two_factor_enabled_providers` to
+   its same value on every save; gate **only on actual change** (compare incoming vs
+   persisted, mirror `newly_grants_administrator()`) or every profile save by a 2FA
+   user gets a spurious challenge.
+3. **Gate replacement/reset/disable only — never first-time enrollment.** Confirmed in
+   code: a user with no factor gets a **password-only** sudo challenge
+   (`Sudo_Session::needs_two_factor()` false), so no lockout; gating zero-to-one buys
+   ~no security and adds onboarding friction. (TOTP: gate only when a key already
+   exists. Providers: gate change/removal, not first add.)
+4. **Drop the effect-backstop from the rationale.** `arm_effect_guards()` covers a
+   fixed WP-core hook set and structurally cannot see Two Factor meta writes; the
+   meta-gating layer is the only effect-level coverage.
+5. **Document residual gaps honestly.** CLI/direct `generate_codes()` is not gated
+   (can't meta-guard `_two_factor_backup_codes` without blocking login); the JS
+   2FA-settings UI gets a non-recoverable `sudo_required` JSON 403 → **depends on the
+   block-editor Phase-1 `challenge_url` work** (see Part 1, Scope 3) or ships a
+   degraded-but-honest error.
+6. **Bridge, not built-in** — opt-in `bridges/` mu-plugin, `class_exists('Two_Factor_Core')`-
+   guarded, rules via `wp_sudo_gated_actions` (built-in rules fail *closed* on a
+   plugin that may be absent; a bridge degrades gracefully).
+7. **Multisite:** 2FA meta keys are **global** (`_two_factor_*`) — do NOT copy the
+   capabilities blog-prefix regex (`is_user_capabilities_meta_key`).
+
+### Dependency
+Cleanly benefits from the block-editor Phase-1 `challenge_url` work (recoverable
+in-UI reauth for the 2FA settings screen). Sequence after, or accept a degraded error.
+
+---
+
+## Cluster 2 — Audit / visibility cluster
+
+Three interrelated sub-items of **different readiness**.
+
+### 2a. External Audit Mode — spec was DRIFTED; fixed in this change, then implement
+The review found `docs/external-audit-mode-spec.md` named a non-existent
+`Event_Recorder::record()` choke point and `render_events_panel()` method, guessed the
+bridge-detector class names, and asserted per-site settings that contradict the
+network-wide `wp_sudo_settings` storage. **Fixed in this change** (verified against
+code):
+- Choke point is the private **`Event_Recorder::enqueue()`** (single point both the
+  buffered `$pending` and direct paths funnel through); short-circuit there, before
+  the buffer append.
+- The four external-audit **meta-events** persist locally via an explicit
+  **`always_persist()` allowlist** at that choke point (resolves the hand-waved
+  "governance hooks always persist").
+- Detector reuses the bridges' own helpers — `wp_sudo_stream_bridge_available()`
+  (checks `wp_stream_get_instance()`) and `wp_sudo_wsal_bridge_available()` (checks
+  `\WSAL\Controllers\Alert_Manager` / `wsal_log_event()`) — **not** the guessed
+  `WP_Stream\Connectors`. Detector evaluated **at event time** (not cached from
+  `admin_init`) so non-admin surfaces (REST/cron/CLI) fail-closed correctly.
+- Dashboard method is **`render_recent_events()`**.
+- Liveness copy says "WP Sudo last **dispatched** an event to {target}" — it cannot
+  confirm bridge-side persistence, so it must not claim "✓ recorded in Stream".
+- Multisite: setting is **network-wide** (in `wp_sudo_settings`); events remain
+  per-site. (Per-site override would require splitting the key — out of scope.)
+
+**Status:** with the spec corrected, 2a is implement-to-spec + TDD. One open item:
+re-verify the upstream Stream/WSAL symbol names against the shipped bridge files
+before coding (per `CLAUDE.md`).
+
+### 2b. Sudo Activity screen MVP — scope-creep + capability contradiction
+- 🔴 A dashboard widget **already** renders a filterable 50-row Recent Events table.
+  A separate paginated "screen" *is* an audit-log viewer — violating the non-goals.
+  **Extend the widget or add a single "View all"** reusing `recent_for_dashboard()`;
+  **forbid** pagination/export/date-range.
+- 🔴 **Capability contradiction:** the Settings → Sudo page requires `manage_wp_sudo`
+  to render, but the activity view should be `view_wp_sudo_activity` — so a Settings
+  tab can't serve view-only users. Needs a dashboard-area screen or separate menu.
+  Resolve before building.
+- **PII discipline:** keep `DASHBOARD_SELECT_COLUMNS` (excludes `ip`/`context`); never
+  use `Event_Store::recent()` (full `*`) — don't regress IP exposure (`ip` exists only
+  on `lockout` rows).
+
+### 2c. Audit-visibility integrity warnings — collapse to one surface
+- 🔴 Three surfaces (Site Health + settings + dashboard) for the same fact = alarm
+  fatigue, violates Simplicity-First. **One authoritative surface — a Site Health
+  test** (`class-site-health.php` already hosts integrity tests), passive inline
+  mention at most.
+- **Detectable conditions only:** passed-event logging disabled
+  (`WP_SUDO_DISABLE_PASSED_EVENT_LOGGING` / `wp_sudo_log_passed_events_enabled`),
+  bridge class absent. The code **cannot** tell "bridge loaded but silently dropping"
+  from "quiet" — warning copy must not imply it can.
+
+### Sequencing
+`2a (now implementable, spec fixed) → 2b (extend widget, with the bridge-status tile
+2a defines) → 2c (one Site Health warning)`. Guardrail across all three: stay a
+**modest built-in visibility layer**, not an audit-log product — delegation to
+Stream/WSAL (2a) is the answer for heavy audit needs. Keep 2b/2c **current-site-scoped**;
+defer network aggregation to the network-dashboard backlog item.
+
+---
+
+## Cross-cutting
+- Each scope (and each phase) takes its own design review + TDD + pre-commit reviewer
+  before code.
+- Two findings of note that the design reviews surfaced: an actor-vs-target
+  **fail-open** that would be introduced by a naive 2FA bridge (prevented at design
+  time, code not yet written), and **spec drift** in the External Audit Mode doc that
+  would have misled implementation (fixed here). The shipped-code item worth acting on
+  is the **Connectors cache-invalidation** finding tracked in Part 1, Scope 1.

--- a/docs/external-audit-mode-spec.md
+++ b/docs/external-audit-mode-spec.md
@@ -6,6 +6,17 @@
 *Draft: April 20, 2026. Status: design backlog. Related historical plan:
 [`archive/execution-plan-v3.1-v3.3.md`](archive/execution-plan-v3.1-v3.3.md).*
 
+> **Revised for code accuracy (post-4.1.0 design review).** Earlier drafts named
+> a `Event_Recorder::record()` choke point and a `Dashboard_Widget::render_events_panel()`
+> method that do not exist, guessed the bridge-detector class names, and asserted
+> per-site settings that contradict the network-wide `wp_sudo_settings` storage.
+> Those are corrected below against the live code (`includes/class-event-recorder.php`,
+> `includes/class-dashboard-widget.php`, `includes/class-admin.php`,
+> `bridges/wp-sudo-stream-bridge.php`, `bridges/wp-sudo-wsal-sensor.php`). The choke
+> point is the private `Event_Recorder::enqueue()`; persisting the four external-audit
+> meta-events while suppressing routine events requires an explicit allowlist at that
+> choke point (see Runtime behavior).
+
 ## Problem
 
 Operators who use **Stream** or **WP Activity Log (WSAL)** as their canonical
@@ -52,8 +63,9 @@ A single operator setting, `wp_sudo_external_audit`, with three values:
 | `wsal`   | Suppressed         | Bridge status tile, link to WSAL  | Yes              | Yes                    |
 
 **Key invariant:** audit hooks keep firing regardless of the setting. Only
-the `Event_Recorder::record()` path to `wpsudo_events` is conditional. This
-guarantees that:
+the `Event_Recorder::enqueue()` path to `wpsudo_events` is conditional (the
+private choke point through which both the buffered and direct write paths
+funnel). This guarantees that:
 
 - External bridges continue to receive events.
 - Third-party integrations on `wp_sudo_*` hooks are unaffected.
@@ -71,14 +83,20 @@ in order:
    `options.wp_sudo_access` gated rule, so the mutation itself requires an
    active sudo session. Changing audit destination is privilege-sensitive.
 3. **Bridge preflight.** The chosen bridge must be **loaded and active** at
-   save time:
-   - `stream` → `class_exists( 'WP_Stream\Connectors' )` (or the equivalent
-     published API at implementation time) **and** the Sudo Stream connector
-     is registered.
-   - `wsal` → `class_exists( 'WpSecurityAuditLog' )` **and** the Sudo
-     sensor is loaded.
-   If preflight fails, the save is rejected with an admin notice and the
-   setting stays at `off`. The rejection reason is logged via
+   save time. Reuse the bridges' own availability helpers rather than
+   re-implementing detection (verified against the bridge files):
+   - `stream` → `wp_sudo_stream_bridge_available()`
+     (`bridges/wp-sudo-stream-bridge.php`, which checks
+     `function_exists( 'wp_stream_get_instance' )`).
+   - `wsal` → `wp_sudo_wsal_bridge_available()`
+     (`bridges/wp-sudo-wsal-sensor.php`, which checks
+     `class_exists( '\WSAL\Controllers\Alert_Manager' )` or
+     `function_exists( 'wsal_log_event' )`).
+   These helpers are the source of truth for "is the bridge live"; the
+   upstream Stream/WSAL symbol names they wrap MUST be re-verified against the
+   shipped bridge files before implementation (per `CLAUDE.md`). If preflight
+   fails, the save is rejected with an admin notice and the setting stays at
+   `off`. The rejection reason is logged via
    `wp_sudo_external_audit_preflight_failed` (see hooks below).
 4. **Confirmation.** The Settings UI requires a confirmation checkbox ("I
    understand that WP Sudo's internal event log will stop recording; events
@@ -91,9 +109,14 @@ logging is always safe.
 
 ### Event_Recorder short-circuit
 
+The choke point is the private `enqueue()` (the single method through which
+every `on_*` callback funnels, whether it buffers into `$pending` or writes
+directly via `Event_Store::insert()`). Short-circuiting here — **before** the
+buffer append — means suppressed events never accumulate in memory:
+
 ```php
-public static function record( array $event ): void {
-    if ( self::is_external_audit_active() ) {
+private static function enqueue( array $row ): void {
+    if ( self::is_external_audit_active() && ! self::always_persist( $row['event'] ) ) {
         /**
          * Fires when an event would have been written to wpsudo_events
          * but external audit mode routed it to a bridge instead.
@@ -101,12 +124,27 @@ public static function record( array $event ): void {
          * @param array  $event   The event that was not persisted locally.
          * @param string $target  'stream' or 'wsal'.
          */
-        do_action( 'wp_sudo_event_externally_routed', $event, self::external_audit_target() );
+        do_action( 'wp_sudo_event_externally_routed', $row, self::external_audit_target() );
         return;
     }
-    // ... existing buffer + shutdown flush path.
+    // ... existing buffer ($pending) + shutdown bulk_insert() path.
 }
 ```
+
+Two implementation requirements:
+
+- **`always_persist()` allowlist.** The four external-audit *meta* events
+  (below) describe the audit configuration itself and MUST be written locally
+  even under external mode, so they bypass the suppression. This is the only
+  per-event exemption; routine events (`action_gated`, `action_blocked`, …) are
+  suppressed uniformly. (Resolves the earlier spec's hand-waved "governance
+  hooks always persist" — it is an explicit allowlist at the choke point, not
+  an implicit second path.)
+- **Evaluate the detector at event time, not at `admin_init`.**
+  `is_external_audit_active()` must run a cheap `wp_sudo_*_bridge_available()`
+  check at `enqueue()` time. Caching it from `admin_init` would reopen a gap on
+  non-admin surfaces (REST, cron, CLI) where `admin_init` never fires — the
+  fail-closed resume-to-internal behavior must hold there too.
 
 `is_external_audit_active()` returns `false` if the bridge has since been
 deactivated (see integrity warning below) — this is a fail-closed guard, not
@@ -114,20 +152,23 @@ the primary check.
 
 ### Dashboard widget
 
-The widget's `render_events_panel()` method branches on the setting:
+The widget's `render_recent_events()` method branches on the setting:
 
 - `off`: renders the existing Recent Events table (current 3.0.0 behavior).
 - `stream`/`wsal`: renders a compact status tile:
 
-  > **Audit routed to Stream** ✓
+  > **Audit routed to Stream**
   >
-  > Recent WP Sudo events are recorded in Stream.
+  > WP Sudo is forwarding events to Stream and not storing them locally.
   > Open Stream in wp-admin: `/wp-admin/admin.php?page=wp_stream`
-  > *Last event received: 3 minutes ago.*
+  > *WP Sudo last dispatched an event to Stream 3 minutes ago.*
 
-  "Last event received" uses a 60-second transient updated on each
-  `wp_sudo_event_externally_routed` dispatch, so the widget confirms the
-  bridge is actually getting events — not just that the setting is on.
+  **Honesty constraint:** the liveness line uses a 60-second transient updated
+  on each `wp_sudo_event_externally_routed` **dispatch** — i.e. when WP Sudo
+  *hands off* the event. It proves WP Sudo fired, **not** that Stream/WSAL
+  persisted it (WP Sudo has no way to confirm bridge-side storage). The copy
+  must therefore say "WP Sudo last dispatched…", never "✓ recorded in Stream"
+  or "events are recorded in Stream" as a confirmed fact.
 
 Active Sessions panel, Policy Summary panel, and filters are unchanged.
 
@@ -167,8 +208,9 @@ New hooks added in Phase 5:
 
 All four are recorded in `wpsudo_events` itself even while external audit is
 active (they describe the audit configuration, not routine events, and must
-not be lost during a destination transition). They are also forwarded to
-the active bridge.
+not be lost during a destination transition) — this is the `always_persist()`
+allowlist at the `enqueue()` choke point (see Runtime behavior), not an
+implicit second write path. They are also forwarded to the active bridge.
 
 A new event type `governance.external_audit_toggled` is emitted on each
 transition so the destination system (Stream/WSAL) captures the configuration
@@ -183,8 +225,9 @@ In Settings → Sudo, under a new **Audit destination** section:
   corresponding plugin is not loaded.
 - Confirmation checkbox appears when selecting Stream or WSAL.
 - Save triggers the preflight flow described above.
-- A status line below the radio group shows: "Last event received by
-  {target}: Xs ago" when mode is active.
+- A status line below the radio group shows: "WP Sudo last dispatched an event
+  to {target}: Xs ago" when mode is active (dispatch, not confirmed bridge
+  persistence — see the Dashboard widget honesty constraint).
 
 ## Uninstall and upgrade behavior
 
@@ -200,10 +243,10 @@ In Settings → Sudo, under a new **Audit destination** section:
 
 Unit coverage:
 
-- `Event_Recorder::record()` short-circuits when mode is active and a bridge
+- `Event_Recorder::enqueue()` short-circuits when mode is active and a bridge
   is available.
-- Short-circuit does **not** apply to governance-transition hooks (those are
-  always persisted locally).
+- Short-circuit does **not** apply to the four external-audit meta-events
+  (the `always_persist()` allowlist) — those are always persisted locally.
 - Preflight rejects `stream`/`wsal` when the bridge plugin is missing.
 - Fail-closed behavior when bridge is deactivated at runtime.
 
@@ -212,7 +255,13 @@ Integration coverage:
 - Full round-trip: enable mode → emit event → verify no row in
   `wpsudo_events` → verify bridge captured event → disable mode → emit event
   → verify row appears.
-- Multisite: setting is per-site (each site configures independently).
+- Multisite: the `wp_sudo_external_audit` setting lives in `wp_sudo_settings`,
+  which is **network-wide** on multisite (`Admin::get()` reads `get_site_option()`;
+  `uninstall.php` deletes via `delete_site_option`). So the audit destination is
+  set once for the network, while **events remain per-site** (`Event_Store` rows
+  carry `site_id` and queries filter on the current site). Each site's
+  `Event_Recorder` consults the same network-wide setting. (A per-site override
+  would require splitting this key out of `wp_sudo_settings` — out of scope here.)
 - Upgrade path from 3.0.x/3.1.x retains `off` and existing events.
 
 Playwright coverage:


### PR DESCRIPTION
## Summary

Persists two further **design-reviewed** scopes and **fixes drift** in the External Audit Mode spec that the Cluster 2 review surfaced. **Planning + docs only — no implementation.**

### New planning doc: `.planning/post-4.1.0-dev-scopes-part2.md`
- **Two Factor lifecycle bridge** — gate factor-management (recovery-code generation, TOTP setup/reset/delete, provider change) via REST routes + selective meta-gating. Review caught a would-be **fail-open** (must check the *actor's* sudo session, not the target's — mirroring `arm_escalation_guard`), required an idempotence check, established that **first-time enrollment must not be gated** (password-only challenge → no lockout), and chose an **opt-in bridge** over built-in rules. Documented residual gaps (CLI generation; JS-UI recoverable-error dependency on the block-editor `challenge_url` work).
- **Audit/visibility cluster** — External Audit Mode (now implementable after the spec fix), Sudo Activity screen MVP (**extend the widget**, not a paginated audit viewer; resolve the `manage_wp_sudo` vs `view_wp_sudo_activity` capability conflict; preserve IP-column discipline), and a single **Site Health** integrity warning scoped to detectable conditions.

### Spec fix: `docs/external-audit-mode-spec.md` (verified against code)
- Choke point is the private `Event_Recorder::enqueue()` — the spec's `record()` **doesn't exist**.
- The four external-audit meta-events persist via an explicit `always_persist()` allowlist (resolves the hand-waved "governance hooks always persist").
- Bridge detection reuses `wp_sudo_stream_bridge_available()` / `wp_sudo_wsal_bridge_available()` (not the guessed `WP_Stream\Connectors`), **evaluated at event time** so non-admin surfaces fail closed.
- Dashboard method is `render_recent_events()`; liveness copy claims only **dispatch**, never confirmed bridge persistence.
- Setting is **network-wide** (`wp_sudo_settings`) while events stay **per-site** — reconciling the spec's per-site contradiction.

## Not in scope
No production/test code; each scope still takes its own design review + TDD before code. The one shipped-code item worth acting on (the Connectors cache-invalidation finding) is tracked in Part 1, Scope 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NvgBLDNajHatAH9eG59LVh)_