### PR TITLE
docs: Connectors matcher cache is blog-invariant (rejected blog-keying fix)

### DIFF
--- a/.planning/connectors-matcher-strategy.md
+++ b/.planning/connectors-matcher-strategy.md
@@ -80,6 +80,18 @@ private static function is_connector_api_key_setting_name( string $key ): bool {
 - Covers sites running WP < 7.0 where the API doesn't exist
 - Costs nothing — the regex is fast and the false positive surface is empty
 
+**Cache scope (evaluated post-4.1.0):** the per-request
+`$connector_setting_names_cache` is intentionally **not** keyed by blog, and that is
+correct. The registry is an `init`-populated in-process singleton
+(`WP_Connector_Registry`), blog-invariant within a request — `switch_to_blog()` does
+not re-run `init` or connector registration, so `wp_get_connectors()` returns the same
+`method`/`setting_name` mapping on every blog. A design review rejected per-blog keying
+(adds complexity + unbounded growth under `switch_to_blog` loops; untestable, since core
+never emits a per-blog-varying registry). The only Tier-1 residual is the
+**late-registration** timing edge above, accepted and backstopped by the Tier-2 regex.
+Caveat: this depends on the matcher running *after* `init` (it does — REST dispatch is
+well after `init`); invoking it earlier would be the real staleness vector.
+
 ### Step 3: Add integration tests
 
 Integration tests require a real WordPress environment with the Connectors API available:

--- a/.planning/post-4.1.0-dev-scopes.md
+++ b/.planning/post-4.1.0-dev-scopes.md
@@ -39,27 +39,31 @@ advertises.
 2. **Integration tests** (extend `tests/Integration/ConnectorsMatcherTest.php`):
    non-`api_key` method must NOT gate; PUT **and** PATCH (not just POST); mixed
    benign+secret payload gates; `api_key`-with-missing-`setting_name` falls through to
-   Tier 2 without error; **the stale-cache cross-blog case (mandatory, see finding).**
+   Tier 2 without error; non-`api_key` method does NOT gate; multisite write gates.
 3. **Manual release verification:** cookie-auth AND Application-Password writes to
    `/wp/v2/settings` with connector fields → `tests/MANUAL-TESTING.md`.
 4. **Doc split** (separate commit/PR): `docs/connectors-api-reference.md` → lean core
    ref + security companion.
 5. **Fix stale ROADMAP §74/§347** — mark shipped, point to code.
 
-### 🔴 Design-review finding (new): cache has no runtime invalidation
-`$connector_setting_names_cache` is populated once per request; `reset_cache()` has
-**zero runtime callers**. Under `switch_to_blog()` mid-request — or a connector
-registered after the first match — the matcher serves a stale connector set, a **false
-negative** for any non-regex `setting_name` (Tier 2 regex only backstops
-`connectors_*_api_key`-shaped names). The existing integration tests manually call
-`reset_cache()` before each assertion, which **masks** this gap.
+### Cache scope (evaluated → non-issue; corrects an earlier overstated finding)
+An earlier pass flagged the per-request `$connector_setting_names_cache` (no runtime
+invalidation; `reset_cache()` has zero runtime callers) as a `switch_to_blog()`
+cross-blog false-negative. **A follow-up design review found that is not reachable**
+and the proposed blog-keying fix is **not warranted**: the WP Connectors registry is
+an `init`-populated in-process **singleton** (`WP_Connector_Registry`; settings at
+`init` priority 20), and `switch_to_blog()` does **not** re-run `init`/registration —
+so `wp_get_connectors()` returns the same `method`/`setting_name` mapping regardless of
+the current blog. Only the stored *credential value* is per-site, not the mapping the
+cache holds. The single per-request cache is therefore correct on multisite; blog-keying
+would add complexity + unbounded growth under `switch_to_blog` loops and is untestable
+(core never produces a per-blog-varying registry).
 
-**Required disposition** (pick one, in scope):
-- **(a)** Wire `reset_cache()` to the `switch_blog` action (one-line fix), OR
-- **(b)** Document accepted residual risk, naming Tier 2 as the stated mitigation.
-
-The new cross-blog test must run **without** a manual `reset_cache()` so it exercises
-production behavior.
+**Disposition: document the accepted residual, no code change.** The sole Tier-1
+residual is **late registration** (a connector registered *after* the matcher's first
+call in a request), already backstopped by the Tier-2 regex and accepted as a
+documented limitation (see `.planning/connectors-matcher-strategy.md` and
+`docs/connectors-api-reference.md`).
 
 ### MUST DO / MUST NOT
 - MUST keep the fail-toward-gating union; gate every core `api_key` setting incl.

--- a/docs/connectors-api-reference.md
+++ b/docs/connectors-api-reference.md
@@ -116,6 +116,19 @@ then reads and writes the database value through `get_option()` /
 `update_option()` on the standard `/wp/v2/settings` endpoint rather than using
 network options.
 
+> **Registry is blog-invariant within a request (matters for caching consumers).**
+> The connector **registry** (`WP_Connector_Registry`, a singleton) is populated
+> **once per request at `init`** (settings at priority 20; `wp_connectors_init`
+> fires during `init`) and is **not** rebuilt or re-filtered by `switch_to_blog()`.
+> So `wp_get_connectors()` returns the same `method`/`setting_name` mapping
+> regardless of the current blog — only the stored *credential value* is per-site
+> (above), not the mapping. A consumer that caches the `api_key` `setting_name`
+> set per request (such as WP Sudo's `connectors.update_credentials` matcher) is
+> therefore correct on multisite with a single per-request cache; per-blog keying
+> is unnecessary. The one residual is **late registration** — a connector
+> registered *after* the cache is first populated in a request — which a
+> regex/name-convention fallback should backstop.
+
 That said, the **effective** connector key may still be shared across the whole
 install/network when core resolves it from:
 


### PR DESCRIPTION
## Summary

You asked me to fix the Connectors matcher's "cache has no runtime invalidation → cross-blog false negative" finding. I took it through a Pre-Implementation Design Review first (it's a security-sensitive, multisite-execution path) — and **the review rejected the fix as unnecessary because the bug isn't real.** This PR records that conclusion (docs-only); **no production code changes.**

## Why no code change
- The WP Connectors registry is an **`init`-populated in-process singleton** (`WP_Connector_Registry`; settings registered at `init` priority 20). `switch_to_blog()` swaps `$wpdb`/options but does **not** re-run `init`/connector registration — so `wp_get_connectors()` returns the **same** `method`/`setting_name` mapping regardless of the current blog.
- Only the stored *credential value* is per-site; the **mapping the cache holds is blog-invariant within a request**. So the existing single per-request cache is correct on multisite.
- Blog-keying would add complexity + **unbounded growth** under `switch_to_blog` loops, and is **untestable** (core never produces a per-blog-varying registry) — per CLAUDE.md, a guard you can't write a real failing test for shouldn't be added.

## Disposition: document the accepted residual
The only real Tier-1 residual is **late registration** (a connector registered *after* the matcher's first call in a request), already backstopped by the Tier-2 regex.

- `docs/connectors-api-reference.md` — registry is blog-invariant within a request; implications for caching consumers.
- `.planning/connectors-matcher-strategy.md` — record the evaluated-and-rejected blog-keying decision.
- `.planning/post-4.1.0-dev-scopes.md` — **correct the earlier overstated finding** (cross-blog staleness is not reachable).

Docs-only; no production code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NvgBLDNajHatAH9eG59LVh)_