### PR TITLE
feat(bridges): gate Two Factor REST factor-management behind WP Sudo

### DIFF
--- a/bridges/wp-sudo-two-factor-lifecycle-bridge.php
+++ b/bridges/wp-sudo-two-factor-lifecycle-bridge.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * WP Sudo ↔ Two Factor (WordPress.org) Lifecycle Bridge
+ *
+ * Requires an active WP Sudo session before security-sensitive Two Factor
+ * factor-MANAGEMENT operations over the Two Factor REST API. These operations
+ * create or replace credentials that can satisfy a *later* WP Sudo 2FA
+ * challenge, so a compromised session (with the password also known or phished)
+ * must not be able to mint them:
+ *
+ *   - POST   /two-factor/1.0/generate-backup-codes  (new recovery codes)
+ *   - POST   /two-factor/1.0/totp                   (set up / reconfigure TOTP)
+ *   - DELETE /two-factor/1.0/totp                   (remove TOTP — a downgrade)
+ *
+ * Drop this file into wp-content/mu-plugins/.
+ *
+ * Requirements:
+ *   - WP Sudo 4.1+
+ *   - Two Factor by the WordPress.org Two Factor team
+ *
+ * Mechanism: the routes are registered as WP Sudo gated rules via the
+ * `wp_sudo_gated_actions` filter, so WP Sudo's REST interceptor governs them
+ * with its normal policy — a cookie-authenticated browser request is gated
+ * (sudo required), and an Application Password request follows the operator's
+ * REST App Password policy. No custom blocking logic lives here.
+ *
+ * Verified against WordPress/two-factor (master): routes are
+ * `two-factor/1.0/totp` (POST + DELETE) and
+ * `two-factor/1.0/generate-backup-codes` (POST); `user_id` is a request
+ * parameter, not a path segment.
+ *
+ * KNOWN LIMITS (v1):
+ *   - The classic profile-form provider toggle (`_two_factor_enabled_providers`
+ *     / `_two_factor_provider`) and classic-form TOTP-key writes are NOT yet
+ *     gated here — they need an effect-level guard with an idempotent,
+ *     enrollment-excluding change predicate and are tracked as a follow-up.
+ *   - A blocked request from the Two Factor *settings UI* (an `apiFetch`)
+ *     receives a `sudo_required` JSON 403 it cannot yet recover from in place; a
+ *     future in-editor/challenge-URL affordance will improve this.
+ *   - Recovery-code generation via WP-CLI or a direct PHP call is not gated
+ *     (governed instead by WP Sudo's non-interactive surface policy).
+ *   - First-time enrollment is intentionally not blocked here — these rules fire
+ *     on the management routes regardless, but a user with no prior factor can
+ *     obtain a sudo session with their password alone (the challenge is
+ *     password-only until a factor exists).
+ *
+ * @package    WP_Sudo_Bridges
+ * @version    1.0.0
+ * @license    GPL-2.0-or-later
+ * @link       https://github.com/dknauss/Sudo
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+add_filter(
+	'wp_sudo_gated_actions',
+	/**
+	 * Register the Two Factor factor-management REST routes as gated rules.
+	 *
+	 * @param array<int, array<string, mixed>> $rules Existing gated rules.
+	 * @return array<int, array<string, mixed>>
+	 */
+	static function ( array $rules ): array {
+		// Runtime integration check: only register when the Two Factor plugin is
+		// actually present. mu-plugins load before regular plugins, so this is
+		// evaluated when the filter runs (request time), not at file load.
+		if ( ! class_exists( 'Two_Factor_Core' ) ) {
+			return $rules;
+		}
+
+		$rules[] = array(
+			'id'       => 'two_factor.backup_codes_generate',
+			'label'    => __( 'Generate Two Factor recovery codes', 'wp-sudo' ),
+			'category' => 'users',
+			'admin'    => null,
+			'ajax'     => null,
+			'rest'     => array(
+				'route'   => '#^/two-factor/1\.0/generate-backup-codes$#',
+				'methods' => array( 'POST' ),
+			),
+		);
+
+		$rules[] = array(
+			'id'       => 'two_factor.totp_manage',
+			'label'    => __( 'Set up or remove Two Factor TOTP', 'wp-sudo' ),
+			'category' => 'users',
+			'admin'    => null,
+			'ajax'     => null,
+			'rest'     => array(
+				'route'   => '#^/two-factor/1\.0/totp$#',
+				'methods' => array( 'POST', 'DELETE' ),
+			),
+		);
+
+		return $rules;
+	}
+);

--- a/docs/current-metrics.md
+++ b/docs/current-metrics.md
@@ -9,21 +9,21 @@ Verification environment: local workspace, PHP 8.x
 
 | Metric | Value | Verification |
 |---|---:|---|
-| Unit tests | 878 tests | `composer test:unit` |
-| Unit assertions | 2539 assertions | `composer test:unit` |
+| Unit tests | 880 tests | `composer test:unit` |
+| Unit assertions | 2569 assertions | `composer test:unit` |
 | Integration tests in suite | 196 test methods | `rg -c "function test" tests/Integration/*.php | awk -F: '{sum+=$2} END{print sum}'` |
-| Unit test files | 27 | `ls tests/Unit/*.php | wc -l` |
+| Unit test files | 28 | `ls tests/Unit/*.php | wc -l` |
 | Integration test files | 26 | `ls tests/Integration/*.php | wc -l` |
 
 ## Size Metrics
 
 | Metric | Value | Verification |
 |---|---:|---|
-| Production PHP lines (`includes/`, `wp-sudo.php`, `uninstall.php`, `mu-plugin/`, `bridges/`) | 15,812 | `find ./includes ./wp-sudo.php ./uninstall.php ./mu-plugin ./bridges -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
-| Tests PHP lines (`tests/`) | 31,434 | `find ./tests -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
-| Production + tests PHP lines | 47,246 | sum of the two rows above |
-| Test-to-production ratio | 1.99:1 | `31434 / 15812` |
-| Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`) | 47,509 | `find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/vendor_test/*" ! -path "*/.tmp/*" ! -path "*/.git/*" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Production PHP lines (`includes/`, `wp-sudo.php`, `uninstall.php`, `mu-plugin/`, `bridges/`) | 15,909 | `find ./includes ./wp-sudo.php ./uninstall.php ./mu-plugin ./bridges -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Tests PHP lines (`tests/`) | 31,565 | `find ./tests -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Production + tests PHP lines | 47,474 | sum of the two rows above |
+| Test-to-production ratio | 1.98:1 | `31565 / 15909` |
+| Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`) | 47,737 | `find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/vendor_test/*" ! -path "*/.tmp/*" ! -path "*/.git/*" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
 
 ## Architectural Facts
 
@@ -66,7 +66,7 @@ Source: `.github/workflows/phpunit.yml`, `.github/workflows/e2e.yml`, `.github/w
 
 ## Verification Notes
 
-- `composer test:unit` passed on 2026-06-24 (`878 tests`, `2539 assertions`).
+- `composer test:unit` passed on 2026-06-25 (`880 tests`, `2569 assertions`).
 - `composer lint` passed on 2026-06-20.
 - `composer analyse` passed on 2026-06-20 (PHPStan L6 `[OK] No errors`; Psalm `No errors found!`, 95.8% type coverage, baseline current).
 - `composer verify:metrics` passed on 2026-06-20 (after this update).

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,52 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="6.16.1@f1f5de594dc76faf8784e02d3dc4716c91c6f6ac">
+  <file src="bridges/wp-sudo-two-factor-lifecycle-bridge.php">
+    <HookNotFound>
+      <code><![CDATA[add_filter(
+	'wp_sudo_gated_actions',
+	/**
+	 * Register the Two Factor factor-management REST routes as gated rules.
+	 *
+	 * @param array<int, array<string, mixed>> $rules Existing gated rules.
+	 * @return array<int, array<string, mixed>>
+	 */
+	static function ( array $rules ): array {
+		// Runtime integration check: only register when the Two Factor plugin is
+		// actually present. mu-plugins load before regular plugins, so this is
+		// evaluated when the filter runs (request time), not at file load.
+		if ( ! class_exists( 'Two_Factor_Core' ) ) {
+			return $rules;
+		}
+
+		$rules[] = array(
+			'id'       => 'two_factor.backup_codes_generate',
+			'label'    => __( 'Generate Two Factor recovery codes', 'wp-sudo' ),
+			'category' => 'users',
+			'admin'    => null,
+			'ajax'     => null,
+			'rest'     => array(
+				'route'   => '#^/two-factor/1\.0/generate-backup-codes$#',
+				'methods' => array( 'POST' ),
+			),
+		);
+
+		$rules[] = array(
+			'id'       => 'two_factor.totp_manage',
+			'label'    => __( 'Set up or remove Two Factor TOTP', 'wp-sudo' ),
+			'category' => 'users',
+			'admin'    => null,
+			'ajax'     => null,
+			'rest'     => array(
+				'route'   => '#^/two-factor/1\.0/totp$#',
+				'methods' => array( 'POST', 'DELETE' ),
+			),
+		);
+
+		return $rules;
+	}
+)]]></code>
+    </HookNotFound>
+  </file>
   <file src="bridges/wp-sudo-webauthn-bridge.php">
     <HookNotFound>
       <code><![CDATA[add_filter(

--- a/tests/Unit/TwoFactorLifecycleBridgeTest.php
+++ b/tests/Unit/TwoFactorLifecycleBridgeTest.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * Tests for the Two Factor lifecycle bridge (v1: REST-route gating).
+ *
+ * @package WP_Sudo
+ */
+
+namespace WP_Sudo\Tests\Unit;
+
+use Brain\Monkey\Functions;
+use WP_Sudo\Tests\TestCase;
+
+/**
+ * @coversNothing Procedural bridge file.
+ *
+ * Note: `tests/bootstrap.php` unconditionally stubs `Two_Factor_Core`, so the
+ * bridge's `class_exists( 'Two_Factor_Core' )` runtime guard always sees the
+ * plugin as present here. The "Two Factor absent → bridge inert" branch is a
+ * standard one-line guard (mirroring the other bridges) that cannot be
+ * exercised in the unit suite without undefining a class; it is left to
+ * real-environment verification.
+ */
+class TwoFactorLifecycleBridgeTest extends TestCase {
+
+	/**
+	 * Capture the wp_sudo_gated_actions filter the bridge registers, then
+	 * require the bridge file under Brain\Monkey-aliased WordPress functions.
+	 *
+	 * @return callable The registered wp_sudo_gated_actions callback.
+	 */
+	private function capture_gated_actions_filter(): callable {
+		$captured = null;
+
+		Functions\when( '__' )->returnArg();
+		Functions\when( 'add_filter' )->alias(
+			static function ( string $hook, callable $callback ) use ( &$captured ): bool {
+				if ( 'wp_sudo_gated_actions' === $hook ) {
+					$captured = $callback;
+				}
+				return true;
+			}
+		);
+
+		require __DIR__ . '/../../bridges/wp-sudo-two-factor-lifecycle-bridge.php';
+
+		$this->assertIsCallable( $captured, 'Bridge must register a wp_sudo_gated_actions filter.' );
+
+		return $captured;
+	}
+
+	/**
+	 * Find a rule by id in the filtered rule list.
+	 *
+	 * @param array<int, array<string, mixed>> $rules Rules.
+	 * @param string                           $id    Rule id.
+	 * @return array<string, mixed>
+	 */
+	private function rule_by_id( array $rules, string $id ): array {
+		foreach ( $rules as $rule ) {
+			if ( ( $rule['id'] ?? '' ) === $id ) {
+				return $rule;
+			}
+		}
+
+		$this->fail( "Rule '{$id}' was not registered." );
+	}
+
+	/**
+	 * The bridge registers exactly the two factor-management REST rules, each
+	 * well-formed for the Action Registry (non-empty id/label/category, null
+	 * admin/ajax, a valid rest matcher).
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_registers_two_well_formed_rules_when_two_factor_present(): void {
+		\Brain\Monkey\setUp();
+
+		$filter = $this->capture_gated_actions_filter();
+		$rules  = $filter( array() );
+
+		$ids = array_column( $rules, 'id' );
+		$this->assertContains( 'two_factor.backup_codes_generate', $ids );
+		$this->assertContains( 'two_factor.totp_manage', $ids );
+		$this->assertCount( 2, $rules );
+
+		foreach ( $rules as $rule ) {
+			$this->assertNotEmpty( $rule['id'] );
+			$this->assertNotEmpty( $rule['label'] );
+			$this->assertNotEmpty( $rule['category'] );
+			$this->assertNull( $rule['admin'] );
+			$this->assertNull( $rule['ajax'] );
+			$this->assertIsArray( $rule['rest'] );
+			$this->assertIsString( $rule['rest']['route'] );
+			$this->assertIsArray( $rule['rest']['methods'] );
+			$this->assertNotFalse(
+				@preg_match( $rule['rest']['route'], '' ),
+				"Route pattern for {$rule['id']} must be a valid regex."
+			);
+		}
+
+		\Brain\Monkey\tearDown();
+	}
+
+	/**
+	 * The TOTP rule matches POST and DELETE on the exact /totp route only, and
+	 * the backup-codes rule matches POST on generate-backup-codes only.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_routes_and_methods_match_the_verified_two_factor_endpoints(): void {
+		\Brain\Monkey\setUp();
+
+		$rules = ( $this->capture_gated_actions_filter() )( array() );
+
+		$totp = $this->rule_by_id( $rules, 'two_factor.totp_manage' );
+		$this->assertSame( 1, preg_match( $totp['rest']['route'], '/two-factor/1.0/totp' ) );
+		$this->assertSame( 0, preg_match( $totp['rest']['route'], '/two-factor/1.0/totp/extra' ) );
+		$this->assertSame( array( 'POST', 'DELETE' ), $totp['rest']['methods'] );
+
+		$backup = $this->rule_by_id( $rules, 'two_factor.backup_codes_generate' );
+		$this->assertSame( 1, preg_match( $backup['rest']['route'], '/two-factor/1.0/generate-backup-codes' ) );
+		$this->assertSame( array( 'POST' ), $backup['rest']['methods'] );
+		// The backup-codes rule must NOT match the totp route or unrelated routes.
+		$this->assertSame( 0, preg_match( $backup['rest']['route'], '/two-factor/1.0/totp' ) );
+		$this->assertSame( 0, preg_match( $backup['rest']['route'], '/wp/v2/users/1' ) );
+
+		\Brain\Monkey\tearDown();
+	}
+}


### PR DESCRIPTION
## Summary

Adds an optional mu-plugin bridge that requires an active WP Sudo session before security-sensitive **Two Factor** (WordPress.org plugin) factor-**management** operations over the Two Factor REST API. These operations create or replace credentials that can satisfy a *later* WP Sudo 2FA challenge, so a compromised session must not be able to mint them without reauthentication.

Gated routes:
- `POST   /two-factor/1.0/generate-backup-codes` — mint new recovery codes
- `POST   /two-factor/1.0/totp` — set up / reconfigure TOTP
- `DELETE /two-factor/1.0/totp` — remove TOTP (a downgrade)

## Mechanism

The bridge registers the routes as WP Sudo gated rules via the `wp_sudo_gated_actions` filter, so WP Sudo's existing REST interceptor governs them under its normal policy — a cookie-authenticated browser request is gated (sudo required), an Application Password request follows the operator's REST App-Password policy. **No custom blocking logic** lives in the bridge; it only adds rules. This mirrors the existing `bridges/wp-sudo-webauthn-bridge.php` pattern (same filter, same rule schema, same `class_exists()` runtime integration guard).

Routes/methods were verified against `WordPress/two-factor` master: routes are `two-factor/1.0/totp` (POST + DELETE) and `two-factor/1.0/generate-backup-codes` (POST); `user_id` is a request parameter, not a path segment.

## Scope — this is v1 (REST routes only)

Documented in the file's `KNOWN LIMITS` docblock:
- The classic profile-form provider toggle / classic-form TOTP-key writes are **not** gated here — they need an effect-level guard with an idempotent, enrollment-excluding change predicate, and are a tracked follow-up.
- A blocked request from the Two Factor *settings UI* (`apiFetch`) receives a `sudo_required` JSON 403 it can't yet recover from in place — the `challenge_url` follow-up will improve this.
- Recovery-code generation via WP-CLI or a direct PHP call is not gated (governed instead by WP Sudo's non-interactive surface policy).
- First-time enrollment is intentionally not blocked here.

## Tests

`tests/Unit/TwoFactorLifecycleBridgeTest.php` (2 tests, `@coversNothing` for the procedural bridge):
- both rules are well-formed for the Action Registry (non-empty id/label/category, null admin/ajax, valid rest matcher);
- the anchored route regexes/methods match exactly the verified endpoints (`/totp` does **not** match `/totp/extra`; backup-codes does **not** match `/totp` or `/wp/v2/users/1`).

The "Two Factor absent → inert" branch is intentionally not unit-tested because `tests/bootstrap.php` unconditionally stubs `Two_Factor_Core`; this is documented in the test class docblock and the guard mirrors the other bridges' one-liner.

## Gates

- `composer test:unit` — 880 tests / 2569 assertions ✅
- `composer analyse` — PHPStan L6 + Psalm clean ✅ (baselined the known `wp_sudo_gated_actions` `HookNotFound` Psalm false positive, identical to the existing webauthn-bridge entry)
- `composer verify:metrics` — in sync (`docs/current-metrics.md` updated: 880/2569, 28 unit files, line counts) ✅
- Pre-commit reviewer: **APPROVED**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NvgBLDNajHatAH9eG59LVh)_