### PR TITLE
test(integration): destroy_all invariant + live escalation-guard hook coverage

### DIFF
--- a/docs/current-metrics.md
+++ b/docs/current-metrics.md
@@ -11,19 +11,19 @@ Verification environment: local workspace, PHP 8.x
 |---|---:|---|
 | Unit tests | 880 tests | `composer test:unit` |
 | Unit assertions | 2569 assertions | `composer test:unit` |
-| Integration tests in suite | 196 test methods | `rg -c "function test" tests/Integration/*.php | awk -F: '{sum+=$2} END{print sum}'` |
+| Integration tests in suite | 201 test methods | `rg -c "function test" tests/Integration/*.php | awk -F: '{sum+=$2} END{print sum}'` |
 | Unit test files | 28 | `ls tests/Unit/*.php | wc -l` |
-| Integration test files | 26 | `ls tests/Integration/*.php | wc -l` |
+| Integration test files | 27 | `ls tests/Integration/*.php | wc -l` |
 
 ## Size Metrics
 
 | Metric | Value | Verification |
 |---|---:|---|
 | Production PHP lines (`includes/`, `wp-sudo.php`, `uninstall.php`, `mu-plugin/`, `bridges/`) | 15,909 | `find ./includes ./wp-sudo.php ./uninstall.php ./mu-plugin ./bridges -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
-| Tests PHP lines (`tests/`) | 31,565 | `find ./tests -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
-| Production + tests PHP lines | 47,474 | sum of the two rows above |
-| Test-to-production ratio | 1.98:1 | `31565 / 15909` |
-| Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`) | 47,737 | `find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/vendor_test/*" ! -path "*/.tmp/*" ! -path "*/.git/*" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Tests PHP lines (`tests/`) | 31,875 | `find ./tests -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Production + tests PHP lines | 47,784 | sum of the two rows above |
+| Test-to-production ratio | 2.00:1 | `31875 / 15909` |
+| Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`) | 48,047 | `find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/vendor_test/*" ! -path "*/.tmp/*" ! -path "*/.git/*" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
 
 ## Architectural Facts
 

--- a/tests/Integration/EscalationGuardTest.php
+++ b/tests/Integration/EscalationGuardTest.php
@@ -1,0 +1,238 @@
+<?php
+/**
+ * Live-hook integration coverage for the role-aware admin-escalation guard.
+ *
+ * Gate::arm_escalation_guard() ships unit-tested only (Brain\Monkey-mocked). It
+ * is armed unconditionally during Gate::register() at plugin init, then gated at
+ * runtime by the opt-in `wp_sudo_guard_escalation` filter (default OFF). These
+ * tests drive the REAL `update_user_metadata` and `grant_super_admin` hooks under
+ * WordPress + a database, asserting behaviour a mocked test cannot: that the
+ * request actually halts (wp_die → WPDieException) BEFORE the capabilities write
+ * persists, that a genuinely bound sudo session lets the grant through, and that
+ * the multisite super-admin grant leaves the network `site_admins` option intact.
+ *
+ * @package WP_Sudo\Tests\Integration
+ */
+
+namespace WP_Sudo\Tests\Integration;
+
+use WP_Sudo\Sudo_Session;
+
+/**
+ * Integration tests for the escalation guard's live hooks.
+ */
+class EscalationGuardTest extends TestCase {
+
+	/**
+	 * The guard hooks are armed process-globally, so the opt-in filters a test
+	 * enables must be removed here or their enabled state leaks to later tests.
+	 * (The base teardown resets neither arbitrary filters nor defined constants;
+	 * this guard deliberately defines no WP_SUDO_ALLOW_ESCALATION constant.)
+	 */
+	public function tear_down(): void {
+		remove_filter( 'wp_sudo_guard_escalation', '__return_true' );
+		remove_filter( 'wp_sudo_allow_escalation', '__return_true' );
+		parent::tear_down();
+	}
+
+	/**
+	 * Turn the (default-OFF) guard on for the current test.
+	 */
+	private function enable_guard(): void {
+		add_filter( 'wp_sudo_guard_escalation', '__return_true' );
+	}
+
+	/**
+	 * Establish a genuinely bound, active sudo session for $user and make them the
+	 * current user — mirrors the real activate() binding (login token in the store
+	 * + matching logged-in cookie), so is_active() verifies for the right reason.
+	 *
+	 * @param \WP_User $user The actor.
+	 */
+	private function grant_bound_session( \WP_User $user ): void {
+		wp_set_current_user( $user->ID );
+
+		$expiration                  = time() + DAY_IN_SECONDS;
+		$manager                     = \WP_Session_Tokens::get_instance( $user->ID );
+		$token                       = $manager->create( $expiration );
+		$_COOKIE[ LOGGED_IN_COOKIE ] = wp_generate_auth_cookie( $user->ID, $expiration, 'logged_in', $token );
+
+		Sudo_Session::activate( $user->ID );
+		Sudo_Session::reset_cache();
+		$this->assertTrue(
+			Sudo_Session::is_active( $user->ID ),
+			'Precondition: the actor holds an active bound sudo session.'
+		);
+	}
+
+	/**
+	 * Read a user's persisted roles with a cache-bypassing fresh fetch, so an
+	 * in-memory WP_User object mutated by an interrupted set_role() cannot mask
+	 * whether the capabilities write actually reached the database.
+	 *
+	 * @param int $user_id User ID.
+	 * @return array<int, string>
+	 */
+	private function persisted_roles( int $user_id ): array {
+		clean_user_cache( $user_id );
+		$fresh = get_user_by( 'id', $user_id );
+
+		return $fresh instanceof \WP_User ? array_values( (array) $fresh->roles ) : array();
+	}
+
+	/**
+	 * With the guard enabled and NO active session, promoting a subscriber to
+	 * administrator hard-blocks: the request halts before the capabilities write
+	 * persists, and the high-severity wp_sudo_escalation_blocked action fires.
+	 *
+	 * Users are created BEFORE the guard is enabled — creating the admin actor
+	 * with the guard on would itself be a guarded administrator grant.
+	 */
+	public function test_new_admin_grant_blocked_without_session(): void {
+		$actor = $this->make_admin(); // Logged in, but holds no sudo session.
+		wp_set_current_user( $actor->ID );
+		$target = self::factory()->user->create_and_get( array( 'role' => 'subscriber' ) );
+
+		$this->enable_guard();
+
+		$blocked = 0;
+		add_action(
+			'wp_sudo_escalation_blocked',
+			static function () use ( &$blocked ) {
+				++$blocked;
+			},
+			10,
+			0
+		);
+
+		$halted = false;
+		try {
+			$target->set_role( 'administrator' );
+		} catch ( \WPDieException $e ) {
+			$halted = true;
+		}
+
+		$this->assertTrue( $halted, 'The grant must halt the request via wp_die().' );
+		$this->assertSame( 1, $blocked, 'wp_sudo_escalation_blocked must fire exactly once.' );
+		$this->assertNotContains(
+			'administrator',
+			$this->persisted_roles( $target->ID ),
+			'The administrator grant must NOT persist (halt before the capabilities write).'
+		);
+	}
+
+	/**
+	 * With the guard enabled and a genuinely bound, active actor session, the same
+	 * promotion is allowed: no halt, no escalation event, and the grant persists.
+	 */
+	public function test_new_admin_grant_allowed_with_bound_session(): void {
+		$actor = $this->make_admin();
+		$this->grant_bound_session( $actor );
+		$target = self::factory()->user->create_and_get( array( 'role' => 'subscriber' ) );
+
+		$this->enable_guard();
+
+		$blocked = 0;
+		add_action(
+			'wp_sudo_escalation_blocked',
+			static function () use ( &$blocked ) {
+				++$blocked;
+			},
+			10,
+			0
+		);
+
+		$halted = false;
+		try {
+			$target->set_role( 'administrator' );
+		} catch ( \WPDieException $e ) {
+			$halted = true;
+		}
+
+		$this->assertFalse( $halted, 'A bound, active session must allow the grant.' );
+		$this->assertSame( 0, $blocked, 'No escalation event fires when the actor holds a session.' );
+		$this->assertContains(
+			'administrator',
+			$this->persisted_roles( $target->ID ),
+			'The grant persists when the actor holds an active sudo session.'
+		);
+	}
+
+	/**
+	 * Default-OFF posture, end to end: with the filter NOT enabled, arming the
+	 * hooks must not change behaviour — a normal administrator promotion succeeds
+	 * even with no session, so SSO/provisioning flows are unaffected until opt-in.
+	 */
+	public function test_default_off_allows_admin_grant_without_session(): void {
+		$target = self::factory()->user->create_and_get( array( 'role' => 'subscriber' ) );
+		wp_set_current_user( 0 );
+
+		$blocked = 0;
+		add_action(
+			'wp_sudo_escalation_blocked',
+			static function () use ( &$blocked ) {
+				++$blocked;
+			},
+			10,
+			0
+		);
+
+		// Guard is OFF (no enable_guard()): this must complete without halting.
+		$target->set_role( 'administrator' );
+
+		$this->assertSame( 0, $blocked, 'The default-OFF guard fires no escalation event.' );
+		$this->assertContains(
+			'administrator',
+			$this->persisted_roles( $target->ID ),
+			'With the guard off, a normal administrator grant persists.'
+		);
+	}
+
+	/**
+	 * Multisite: granting super admin with the guard enabled and no session halts
+	 * before the network `site_admins` option is written. grant_super_admin() does
+	 * NOT touch the capabilities meta, so this exercises the separate action guard.
+	 */
+	public function test_super_admin_grant_blocked_without_session_on_multisite(): void {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'grant_super_admin() is a multisite-only path.' );
+		}
+
+		$actor = $this->make_admin();
+		wp_set_current_user( $actor->ID );
+		$target = self::factory()->user->create_and_get( array( 'role' => 'administrator' ) );
+		$this->assertFalse(
+			is_super_admin( $target->ID ),
+			'Precondition: the target is not already a super admin (an idempotent re-grant would pass).'
+		);
+
+		$this->enable_guard();
+
+		$blocked = 0;
+		add_action(
+			'wp_sudo_escalation_blocked',
+			static function () use ( &$blocked ) {
+				++$blocked;
+			},
+			10,
+			0
+		);
+
+		$halted = false;
+		try {
+			grant_super_admin( $target->ID );
+		} catch ( \WPDieException $e ) {
+			$halted = true;
+		}
+
+		$this->assertTrue( $halted, 'grant_super_admin() must halt without an active session.' );
+		$this->assertSame( 1, $blocked, 'wp_sudo_escalation_blocked must fire once for the super-admin grant.' );
+
+		$super_admins = get_super_admins();
+		$this->assertNotContains(
+			$target->user_login,
+			is_array( $super_admins ) ? $super_admins : array(),
+			'The super-admin grant must NOT persist (site_admins network option unchanged).'
+		);
+	}
+}

--- a/tests/Integration/SudoSessionTest.php
+++ b/tests/Integration/SudoSessionTest.php
@@ -284,4 +284,76 @@ class SudoSessionTest extends TestCase {
 			'Logout clears the sudo token meta.'
 		);
 	}
+
+	/**
+	 * INTG-F2: destroying ALL of a user's login sessions (an admin "log out
+	 * everywhere" / forced session revocation) ends the sudo window on the next
+	 * request — even though destroy_all() fires no wp_logout and changes no
+	 * password, so WP Sudo's own token/bind meta is never signalled to clear.
+	 *
+	 * This covers a mechanism distinct from the two tests above:
+	 *  - test_binding_rejects_when_login_session_token_changes keeps the user
+	 *    logged in under a *different* session (bind-mismatch branch).
+	 *  - test_logout_deactivates_bound_session clears WP Sudo meta directly via the
+	 *    wp_logout handler.
+	 * Here the sudo token meta and bind survive untouched; the proof stops
+	 * verifying solely because the destroyed session invalidates the auth cookie,
+	 * so the NEXT request is unauthenticated and verify_token()'s current-user
+	 * guard fails closed. It proves WP Sudo rides on core auth rather than holding
+	 * an independent grant that outlives the login it was minted under.
+	 *
+	 * Note: the effect is a next-request, core-auth-cookie invalidation, not a
+	 * same-request change to WP Sudo's bind — verify_token() resolves the bind from
+	 * the cookie's token string (wp_get_session_token()), which does not consult the
+	 * emptied session store mid-request. Asserting is_active() === false on the
+	 * SAME request would encode a false invariant; the test models the next request.
+	 */
+	public function test_destroy_all_sessions_ends_sudo_on_next_request(): void {
+		$user = $this->make_admin();
+		wp_set_current_user( $user->ID );
+
+		$expiration                  = time() + DAY_IN_SECONDS;
+		$manager                     = \WP_Session_Tokens::get_instance( $user->ID );
+		$token                       = $manager->create( $expiration );
+		$_COOKIE[ LOGGED_IN_COOKIE ] = wp_generate_auth_cookie( $user->ID, $expiration, 'logged_in', $token );
+
+		Sudo_Session::activate( $user->ID );
+		Sudo_Session::reset_cache();
+		$this->assertTrue( Sudo_Session::is_active( $user->ID ), 'Active before destroy_all().' );
+
+		// Precondition: the login cookie authenticates while its token is in the store.
+		$this->assertSame(
+			$user->ID,
+			wp_validate_auth_cookie( $_COOKIE[ LOGGED_IN_COOKIE ], 'logged_in' ),
+			'Precondition: the login cookie authenticates the user.'
+		);
+
+		// Destroy every login session for this user. This neither fires wp_logout
+		// nor changes the password, so WP Sudo's token/bind meta is left intact.
+		$manager->destroy_all();
+
+		// The auth cookie no longer validates — its token is gone from the store.
+		$this->assertFalse(
+			wp_validate_auth_cookie( $_COOKIE[ LOGGED_IN_COOKIE ], 'logged_in' ),
+			'destroy_all() invalidates the login cookie.'
+		);
+
+		// WP Sudo's own state was NOT proactively cleared: the next-request auth
+		// failure is the only thing standing between a stale proof and replay.
+		$this->assertNotEmpty(
+			get_user_meta( $user->ID, Sudo_Session::TOKEN_META_KEY, true ),
+			'destroy_all() does not clear WP Sudo token meta (no wp_logout / password change).'
+		);
+
+		// Model the next request: the invalid cookie means WordPress resolves no
+		// authenticated user. A logged-out request must see no active sudo session,
+		// because verify_token() requires the proof's user to be the current user.
+		wp_set_current_user( 0 );
+		Sudo_Session::reset_cache();
+
+		$this->assertFalse(
+			Sudo_Session::is_active( $user->ID ),
+			'After destroy_all(), the next (logged-out) request has no active sudo session.'
+		);
+	}
 }


### PR DESCRIPTION
## Summary

Tier 1 testing-backlog hardening — backfills real-WordPress integration coverage for behavior that previously had only unit (mocked) or no integration tests. **No production code changes** (production diff: 0 lines).

## `destroy_all()` session invariant — `SudoSessionTest`

Adds `test_destroy_all_sessions_ends_sudo_on_next_request()`. Destroying all of a user's login sessions (an admin "log out everywhere" / forced session revocation) ends the sudo window on the **next** request — even though `destroy_all()` fires no `wp_logout` and changes no password, so WP Sudo's token/bind meta is left intact.

The design (design-reviewed) hinges on a subtlety: `verify_token()` resolves the bind from the cookie's token string via `wp_get_session_token()`, which does **not** consult the emptied session store mid-request. Asserting `is_active()===false` on the *same* request would encode a false invariant, so the test models the next request:
1. activate a bound session; assert the login cookie validates (`wp_validate_auth_cookie`);
2. `destroy_all()`; assert the cookie no longer validates;
3. assert WP Sudo's `TOKEN_META_KEY` is **untouched** (proving it rides on core auth, not an independent grant);
4. model the next request (`wp_set_current_user(0)`); assert `is_active()===false` (the current-user guard fails closed).

Covers a mechanism distinct from the existing token-change test (different login session, user stays logged in) and the `wp_logout` test (clears meta directly).

## Escalation-guard live hooks — new `EscalationGuardTest`

Exercises `Gate::arm_escalation_guard`'s **real** `update_user_metadata` and `grant_super_admin` hooks (armed at plugin init, gated by the opt-in `wp_sudo_guard_escalation` filter, default OFF) — coverage a mocked unit test can't provide:

- **blocked without a session** — `set_role('administrator')` halts via `wp_die` (`WPDieException`) before the capabilities write persists; `wp_sudo_escalation_blocked` fires once; the admin role does not reach the DB (cache-bypassing read-back).
- **allowed with a genuinely bound, active session** — builds the real binding (login token in `WP_Session_Tokens` + matching `LOGGED_IN_COOKIE` + `Sudo_Session::activate`); the same promotion succeeds.
- **default OFF** — arming the hooks does not change default behavior (promotion succeeds with no session).
- **multisite super-admin** — `markTestSkipped` on single-site; otherwise the grant halts without writing the network `site_admins` option.

Incorporates all three design-review blocker resolutions: `try/catch(WPDieException)` so post-halt DB state can be asserted; explicit teardown of the opt-in filters (hooks are armed process-globally); no leaking `WP_SUDO_ALLOW_ESCALATION` constant; users created before enabling the guard; state read via real hooks + fresh DB reads (no new production accessors, no reflection needed).

## Tier-1 item 3 — PHP 8.2 integration CI lane

Already present in `.github/workflows/phpunit.yml` (lines ~170–200) — **no workflow change needed**.

## Gates

- `composer test:unit` — 880 / 2569 ✅ (integration files not picked up by the unit suite)
- `composer analyse` — PHPStan + Psalm clean ✅
- `composer verify:metrics` — in sync ✅ (integration methods 196→201, files 26→27, ratio 2.00:1)
- Pre-commit reviewer: **APPROVED** (verified every assertion against the live production code)

Note: `composer test:integration` requires WordPress + MySQL and runs only in CI — expected for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NvgBLDNajHatAH9eG59LVh)_