### PR TITLE
ci: rebalance e2e baseline shard

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -76,14 +76,14 @@ jobs:
             group-total: 4
             group-name: challenge-basic-admin
             test-command: |
-              npm run test:e2e -- tests/e2e/specs/admin-bar-deactivate.spec.ts tests/e2e/specs/admin-bar-timer.spec.ts tests/e2e/specs/challenge.spec.ts --grep 'ABAR|TIMR|CHAL-0[1-5]'
+              npm run test:e2e -- tests/e2e/specs/admin-bar-deactivate.spec.ts tests/e2e/specs/challenge.spec.ts --grep 'ABAR|CHAL-0[1-5]'
               npm run test:e2e -- tests/e2e/specs/challenge.spec.ts --grep 'CHAL-09|CHAL-10|CHAL-11'
           - group-index: 2
             group-total: 4
             group-name: challenge-2fa-ui
             test-command: |
               npm run test:e2e -- tests/e2e/specs/challenge.spec.ts --grep 'CHAL-0[6-8]'
-              npm run test:e2e -- tests/e2e/specs/cookie.spec.ts tests/e2e/specs/gate-ui.spec.ts tests/e2e/specs/keyboard.spec.ts
+              npm run test:e2e -- tests/e2e/specs/admin-bar-timer.spec.ts tests/e2e/specs/cookie.spec.ts tests/e2e/specs/gate-ui.spec.ts tests/e2e/specs/keyboard.spec.ts
           - group-index: 3
             group-total: 4
             group-name: challenge-lockout-surfaces

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -10,19 +10,19 @@
 
 ### Runtime Evidence
 
-- [ ] **E2E-01**: Maintainers can refresh the latest `E2E Tests` 1/4 through 4/4 GitHub Actions job durations immediately before changing the workflow.
-- [ ] **E2E-02**: The rebalance decision identifies the current long pole and the shortest suitable destination group using refreshed Actions data, not local timing assumptions.
+- [x] **E2E-01**: Maintainers can refresh the latest `E2E Tests` 1/4 through 4/4 GitHub Actions job durations immediately before changing the workflow.
+- [x] **E2E-02**: The rebalance decision identifies the current long pole and the shortest suitable destination group using refreshed Actions data, not local timing assumptions.
 
 ### Workflow Rebalance
 
-- [ ] **E2E-03**: The required baseline `.github/workflows/e2e.yml` matrix still has exactly four groups and the same final required `E2E Tests` gate.
-- [ ] **E2E-04**: A small, low-risk test slice is moved out of `E2E Tests 1/4 (challenge-basic-admin)` without skipping specs, removing surfaces, or moving coverage to manual-only validation.
-- [ ] **E2E-05**: The workflow comments or adjacent documentation explain the rebalance rationale and preserve the fixed `wp-env` startup-floor constraint.
+- [x] **E2E-03**: The required baseline `.github/workflows/e2e.yml` matrix still has exactly four groups and the same final required `E2E Tests` gate.
+- [x] **E2E-04**: A small, low-risk test slice is moved out of `E2E Tests 1/4 (challenge-basic-admin)` without skipping specs, removing surfaces, or moving coverage to manual-only validation.
+- [x] **E2E-05**: The workflow comments or adjacent documentation explain the rebalance rationale and preserve the fixed `wp-env` startup-floor constraint.
 
 ### Verification and Documentation
 
-- [ ] **E2E-06**: Required GitHub CI passes after the workflow change, including all four baseline E2E groups.
-- [ ] **E2E-07**: `docs/e2e-runtime-review.md` records the rebalance implementation, validation run, and whether the long-pole runtime improved enough to keep the change.
+- [x] **E2E-06**: Required GitHub CI passes after the workflow change, including all four baseline E2E groups.
+- [x] **E2E-07**: `docs/e2e-runtime-review.md` records the rebalance implementation, validation run, and whether the long-pole runtime improved enough to keep the change.
 
 ## Future Requirements
 
@@ -43,13 +43,13 @@
 
 | Requirement | Phase | Status |
 |-------------|-------|--------|
-| E2E-01 | Phase 20 | Pending |
-| E2E-02 | Phase 20 | Pending |
-| E2E-03 | Phase 20 | Pending |
-| E2E-04 | Phase 20 | Pending |
-| E2E-05 | Phase 20 | Pending |
-| E2E-06 | Phase 20 | Pending |
-| E2E-07 | Phase 20 | Pending |
+| E2E-01 | Phase 20 | Complete |
+| E2E-02 | Phase 20 | Complete |
+| E2E-03 | Phase 20 | Complete |
+| E2E-04 | Phase 20 | Complete |
+| E2E-05 | Phase 20 | Complete |
+| E2E-06 | Phase 20 | Complete |
+| E2E-07 | Phase 20 | Complete |
 
 **Coverage:**
 - v1 requirements: 7 total
@@ -58,4 +58,4 @@
 
 ---
 *Requirements defined: 2026-06-29*
-*Last updated: 2026-06-29 — v4.3.1 milestone requirements created.*
+*Last updated: 2026-06-29 — Phase 20 completed; all v4.3.1 requirements marked complete.*

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -7,7 +7,7 @@
 # Active Roadmap: Milestone v4.3.1 — E2E Shard Rebalance
 
 **Milestone:** v4.3.1
-**Status:** Planned
+**Status:** Complete
 **Previous milestone last phase:** 19 (2FA Bridge Planning and Compatibility Matrix, v4.3.0)
 **Phase numbering continues from:** 20
 
@@ -15,7 +15,7 @@
 
 ## Phases
 
-- [ ] **Phase 20: Baseline E2E Shard Rebalance** — Refresh current Actions evidence, move one small low-risk test slice out of group 1 into the shortest suitable existing group, and verify/document the result.
+- [x] **Phase 20: Baseline E2E Shard Rebalance** — Refresh current Actions evidence, move one small low-risk test slice out of group 1 into the shortest suitable existing group, and verify/document the result. (completed 2026-06-29)
 
 ## Phase Details
 
@@ -34,13 +34,13 @@
 4. CI passes on the resulting branch/PR, including `E2E Tests 1/4` through `4/4` and the final gate.
 5. `docs/e2e-runtime-review.md` records the implementation, validation run, and whether observed timing supports keeping the rebalance.
 
-**Plans:** 0/1 planned
+**Plans:** 1/1 plans complete
 
 Plans:
-- [ ] 20-01-PLAN.md — Refresh E2E runtime evidence, rebalance one low-risk test slice within the existing four-group matrix, and document/verify the result.
+- [x] 20-01-PLAN.md — Refresh E2E runtime evidence, rebalance one low-risk test slice within the existing four-group matrix, and document/verify the result. (completed 2026-06-29)
 
 ## Progress
 
 | Phase | Milestone | Plans Complete | Status | Completed |
 |-------|-----------|----------------|--------|-----------|
-| 20. Baseline E2E Shard Rebalance | v4.3.1 | 0/1 | Planned | - |
+| 20. Baseline E2E Shard Rebalance | v4.3.1 | 1/1 | Complete | 2026-06-29 |

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,43 +2,42 @@
 gsd_state_version: 1.0
 milestone: v4.3.1
 milestone_name: E2E Shard Rebalance
-status: planned
-last_updated: "2026-06-29T21:45:00Z"
-last_activity: "2026-06-29 — v4.3.1 E2E Shard Rebalance milestone started; active phase directory created."
+status: complete
+last_updated: "2026-06-29T22:24:56Z"
+last_activity: "2026-06-29 — Phase 20 completed on ci/e2e-shard-rebalance; PR #129 documents and validates the E2E shard rebalance."
 progress:
   total_phases: 1
-  completed_phases: 0
+  completed_phases: 1
   total_plans: 1
-  completed_plans: 0
+  completed_plans: 1
 ---
 
 ## Current Position
 
-Phase: 20 — Baseline E2E Shard Rebalance is planned and ready for discussion/planning.
-Plan: 20-01 planned, not yet written.
-Status: Defining/planning next execution phase.
-Branch: main — latest pushed commit archives v4.3.0 planning milestone after PR #127 merge. Latest tagged plugin release remains `v4.2.2`; product version metadata was not bumped.
-Done & merged to main: v4.3.0 planning milestone archived; PR #127 Playwright 1.61.1 bump merged and green.
-Open threads: Implement the no-coverage-loss E2E shard-rebalance follow-up. WordPress.org submission remains intentionally delayed/on hold; keep `docs/wporg-submission-checklist.md` ready. Patchstack paid-fixture/manual runtime testing remains a separate pending candidate.
-Resume file: `.planning/phases/20-baseline-e2e-shard-rebalance/20-CONTEXT.md` — Phase 20 context exists. Next command: `$gsd-discuss-phase 20` or `$gsd-plan-phase 20`.
-Last activity: 2026-06-29 — v4.3.1 E2E Shard Rebalance milestone started; requirements, roadmap, and active phase directory created.
+Phase: 20 — Baseline E2E Shard Rebalance is complete.
+Plan: 20-01 complete; summary written at `.planning/phases/20-baseline-e2e-shard-rebalance/20-01-SUMMARY.md`.
+Status: Milestone v4.3.1 complete and ready for `$gsd-complete-milestone` after PR #129 is merged.
+Branch: `ci/e2e-shard-rebalance` — pushed; PR #129 open against `main`. Latest tagged plugin release remains `v4.2.2`; product version metadata was not bumped.
+Done & validated: TIMR/admin-bar-timer moved from E2E group 1 to group 2; GitHub Actions run 28406226487 passed all four E2E shards and final `E2E Tests` gate.
+Open threads: Merge PR #129 when checks/review are acceptable. WordPress.org submission remains intentionally delayed/on hold; keep `docs/wporg-submission-checklist.md` ready. Patchstack paid-fixture/manual runtime testing remains a separate pending candidate.
+Resume file: None.
 
 ## Project Reference
 
 Canonical current facts:
 
-- `docs/e2e-runtime-review.md` — runtime evidence and rebalance decision source.
+- `docs/e2e-runtime-review.md` — runtime evidence, Phase 20 implementation, validation run, and keep decision.
 - `docs/release-status.md` — tagged/package release state and WordPress.org publication status.
 - `docs/current-metrics.md` — current test, size, and architectural counts.
 - `docs/ROADMAP.md` — product roadmap and priority order.
 - `CHANGELOG.md` — shipped release contents.
 
 **Core value:** Every destructive admin action requires proof the person at the keyboard is still the authenticated user.
-**Current focus:** v4.3.1 E2E Shard Rebalance. Refresh Actions runtime evidence, rebalance one small low-risk test slice within the existing four required E2E groups, and document CI results. Latest tagged release is **4.2.2** (see `docs/release-status.md`). WordPress.org submission (`docs/wporg-submission-checklist.md`) is delayed/on hold, but readiness should be maintained.
+**Current focus:** v4.3.1 E2E Shard Rebalance is complete. Latest tagged release is **4.2.2** (see `docs/release-status.md`). WordPress.org submission (`docs/wporg-submission-checklist.md`) is delayed/on hold, but readiness should be maintained.
 
 ## Active Priorities
 
-1. ○ **20 — Baseline E2E Shard Rebalance** (E2E-01 through E2E-07): planned — refresh current GitHub Actions runtimes, rebalance one small group-1 test slice within the current four-group matrix, and verify/document the CI outcome.
+1. ✓ **20 — Baseline E2E Shard Rebalance** (E2E-01 through E2E-07): complete — refreshed Actions evidence, rebalanced one small group-1 test slice within the current four-group matrix, and verified/documented CI outcome.
 
 ## Accumulated Context
 
@@ -47,15 +46,17 @@ Canonical current facts:
 - Current test and size counts are centralized in `docs/current-metrics.md`.
 - WordPress 7.0 GA shipped May 20, 2026; package metadata says `Tested up to: 7.0`.
 - This plugin is not currently published to the WordPress.org plugin repository.
+- PR #129 validation run: https://github.com/dknauss/Sudo/actions/runs/28406226487.
 
 ### Pending Todos
 
 - Patchstack runtime testing remains pending: acquire a paid Patchstack-enabled fixture plus manual challenge/lifecycle runtime tests before making runtime support claims.
-- E2E shard rebalance is now the active milestone: refresh Actions data before editing `.github/workflows/e2e.yml`.
 
 ## Key Decisions
 
 - GitHub Actions job timestamps are the source of truth for E2E runtime tuning decisions; no local Playwright/browser timings should drive the rebalance.
 - Rebalance within the existing four required E2E groups before adding parallelism because each group pays the fixed `wp-env` startup floor.
+- Move `tests/e2e/specs/admin-bar-timer.spec.ts` / `TIMR` from group 1 to group 2 based on refreshed Actions evidence.
+- Keep the rebalance because PR #129 passed all four E2E shard jobs and the final gate on run 28406226487.
 - Keep WordPress.org submission delayed/on hold while maintaining readiness.
 - Do not create a product release tag from a GSD planning milestone unless plugin version metadata is intentionally bumped.

--- a/.planning/phases/20-baseline-e2e-shard-rebalance/20-01-SUMMARY.md
+++ b/.planning/phases/20-baseline-e2e-shard-rebalance/20-01-SUMMARY.md
@@ -1,0 +1,108 @@
+---
+phase: 20-baseline-e2e-shard-rebalance
+plan: 01
+subsystem: ci
+tags: [github-actions, e2e, playwright, wp-env, runtime-evidence]
+requires:
+  - phase: 18
+    provides: Phase 18 runtime evidence and recommendation to rebalance within the existing four required E2E groups before adding parallelism
+provides:
+  - Refreshed GitHub Actions E2E runtime snapshot collected before the workflow edit
+  - Four-group required E2E matrix with the TIMR/admin-bar-timer slice moved from group 1 to group 2
+  - GitHub CI validation evidence for PR #129, including all four E2E shards and final gate
+  - Documented keep decision for the rebalance
+affects: [e2e, ci, release-readiness, github-actions]
+tech-stack:
+  added: []
+  patterns:
+    - Use GitHub Actions job timestamps, not local Playwright timings, for shard rebalance decisions
+    - Preserve the four-group baseline E2E matrix and final required gate while redistributing small slices
+key-files:
+  created:
+    - .planning/phases/20-baseline-e2e-shard-rebalance/20-01-SUMMARY.md
+  modified:
+    - .github/workflows/e2e.yml
+    - docs/e2e-runtime-review.md
+key-decisions:
+  - "Moved `tests/e2e/specs/admin-bar-timer.spec.ts` / `TIMR` from E2E group 1 to group 2 because refreshed Actions evidence showed group 1 as the long pole and group 2 as the shortest suitable destination."
+  - "Kept the rebalance after PR #129 passed all four E2E shard jobs and the final `E2E Tests` gate on GitHub Actions run 28406226487."
+  - "Retained exactly four required E2E groups rather than adding parallelism because every group pays the fixed `wp-env` startup floor."
+patterns-established:
+  - "E2E runtime reviews should record exact Actions run IDs, group durations, group conclusions, and keep/revert decisions."
+  - "Shard rebalances must preserve required-check semantics: four baseline groups plus final `E2E Tests` gate."
+requirements-completed:
+  - E2E-01
+  - E2E-02
+  - E2E-03
+  - E2E-04
+  - E2E-05
+  - E2E-06
+  - E2E-07
+duration: 39min
+completed: 2026-06-29
+---
+
+# Phase 20 Plan 01: Baseline E2E Shard Rebalance Summary
+
+**GitHub Actions-backed E2E shard rebalance moved the timer slice from group 1 to group 2 while preserving the four-group required gate.**
+
+## Performance
+
+- **Duration:** 39 min
+- **Started:** 2026-06-29T21:45:00Z
+- **Completed:** 2026-06-29T22:24:30Z
+- **Tasks:** 3 completed
+- **Files modified:** 3
+
+## Accomplishments
+
+- Refreshed current GitHub Actions E2E group timing evidence immediately before editing the workflow.
+- Identified `E2E Tests 1/4 (challenge-basic-admin)` as the current long pole and `E2E Tests 2/4 (challenge-2fa-ui)` as the shortest suitable destination group.
+- Moved `tests/e2e/specs/admin-bar-timer.spec.ts` / `TIMR` from group 1 to group 2 without deleting specs, skipping coverage, changing group count, or changing the final required `E2E Tests` gate.
+- Opened PR #129 and validated the changed workflow with GitHub Actions run 28406226487: all four E2E shard jobs and the final gate passed.
+- Recorded the implementation, exact run URL, shard durations, conclusions, and keep/revert decision in `docs/e2e-runtime-review.md`.
+
+## Task Commits
+
+1. **Tasks 1-2: Refresh evidence and rebalance workflow** — `316bc60` (`ci: rebalance e2e baseline shard`)
+2. **Task 3: Record GitHub CI validation evidence** — `20ca4cf` (`docs: record phase 20 e2e validation`)
+
+**Plan metadata:** this summary commit.
+
+## Files Created/Modified
+
+- `.github/workflows/e2e.yml` — Removed `admin-bar-timer.spec.ts` / `TIMR` from group 1 and added the timer spec to group 2 while preserving the four-group matrix and final gate.
+- `docs/e2e-runtime-review.md` — Added Phase 20 refresh evidence, implementation rationale, PR #129 validation run, per-shard durations/conclusions, and keep decision.
+- `.planning/phases/20-baseline-e2e-shard-rebalance/20-01-SUMMARY.md` — Captures execution outcome and traceability.
+
+## Decisions Made
+
+- Moved the timer slice because refreshed Actions data showed group 1 averaging 407.9 seconds versus group 2 at 265.8 seconds across eight successful comparable observations.
+- Kept the rebalance because PR #129 run 28406226487 passed with group durations of 367s, 320s, 329s, and 289s, plus a successful final gate.
+- Stayed within four groups to avoid another fixed `wp-env` startup floor and preserve required-check semantics.
+
+## Deviations from Plan
+
+None — plan executed as written. The validation note was committed after the first implementation commit so the documentation could include the exact PR and CI run evidence.
+
+## Issues Encountered
+
+None.
+
+## User Setup Required
+
+None — no external service configuration required.
+
+## Next Phase Readiness
+
+Phase 20 is ready for transition/completion. PR #129 contains the rebalance and validation documentation. If future E2E evidence shows a new long pole, use the same Actions-run-ID evidence pattern before any additional shard movement.
+
+---
+*Phase: 20-baseline-e2e-shard-rebalance*
+*Completed: 2026-06-29*
+
+## Self-Check: PASSED
+
+- Summary frontmatter includes all Phase 20 requirement IDs.
+- `docs/e2e-runtime-review.md` includes pre-edit refresh evidence and post-change validation evidence.
+- GitHub Actions run 28406226487 passed all four E2E shard jobs and the final gate.

--- a/.planning/phases/20-baseline-e2e-shard-rebalance/20-VERIFICATION.md
+++ b/.planning/phases/20-baseline-e2e-shard-rebalance/20-VERIFICATION.md
@@ -1,0 +1,82 @@
+---
+phase: 20-baseline-e2e-shard-rebalance
+verified: 2026-06-29T22:41:10Z
+status: passed
+score: 6/6 must-haves verified
+---
+
+# Phase 20: Baseline E2E Shard Rebalance Verification Report
+
+**Phase Goal:** The required four-group E2E matrix has a better-balanced critical path while preserving the same coverage, same required gate, and same startup-cost-aware group count.
+**Verified:** 2026-06-29T22:41:10Z
+**Status:** passed
+**Re-verification:** No — initial verification
+
+## Goal Achievement
+
+### Observable Truths
+
+| # | Truth | Status | Evidence |
+|---|-------|--------|----------|
+| 1 | Maintainer can see a fresh GitHub Actions runtime snapshot collected before the workflow edit. | ✓ VERIFIED | `docs/e2e-runtime-review.md` has `## Phase 20 refresh`, collected `2026-06-29T22:10:22Z`, with `gh run list` / `gh run view` commands and eight exact run IDs/URLs. |
+| 2 | The rebalance decision names the current long pole and shortest suitable destination group from refreshed Actions data. | ✓ VERIFIED | Docs identify `E2E Tests 1/4 (challenge-basic-admin)` as the 407.9s average long pole and `E2E Tests 2/4 (challenge-2fa-ui)` as the 265.8s shortest suitable destination. |
+| 3 | The required baseline workflow still has exactly four E2E matrix groups and the final required `E2E Tests` gate. | ✓ VERIFIED | Static inspection found group indexes `{1,2,3,4}`, every group has `group-total: 4`, and `e2e-tests` remains `name: "E2E Tests"` with `needs: [changes, e2e-group]`. |
+| 4 | A small low-risk slice leaves group 1 without deleting, skipping, or manualizing spec coverage. | ✓ VERIFIED | `.github/workflows/e2e.yml` removes `admin-bar-timer.spec.ts` / `TIMR` from group 1 and adds `admin-bar-timer.spec.ts` to group 2. Diff adds no `test.skip`, `--grep-invert`, or manual-only behavior. |
+| 5 | GitHub CI passes after the workflow change, including all four baseline E2E groups and the final gate. | ✓ VERIFIED | Run `28406226487` concluded `success`; all four `E2E Tests N/4` jobs and final `E2E Tests` gate succeeded. Latest PR #129 required checks are also green; PR merge state is `CLEAN` at head `b29ce647fb13916944d7893ec34b2ba958b6280a`. |
+| 6 | `docs/e2e-runtime-review.md` records implementation, validation run, and keep/revert decision. | ✓ VERIFIED | Docs include `## Phase 20 validation`, PR #129, run URL `https://github.com/dknauss/Sudo/actions/runs/28406226487`, per-group conclusions/durations, final gate result, and `Keep/revert decision: keep`. |
+
+**Score:** 6/6 truths verified
+
+### Required Artifacts
+
+| Artifact | Expected | Status | Details |
+|----------|----------|--------|---------|
+| `.github/workflows/e2e.yml` | Four-group required baseline E2E matrix with rebalanced test slice | ✓ VERIFIED | Exactly four groups remain; `TIMR`/timer slice moved from group 1 to group 2; final gate unchanged. |
+| `docs/e2e-runtime-review.md` | Runtime evidence, implementation note, CI validation result | ✓ VERIFIED | Contains Phase 20 refresh evidence, rebalance decision, implementation details, validation run, durations, conclusions, and keep decision. |
+| `.planning/REQUIREMENTS.md`, `.planning/ROADMAP.md`, `.planning/STATE.md`, `20-01-SUMMARY.md` | Planning/state traceability | ✓ VERIFIED | Phase 20 is marked complete; all seven E2E requirements are mapped and no Phase 20 requirement is orphaned. |
+
+### Key Link Verification
+
+| From | To | Via | Status | Details |
+|------|----|-----|--------|---------|
+| `docs/e2e-runtime-review.md` | `.github/workflows/e2e.yml` | Refreshed Actions data drives destination group | ✓ WIRED | Docs identify group 1 as long pole and group 2 as destination; workflow reflects the timer slice move to group 2. |
+| `.github/workflows/e2e.yml` | GitHub required checks | Matrix group names and final gate semantics | ✓ WIRED | PR #129 rollup shows `E2E Tests 1/4` through `4/4` and final `E2E Tests` succeeded. |
+| GitHub Actions CI run | `docs/e2e-runtime-review.md` | Exact run URL and durations recorded | ✓ WIRED | Run `28406226487` live GitHub data matches documented success for all four groups and final gate. |
+
+### Requirements Coverage
+
+| Requirement | Source Plan | Description | Status | Evidence |
+|-------------|-------------|-------------|--------|----------|
+| E2E-01 | 20-01-PLAN.md | Refresh latest E2E group durations before workflow change. | ✓ SATISFIED | Phase 20 refresh section includes commands, timestamps, run IDs, URLs, and per-group durations. |
+| E2E-02 | 20-01-PLAN.md | Identify long pole and destination from Actions data, not local assumptions. | ✓ SATISFIED | Docs explicitly state Actions timestamps are source of truth and local Playwright timing assumptions were not used. |
+| E2E-03 | 20-01-PLAN.md | Preserve four-group matrix and final `E2E Tests` gate. | ✓ SATISFIED | Static workflow inspection confirms four groups, `group-total: 4`, final gate name and dependencies. |
+| E2E-04 | 20-01-PLAN.md | Move small slice without skipping/removing/manualizing coverage. | ✓ SATISFIED | Timer spec moved from group 1 to group 2; no added skip/manual-only patterns. |
+| E2E-05 | 20-01-PLAN.md | Explain startup-floor rationale. | ✓ SATISFIED | Runtime review explains staying within four groups because each group pays fixed `wp-env` startup floor. |
+| E2E-06 | 20-01-PLAN.md | Required GitHub CI passes after workflow change. | ✓ SATISFIED | Run `28406226487` passed all groups/final gate; latest PR required checks pass. |
+| E2E-07 | 20-01-PLAN.md | Record implementation, validation, and keep/revert decision. | ✓ SATISFIED | Phase 20 validation section documents PR, run, job results, durations, final gate, and keep decision. |
+
+### Anti-Patterns Found
+
+| File | Line | Pattern | Severity | Impact |
+|------|------|---------|----------|--------|
+| — | — | — | — | No blocker anti-patterns found. Grep hits for `manual-only`/`skip` are negative assertions in docs, not added skip behavior. No production code files were modified. |
+
+### Human Verification Required
+
+None. The phase goal is CI/workflow/documentation evidence and was verified programmatically against local files plus live GitHub PR/run status.
+
+### GitHub CI Evidence
+
+- Branch/head verified locally: `ci/e2e-shard-rebalance` at `b29ce647fb13916944d7893ec34b2ba958b6280a`.
+- PR #129 verified live: `OPEN`, non-draft, base `main`, merge state `CLEAN`, head `b29ce647fb13916944d7893ec34b2ba958b6280a`.
+- Initial implementation validation run verified live: `28406226487`, workflow `E2E Tests`, head SHA `316bc604c4869fc84bba6416e1dfc0f417a1b7aa`, conclusion `success`.
+- Latest required PR checks verified live with `gh pr checks 129 -R dknauss/Sudo --required`: `CodeQL`, `E2E Nginx Smoke`, `E2E Tests`, `PHPUnit`, and `Psalm` all pass.
+
+### Gaps Summary
+
+No gaps found. Phase 20 achieved the goal: the baseline E2E matrix remains four groups with the same final required gate, the timer slice was moved from the long-pole group to the shortest suitable group without coverage loss, docs record the evidence and keep decision, and GitHub CI is green.
+
+---
+
+_Verified: 2026-06-29T22:41:10Z_
+_Verifier: Claude (gsd-verifier)_

--- a/docs/e2e-runtime-review.md
+++ b/docs/e2e-runtime-review.md
@@ -250,3 +250,28 @@ Destination group: `E2E Tests 2/4 (challenge-2fa-ui)`, the shortest suitable exi
 Rationale: Group 1 remains materially slower than the other baseline groups, while group 2 is consistently shortest in the refreshed data. Moving the timer spec preserves coverage, keeps the same required final `E2E Tests` gate, and stays within the existing four groups so the workflow does not add another fixed `wp-env` startup floor.
 
 Implementation: `.github/workflows/e2e.yml` now removes `admin-bar-timer.spec.ts` and `TIMR` from group 1 and adds `admin-bar-timer.spec.ts` to group 2's second command. No spec is skipped, deleted, or moved to manual-only validation.
+
+## Phase 20 validation — E2E shard rebalance implementation
+
+Validated: 2026-06-29T22:21:21Z
+Implementation branch: `ci/e2e-shard-rebalance`
+Implementation PR: https://github.com/dknauss/Sudo/pull/129
+Implementation commit: `316bc604c4869fc84bba6416e1dfc0f417a1b7aa`
+GitHub Actions run: https://github.com/dknauss/Sudo/actions/runs/28406226487
+Workflow conclusion: `success`
+
+Validation command:
+
+```bash
+gh run view 28406226487 -R dknauss/Sudo --json databaseId,workflowName,displayTitle,event,headBranch,headSha,conclusion,url,jobs
+```
+
+| Job/group | Conclusion | Duration seconds | Job URL |
+|---|---|---:|---|
+| E2E Tests 1/4 (challenge-basic-admin) | success | 367 | https://github.com/dknauss/Sudo/actions/runs/28406226487/job/84169231188 |
+| E2E Tests 2/4 (challenge-2fa-ui) | success | 320 | https://github.com/dknauss/Sudo/actions/runs/28406226487/job/84169231171 |
+| E2E Tests 3/4 (challenge-lockout-surfaces) | success | 329 | https://github.com/dknauss/Sudo/actions/runs/28406226487/job/84169231183 |
+| E2E Tests 4/4 (challenge-replay-multisite) | success | 289 | https://github.com/dknauss/Sudo/actions/runs/28406226487/job/84169231174 |
+| E2E Tests final gate | success | 4 | https://github.com/dknauss/Sudo/actions/runs/28406226487/job/84170141517 |
+
+Keep/revert decision: **keep**. The implementation run passed all four shard jobs and the required final `E2E Tests` gate. Group 1 dropped from the refreshed 407.9-second average to 367 seconds in this validation run, while the moved timer slice kept group 2 within the observed historical group-1 long-pole range and did not create a new longer shard than group 1 in this run.

--- a/docs/e2e-runtime-review.md
+++ b/docs/e2e-runtime-review.md
@@ -199,3 +199,54 @@ This plan does **not** implement the workflow change. It records the evidence-ba
 - **Evidence:** 9 successful post-cutoff baseline observations show `E2E Tests 1/4 (challenge-basic-admin)` averaging 372.2 seconds, about 34% slower than the next comparable baseline groups and repeatably on the critical path.
 - **Rationale:** A small rebalance within the current four groups can reduce the long pole without adding startup overhead, changing required checks, or sacrificing coverage.
 - **Owner/timing:** Maintainer / next CI-speed follow-up before the next release-grade tuning pass; re-run the refresh commands in this document immediately before editing `.github/workflows/e2e.yml`.
+
+## Phase 20 refresh — E2E shard rebalance implementation
+
+Collected: 2026-06-29T22:10:22Z
+Repository: `dknauss/Sudo`
+Workflow: `.github/workflows/e2e.yml` / `E2E Tests`
+Implementation branch: `ci/e2e-shard-rebalance`
+
+This refresh was collected immediately before editing `.github/workflows/e2e.yml`. It uses GitHub Actions job timestamps as the source of truth; local Playwright timing assumptions were not used.
+
+### Phase 20 refresh commands
+
+```bash
+gh run list -R dknauss/Sudo --workflow e2e.yml --limit 20 --json databaseId,displayTitle,event,headBranch,status,conclusion,createdAt,updatedAt,url
+RUN_ID=<run id from successful comparable run>
+gh run view "$RUN_ID" -R dknauss/Sudo --json databaseId,workflowName,displayTitle,event,headBranch,conclusion,createdAt,url,jobs
+```
+
+Successful completed workflow runs were expanded with `gh run view "$RUN_ID" -R dknauss/Sudo --json jobs`; comparable jobs are only `E2E Tests 1/4` through `4/4` from successful workflow runs. `Detect code changes` and the exact final gate job named `E2E Tests` remain excluded from runtime aggregation.
+
+### Phase 20 refreshed run inventory
+
+| Run ID | Created | Event | Branch/ref | 1/4 seconds | 2/4 seconds | 3/4 seconds | 4/4 seconds | URL |
+|---:|---|---|---|---:|---:|---:|---:|---|
+| 28405201903 | 2026-06-29T21:54:21Z | push | main | 411 | 258 | 345 | 292 | https://github.com/dknauss/Sudo/actions/runs/28405201903 |
+| 28404488595 | 2026-06-29T21:40:25Z | push | main | 458 | 279 | 353 | 312 | https://github.com/dknauss/Sudo/actions/runs/28404488595 |
+| 28403154219 | 2026-06-29T21:14:55Z | push | main | 400 | 278 | 354 | 305 | https://github.com/dknauss/Sudo/actions/runs/28403154219 |
+| 28403078588 | 2026-06-29T21:13:30Z | pull_request | dependabot/github_actions/actions/cache-6 | 418 | 304 | 317 | 305 | https://github.com/dknauss/Sudo/actions/runs/28403078588 |
+| 28396183980 | 2026-06-29T19:08:40Z | pull_request | dependabot/npm_and_yarn/playwright/test-1.61.1 | 400 | 261 | 328 | 302 | https://github.com/dknauss/Sudo/actions/runs/28396183980 |
+| 28393595457 | 2026-06-29T18:21:46Z | push | main | 416 | 236 | 293 | 286 | https://github.com/dknauss/Sudo/actions/runs/28393595457 |
+| 28384568687 | 2026-06-29T15:46:40Z | pull_request | dependabot/npm_and_yarn/wordpress/env-11.9.0 | 385 | 256 | 295 | 271 | https://github.com/dknauss/Sudo/actions/runs/28384568687 |
+| 28380853974 | 2026-06-29T14:49:49Z | pull_request | dependabot/github_actions/actions/cache-6 | 375 | 254 | 282 | 272 | https://github.com/dknauss/Sudo/actions/runs/28380853974 |
+
+### Phase 20 refreshed aggregates
+
+| Job/group | Observations | Min seconds | Max seconds | Average seconds | Median seconds |
+|---|---:|---:|---:|---:|---:|
+| E2E Tests 1/4 (challenge-basic-admin) | 8 | 375 | 458 | 407.9 | 405.5 |
+| E2E Tests 2/4 (challenge-2fa-ui) | 8 | 236 | 304 | 265.8 | 259.5 |
+| E2E Tests 3/4 (challenge-lockout-surfaces) | 8 | 282 | 354 | 320.9 | 322.5 |
+| E2E Tests 4/4 (challenge-replay-multisite) | 8 | 271 | 312 | 293.1 | 297.0 |
+
+### Phase 20 rebalance decision
+
+Current long pole: `E2E Tests 1/4 (challenge-basic-admin)` at 407.9 seconds average across 8 successful comparable observations.
+
+Destination group: `E2E Tests 2/4 (challenge-2fa-ui)`, the shortest suitable existing group at 265.8 seconds average. The selected low-risk slice is `tests/e2e/specs/admin-bar-timer.spec.ts` / `TIMR`, moved from group 1 to group 2.
+
+Rationale: Group 1 remains materially slower than the other baseline groups, while group 2 is consistently shortest in the refreshed data. Moving the timer spec preserves coverage, keeps the same required final `E2E Tests` gate, and stays within the existing four groups so the workflow does not add another fixed `wp-env` startup floor.
+
+Implementation: `.github/workflows/e2e.yml` now removes `admin-bar-timer.spec.ts` and `TIMR` from group 1 and adds `admin-bar-timer.spec.ts` to group 2's second command. No spec is skipped, deleted, or moved to manual-only validation.


### PR DESCRIPTION
## Summary
- refresh GitHub Actions E2E runtime evidence for the current baseline
- move the low-risk admin bar timer slice (`TIMR` / `admin-bar-timer.spec.ts`) from E2E group 1 to group 2
- document the Phase 20 evidence and rationale in `docs/e2e-runtime-review.md`

## Validation
- reviewer approval written
- `git diff --cached --check`
- workflow structural assertions: four groups, group 1 no TIMR, group 2 includes timer, final gate preserved
- `composer test`
- `composer lint`
- `composer analyse`
- `composer verify:metrics`

## Notes
- no release tag/version change
- full E2E GitHub Actions run is the acceptance gate for this CI/runtime change
