### PR TITLE
fix: preserve settings tab across sudo reauth (return_url encoding)

### DIFF
--- a/.planning/debug/settings-tab-lost-on-reauth-replay.md
+++ b/.planning/debug/settings-tab-lost-on-reauth-replay.md
@@ -1,345 +1,327 @@
 ---
-status: partially_resolved
+status: root_cause_confirmed
 trigger: "settings-tab-lost-on-reauth-replay"
 created: 2026-07-01T00:00:00Z
-updated: 2026-07-01T03:00:00Z
+updated: 2026-07-01T04:00:00Z
 ---
 
-## Resolution (2026-07-01)
+## Resolution (2026-07-01, corrected)
 
 - **MULTISITE: RESOLVED.** Root cause = `Admin::handle_network_settings_save()` hardcoded its
-  post-save redirect and ignored `wp_get_referer()`, dropping `&tab=`. Fixed in commit `a4798d4`
-  (branch `fix/multisite-settings-tab-redirect`): redirect is built from `network_admin_url('settings.php')`
-  + `page`, lifting ONLY a `VALID_TABS`-validated `tab` from a page-scoped referer. Reproduction test
-  renamed to assert the tab is preserved; two security tests + the pre-existing allowlist pin cover it.
-- **SINGLE-SITE: UNCONFIRMED (no plugin defect found).** Every single-site path reachable from
-  `tab=access` (stash/GET-replay, POST-replay form, Ctrl+Shift+S shortcut cancel AND success redirect,
-  blocked-notice link, AJAX grant/revoke) was traced against REAL WP core source and unit-tested — all
-  preserve `&tab=`. Leading remaining hypothesis: a **WordPress Playground iframe + service-worker
-  navigation artifact** affecting JS `window.location.href` assignments (the plugin already special-cases
-  Playground once, `admin/js/wp-sudo-challenge.js:15-42`). AWAITING a live-Playground capture from the
-  user to confirm/refute (see the recommended capture steps in the log below); not reproducible in a
-  headless browser. Do NOT add speculative production code for the single-site case until confirmed.
+  post-save redirect and ignored `wp_get_referer()`, dropping `&tab=`. Fixed in commit `0ef45f1`
+  ("fix: preserve settings tab on multisite network settings save (#132)"): redirect is built from
+  `network_admin_url('settings.php')` + `page`, lifting ONLY a `VALID_TABS`-validated `tab` from a
+  page-scoped referer. Covered by `test_handle_network_settings_save_redirect_preserves_tab_query_arg`
+  and sibling security tests (tests/Unit/AdminTest.php). Unaffected by the single-site finding below —
+  different mechanism, different code path, already shipped and verified.
+
+- **SINGLE-SITE: CONFIRMED, ROOT CAUSE FOUND (corrected from prior FALSIFIED conclusion).**
+  A prior session in this file concluded the single-site report was an unreproducible "WordPress
+  Playground iframe/Service-Worker navigation artifact." **That conclusion was wrong** and is
+  retracted below. Live evidence (see Current Focus) proved the defect is real and upstream in
+  WP-Sudo's own PHP. This session found the actual mechanism: it is **not** in
+  `get_current_admin_url()` or `wp_validate_redirect()` (both are genuinely tab-safe, as the prior
+  session proved) — it is in **`add_query_arg()` itself**, which every prior investigating session
+  mis-modeled in its test stubs. See root_cause below for the full mechanism and the per-trigger
+  table.
 
 ## Current Focus
 
+hypothesis: [CORRECTED, this session] The prior session's simulation script (and every existing
+   unit test stub for `add_query_arg()` in this suite) used PHP's native `http_build_query()` to
+   emulate WordPress's `add_query_arg()`. `http_build_query()` URL-encodes its output by default.
+   Real WordPress `add_query_arg()` does NOT: it calls `build_query()`, which calls
+   `_http_build_query( $data, null, '&', '', false )` — the trailing `false` disables
+   `urlencode()` for every value written into the query string via the function's `$key => $value`
+   array argument (as opposed to values already present in the base URL's own query string, which
+   *are* re-encoded via `urlencode_deep()` after being parsed back out with `wp_parse_str()`). Every
+   call site in WP-Sudo that builds `return_url`/`redirect_to` places a FULL URL — itself already
+   containing a query string with its own `&` — as a raw VALUE in the array passed to
+   `add_query_arg()`. Because that value is never encoded, its embedded `&tab=access` (or any other
+   nested query param) is emitted as a literal `&` in the final output URL, becoming a NEW
+   top-level sibling query parameter instead of staying part of the value. When the browser then
+   parses that URL's query string into PHP's `$_GET` on the next request, `$_GET['return_url']` (or
+   `$_GET['wp_sudo_redirect_to']`) is truncated at the first `&` and everything after it — including
+   `tab=access` — is silently lost. This is exactly Mechanism (B) from the reinvestigation brief:
+   "return_url built from the full URL but appended to the challenge URL WITHOUT proper
+   URL-encoding."
+test: (1) Pulled add_query_arg()/build_query()/_http_build_query() from wordpress-develop trunk
+   (wp-includes/functions.php, verified via raw.githubusercontent.com this session) and confirmed
+   `build_query()` passes `$urlencode = false` to `_http_build_query()`, and that new `$key => $value`
+   array entries are written via `$k . '=' . $v` (line "} else { array_push( $ret, $k . '=' . $v ); }"),
+   i.e. completely unencoded, whereas parsed-from-existing-query values go through
+   `urlencode_deep()` first (functions.php ~line 1183, inside `add_query_arg()` itself, BEFORE the
+   new args are merged in). (2) Wrote a byte-for-byte PHP port of the real function
+   (scratchpad/sim2.php) and ran it against the EXACT reported scenario
+   (`Plugin::enqueue_shortcut()` on `options-general.php?page=wp-sudo-settings&tab=access`) end to
+   end: return_url construction -> add_query_arg() merge -> browser round-trip via parse_url()/
+   parse_str(). (3) Added a new shared test helper, `TestCase::stub_faithful_add_query_arg()`
+   (tests/TestCase.php), that is a byte-for-byte port of the same real WP function (not
+   http_build_query()-based), and used it to write 4 new failing PHPUnit tests exercising the real
+   production code paths directly (not just a standalone simulation): `Plugin::enqueue_shortcut()`,
+   `Gate::intercept()` -> `challenge_admin()`, `Gate::render_gate_notice()` (structurally identical
+   to `render_blocked_notice()`), and `Admin_Bar::admin_bar_node()`.
+expecting: If the hypothesis is correct, each of these 4 real-code-path tests, using genuinely
+   faithful `add_query_arg()` semantics, will fail with the tab/query-string truncated at the first
+   `&`. If wrong (e.g. if the prior session's Playground-artifact theory were correct instead), the
+   tests would pass, because the defect would not be reproducible via pure PHP-level unit testing at
+   all.
+found: CONFIRMED for all 4 trigger points. Every test failed exactly as predicted, and passed
+   (`composer test:unit`: 949 tests, 945 pass, only these 4 new tests fail, zero regressions) when
+   run as part of the full existing suite — proving the new faithful stub is inert for every
+   pre-existing test and the failures are specific to this defect.
+   - `tests/Unit/PluginTest.php::test_enqueue_shortcut_challenge_url_preserves_tab_query_arg_from_access_tab`
+     — FAILS: `Failed asserting that '.../options-general.php?page=wp-sudo-settings' contains "tab=access"`.
+   - `tests/Unit/GateTest.php::test_intercept_admin_challenge_redirect_preserves_tab_query_arg`
+     — FAILS: identical truncation on the gated-action (Save Changes / any admin gated request) bounce.
+   - `tests/Unit/GateTest.php::test_gate_notice_challenge_link_preserves_query_string_on_current_page`
+     — FAILS: identical truncation on the persistent gate-notice / one-shot blocked-notice
+     "Confirm your identity" link (`paged=2` dropped from a `plugins.php?...` query string).
+   - `tests/Unit/AdminBarTest.php::test_admin_bar_node_deactivate_url_preserves_tab_query_arg`
+     — FAILS: identical truncation on the admin-bar "Sudo: M:SS" countdown node's deactivate link
+     (`REDIRECT_PARAM`), a 4th, previously-unidentified trigger with the exact same mechanism.
+implication: This is ONE shared root cause (a systemic misuse of `add_query_arg()`'s
+   "values are expected to be encoded appropriately with urlencode()" contract — which the function's
+   own docblock explicitly warns about) manifesting independently at every WP-Sudo call site that
+   nests a full URL as an array value passed to `add_query_arg()`. It is NOT a WordPress Playground
+   artifact, NOT a JS navigation issue, and NOT specific to the keyboard shortcut — the same defect
+   pattern recurs at 4 distinct trigger points, all PHP-side, all in `includes/`. The reason 3 prior
+   investigating sessions in this file failed to find it: every one of their "real semantics" test
+   stubs for `add_query_arg()` (in this file's own historical notes, in `tests/Unit/AdminTest.php`'s
+   `stub_real_add_query_arg_semantics()`, in `tests/Unit/GateTest.php`'s
+   `mock_rest_challenge_url_helpers()`, and in more than a dozen other call sites across the test
+   suite) used PHP's native `http_build_query()`, which encodes by default — silently "fixing" the
+   exact bug under test before it could ever be observed. The one test that came closest
+   (`test_enqueue_assets_cancel_url_preserves_tab_query_arg_from_access_tab`,
+   tests/Unit/ChallengeTest.php) tested the WRONG HALF of the pipeline: it seeded `$_GET['return_url']`
+   directly with an already-correct, already-tabbed value and only tested what `Challenge` does with
+   it downstream (which is fine) — it never exercised how `return_url` is embedded into the
+   `challenge_url` upstream (where the corruption actually happens).
+next_action: None further needed for root-cause confirmation. Per this session's mode
+   (`goal: reproduce_and_root_cause_ONLY`), NO production fix has been implemented. See Resolution
+   below for the consolidated fix direction the orchestrator's Pre-Implementation Design Review
+   should evaluate.
+
+---
+
 hypothesis: MULTISITE root cause (handle_network_settings_save hardcoded redirect) remains CONFIRMED — unchanged.
-   SINGLE-SITE, SUCCESS-REDIRECT PASS (this session): focused re-verification of the ONE remaining untested
+   SINGLE-SITE, SUCCESS-REDIRECT PASS (historical session): focused re-verification of the ONE remaining untested
    angle — the post-auth SUCCESS redirect for a PROACTIVE reauth (Ctrl/Cmd+Shift+S, or session-only
    activation) with NO stashed action, single-site, tab=access. Re-traced every hop of
    `return_url` -> `cancelUrl` -> `window.location.href` against REAL WordPress core source (not the
    prior session's test stubs) end-to-end: `Plugin::get_current_admin_url()` / `Gate::get_current_admin_url()`
    (REQUEST_URI-faithful) -> `add_query_arg()` (real WP source pulled from wordpress-develop trunk,
-   confirmed `urlencode_deep()` + `build_query()` use a literal `&` separator, NOT `&amp;`) -> GET
-   round-trip into `$_GET['return_url']` (confirmed via PHP `parse_str`/`http_build_query` simulation,
-   byte-for-byte) -> `Challenge::enqueue_assets()`'s `esc_url_raw()` (confirmed via real WP core source:
-   'db' context skips the `&` -> `&#038;` entity-replacement that only applies in 'display' context) ->
-   `wp_validate_redirect()` -> `wp_sanitize_redirect()` (confirmed via real WP core source: `&` and `=`
-   are both in the allowed character class `[^a-z0-9-~+_.?#=&;,/:%!*\[\]()@]`, so the tab param is never
-   stripped). Every hop is provably tab-preserving using REAL implementations, not stubs. Also re-verified
-   `render_resume_page()` (the "already authenticated on page load" duplicate success path) uses the
-   identical `cancel_url` construction — same conclusion applies.
-test: Ran the existing `test_enqueue_assets_cancel_url_preserves_tab_query_arg_from_access_tab` test again
-   (unchanged from prior session) plus manual PHP verification scripts simulating add_query_arg's
-   urlencode_deep/build_query round-trip and confirmed against live wordpress-develop trunk source for
-   add_query_arg(), esc_url()/esc_url_raw(), wp_validate_redirect(), and wp_sanitize_redirect(). All confirm
-   tab-safety. Did NOT write a new failing test this pass — no code branch was found to falsify.
-expecting: n/a — could not construct a hypothesis this pass that predicts single-site tab loss from any
-   WP-Sudo code path; every remaining candidate was eliminated by direct comparison to WP core source.
-next_action: none further without a live WP Playground browser session (out of scope for this agent — see
-   docs/ai-agentic-guidance.md / CLAUDE.md browser handoff policy). See Resolution for the exact capture
-   needed to confirm the environmental-artifact hypothesis.
+   INCORRECTLY believed at the time to confirm `urlencode_deep()` + `build_query()` use a literal `&`
+   separator "safely" — this session found that belief was wrong: build_query's separator IS a literal
+   `&`, but that is exactly the problem, because new values are never urlencoded before being joined
+   with it) -> GET round-trip into `$_GET['return_url']` (the historical session's own manual
+   simulation script used `parse_str`/`http_build_query`, which does NOT reproduce real
+   `add_query_arg()` behavior — see correction above) -> `Challenge::enqueue_assets()`'s `esc_url_raw()`
+   -> `wp_validate_redirect()` -> `wp_sanitize_redirect()`. NOTE: this pass's conclusion that "every hop
+   is provably tab-preserving using REAL implementations" was INCORRECT specifically at the
+   `add_query_arg()` hop — every other hop's analysis (esc_url_raw, wp_validate_redirect,
+   wp_sanitize_redirect) remains correct and is NOT part of the defect.
+test: Ran the existing `test_enqueue_assets_cancel_url_preserves_tab_query_arg_from_access_tab` test
+   (tests/Unit/ChallengeTest.php) — this test seeds `$_GET['return_url']` directly with an
+   already-tabbed value and therefore cannot detect the upstream `add_query_arg()` defect (it tests
+   Challenge's consumption of an already-correct value, not the construction of that value). This is
+   why it passed despite the real bug existing.
+expecting: n/a (historical).
+next_action: See corrected Current Focus above.
 
 ## Symptoms
 
 expected: After passing the challenge, the user returns to the same tabbed settings screen they were on, with &tab=access (or whatever tab) preserved.
 actual: The user lands on the bare settings page (?page=wp-sudo-settings) with no &tab= — dumped back to the default/first tab.
 errors: None (functional, not an error).
-reproduction: Be on options-general.php?page=wp-sudo-settings&tab=access; trigger a sudo-gated action from that screen (most likely: save the Sudo settings, which POSTs to options.php; or another gated action reached from that tab); pass the reauth challenge; observe you return to the tabless settings URL.
+reproduction: Be on options-general.php?page=wp-sudo-settings&tab=access; press Ctrl/Cmd+Shift+S (or trigger any gated action, or wait for the persistent gate notice / one-shot blocked notice on a gated page with a query string, or use the admin-bar sudo countdown's deactivate link from a tabbed/query-string page); pass the reauth challenge (or deactivate); observe you return to the tab-less/query-less URL.
 started: Present in current main (v4.5, Phase 24 shipped). Not previously reported; the tabbed settings UI + gate/stash/replay predate Phase 24.
 
 ## Eliminated
 
-- hypothesis: [RE-VERIFIED this session, still holds] Single-site Settings tab save (`<form action="options.php">`, `options.wp_sudo` rule) loses the tab somewhere in the stash → challenge → replay round-trip.
-  evidence (this session): render_access_tab() (includes/class-admin.php:1844-1944) and render_drift_detection_panel()
-    (includes/class-admin.php:1956-2017) confirmed to contain ZERO `<form>` elements — only AJAX buttons
-    (wp-sudo-grant-cap, wp-sudo-revoke-cap, wp-sudo-grant-manage). Therefore the Settings-tab save form
-    (only rendered in the `default: // 'settings'` branch of render_settings_page()'s tab switch,
-    includes/class-admin.php:1738-1761) CANNOT be the form the user submitted while `tab=access` was showing
-    — the two tabs are mutually exclusive in a single page load. The user's report ("was on tab=access...
-    after passing the challenge, landed on bare ?page=wp-sudo-settings") cannot be this rule at all. Confirmed
-    NOT the reproduction path for this report (though the original single-site trace itself remains correct:
-    options.php's own wp_get_referer()-based redirect preserves the tab whenever this rule DOES fire, e.g.
-    from the Settings tab itself).
-  timestamp: 2026-07-01T01:00:00Z (re-verified; original trace unchanged, see below)
-  evidence: Traced the full single-site path line-by-line and confirmed each hop preserves the tab:
-    - `Request_Stash::build_original_url()` (includes/class-request-stash.php:258-264) captures the tabless POST target `/wp-admin/options.php` for `url` — correct, since that IS the POST target.
-    - `Request_Stash::get_return_url()` (includes/class-request-stash.php:174-178) calls `wp_get_referer()`, which reads `_wp_http_referer` — set by WP core's `wp_referer_field()` (called via `settings_fields()` → `wp_nonce_field()`) to `remove_query_arg('_wp_http_referer')` on the *current page's* `REQUEST_URI` at render time, i.e. the tabbed `options-general.php?page=wp-sudo-settings&tab=settings` (verified against `wordpress-develop` trunk `wp-includes/functions.php` lines ~1930 and ~1980-1991).
-    - `_wp_http_referer` is included in every rule's replay allowlist via `Action_Registry::DEFAULT_REPLAY_POST_FIELDS` (includes/class-action-registry.php:73-80), merged in by `stash_allowlist()` (includes/class-action-registry.php:754-759). So it IS present in `$stash['post']` and gets replayed as a hidden form field.
-    - `Challenge::build_replay_response_data()` (includes/class-challenge.php:790-852): for a non-blocked POST (the settings-save case is NOT redacted/blocked — `wp_sudo_settings` is not a sensitive key), the method returns the `replay=true` branch (lines 845-851): `url = $safe_url` (tabless `options.php`, correct — it must POST there) and `post_data = $stash['post']` (includes the tabbed `_wp_http_referer`).
-    - WP core's `options.php` (`wordpress-develop` trunk, verified via raw.githubusercontent.com) line 374-375: `$goback = add_query_arg('settings-updated', 'true', wp_get_referer()); wp_redirect($goback);` — `wp_get_referer()` here reads `_wp_http_referer` from the REPLAYED POST body (the hidden field the wp-sudo JS submits), which is the tabbed URL.
-    - `wp_validate_redirect()` (verified against local `.tmp/wordpress/wp-includes/pluggable.php:1665`) does not strip query args in the same-host case — the full query string including `&tab=` passes through untouched.
-    - Conclusion: single-site Settings-tab save-and-replay correctly preserves `&tab=`. This path is NOT the bug.
-  timestamp: 2026-07-01T00:00:00Z
+- hypothesis: [RE-VERIFIED] Single-site Settings tab save (`<form action="options.php">`, `options.wp_sudo` rule) loses the tab somewhere in the stash → challenge → replay round-trip.
+  evidence: `render_access_tab()` (includes/class-admin.php:1844-1944) contains ZERO `<form>` elements — only AJAX buttons. The Settings-tab save form only renders in the `default: // 'settings'` branch, so it cannot be what the user submitted while `tab=access` was showing. Separately, the full single-site Settings-tab save-and-replay chain (`Request_Stash::build_original_url()`/`get_return_url()` -> `_wp_http_referer` replay allowlist -> `Challenge::build_replay_response_data()`'s POST-replay branch -> WP core's own `options.php` `wp_get_referer()`-based redirect -> `wp_validate_redirect()`) was traced line-by-line against real WordPress core source and confirmed tab-safe: this path does NOT use the `add_query_arg(array $args, $base_url)` pattern that causes the confirmed defect — it uses `wp_get_referer()`'s value directly as the redirect target (a `$location`, not a nested array value), so there is no place for the "unencoded nested value" mechanism to apply.
+  timestamp: 2026-07-01T00:00:00Z (re-verified 01:00:00Z; conclusion unchanged, still correctly eliminated)
 
 - hypothesis: Access tab (grant/revoke capability buttons, `options.wp_sudo_access` rule) goes through the stash → challenge → replay round-trip and loses the tab there.
-  evidence: `Admin::render_access_tab()` (includes/class-admin.php:1844-1944) renders grant/revoke as AJAX buttons (`wp-sudo-grant-cap`, `wp-sudo-revoke-cap`), not a real form submission. `admin/js/wp-sudo-admin.js` `sendAccessAction()` (line 274+) handles a gate rejection purely as an inline error message (`data.message`) — it never checks for a `challenge_url` and never redirects to the challenge page at all. So Access-tab actions never enter the stash/challenge/replay pipeline in the browser; there is no "return to a URL" step to lose the tab on. Eliminated as the mechanism for the reported symptom, though it is a separate, softer UX gap (user must reauthenticate elsewhere and retry manually).
+  evidence: `Admin::render_access_tab()` renders grant/revoke as AJAX buttons; `sendAccessAction()` (admin/js/wp-sudo-admin.js) handles a gate rejection purely as an inline error message and never redirects to the challenge page. Access-tab actions never enter the stash/challenge/replay pipeline in the browser.
   timestamp: 2026-07-01T00:00:00Z
 
-- hypothesis: [NEW this session] The Ctrl+Shift+S / Cmd+Shift+S keyboard shortcut (session-only challenge, no stash_key) opens the challenge page from tab=access via Plugin::enqueue_shortcut()'s `return_url`, but the round trip through Challenge::enqueue_assets()'s `cancelUrl` computation drops or corrupts `&tab=access`.
-  evidence: Wrote and ran a new faithful-semantics unit test, `test_enqueue_assets_cancel_url_preserves_tab_query_arg_from_access_tab` (tests/Unit/ChallengeTest.php), that: (1) seeds `$_GET['return_url']` with exactly the value `Plugin::enqueue_shortcut()` would produce from `options-general.php?page=wp-sudo-settings&tab=access` (per `Plugin::get_current_admin_url()`, includes/class-plugin.php:570-585, which uses `$_SERVER['REQUEST_URI']` faithfully — verified by a pre-existing test, `test_enqueue_shortcut_return_url_is_not_double_encoded`); (2) lets `wp_validate_redirect()` run with real same-host semantics (not stubbed to a fixed string); (3) asserts `wpSudoChallenge.cancelUrl` (what the challenge JS uses for the `code==='authenticated'` session-only-success redirect at admin/js/wp-sudo-challenge.js:148/245/251) contains `tab=access`.
-  found: Test PASSES (`./vendor/bin/phpunit --filter test_enqueue_assets_cancel_url_preserves_tab_query_arg_from_access_tab tests/Unit/ChallengeTest.php` → 1 test, 4 assertions, OK). Also independently confirmed the `add_query_arg()`/`parse_str()` round-trip does not corrupt a nested `&`-containing URL value via a standalone PHP script (http_build_query + parse_url round-trips the tabbed URL byte-for-byte).
-  implication: The keyboard-shortcut session-only path is NOT the defect. Eliminated.
+- hypothesis: [RETRACTED — see correction] "WordPress Playground iframe + Service-Worker navigation artifact" affecting JS `window.location.href` assignments.
+  evidence: This session proved the corruption happens entirely server-side, in PHP, before `wp_localize_script()` ever hands `cancelUrl`/`challengeUrl` to the browser. `window.wpSudoChallenge.cancelUrl` (and `wpSudoShortcut.challengeUrl`) are ALREADY tab-less at the moment PHP generates them — confirmed by 4 new unit tests exercising the actual production PHP methods (`Plugin::enqueue_shortcut()`, `Gate::challenge_admin()`, `Gate::render_gate_notice()`, `Admin_Bar::admin_bar_node()`) with zero browser, iframe, or Service Worker involved. Playground is not implicated; this is a plain PHP `add_query_arg()` usage defect that would reproduce identically on any single-site WordPress install, in any browser, with no plugins running JS at all (the countdown/deactivate case is a pure PHP round trip: `add_query_arg()` writes the URL, a later request reads `$_GET` back).
+  timestamp: 2026-07-01T04:00:00Z
+
+- hypothesis: `sendAccessAction()` (admin/js/wp-sudo-admin.js) redirects to a `challenge_url` on a `sudo_required` AJAX error, and that redirect drops the tab.
+  evidence: Re-read `sendAccessAction()` end-to-end (admin/js/wp-sudo-admin.js:274-351); the error branch only sets `resultEl.textContent`/`window.alert` — no `challenge_url` field is read anywhere, no redirect occurs.
   timestamp: 2026-07-01T01:00:00Z
 
-- hypothesis: [NEW this session] The Access-tab AJAX grant/revoke `sudo_required` block sets a one-shot transient (`Gate::set_blocked_transient()`); on the NEXT admin page load `Gate::render_blocked_notice()` shows a "Confirm your identity" admin-notice link whose `challenge_url`'s `return_url` (`Gate::get_current_admin_url()`) could be built from a different/wrong page than tab=access, dropping the tab.
-  evidence: `Gate::get_current_admin_url()` (includes/class-gate.php:3037-3052) uses `$_SERVER['REQUEST_URI']` faithfully, structurally identical to `Plugin::get_current_admin_url()` (diffed the two private methods: only the empty-`$_SERVER['REQUEST_URI']`/empty-host fallback differs — `''` vs `admin_url()`/`network_admin_url()` — not relevant when REQUEST_URI is present). Since `render_blocked_notice()` fires on `admin_notices` on the SAME reloaded page (still `tab=access` if the user simply reloads or the notice appears on the next natural page view), `return_url` correctly captures `tab=access` and flows into the same `cancelUrl` mechanism already verified correct above.
-  implication: Structurally the same as the shortcut path; no distinct defect found. Eliminated (with the caveat that this depends on the notice being rendered while `tab=access` is still the active URL, which is the expected case per the user's report).
-  timestamp: 2026-07-01T01:00:00Z
-
-- hypothesis: [NEW this session] `sendAccessAction()` (admin/js/wp-sudo-admin.js) actually redirects to a `challenge_url` on a `sudo_required` AJAX error, and that redirect drops the tab.
-  evidence: Re-read `sendAccessAction()` end-to-end (admin/js/wp-sudo-admin.js:274-351) and every call site (grant, revoke-cap, revoke-session, grant-manage). The error branch (`else` at line 323-335) only ever sets `resultEl.textContent = emsg` or `window.alert(emsg)` — no `challenge_url` field is read anywhere in this file, no `window.location` assignment exists in the error path. Confirmed (again) no redirect occurs from this handler.
-  implication: Still eliminated, now re-verified line-by-line rather than assumed from the prior session's summary.
-  timestamp: 2026-07-01T01:00:00Z
+- hypothesis: `wp_validate_redirect()` / `wp_sanitize_redirect()` strip or corrupt the `&tab=` query argument.
+  evidence: Both real functions (wordpress-develop trunk, wp-includes/pluggable.php:1553-1732) explicitly allow `&`, `=`, `:` in `wp_sanitize_redirect()`'s character-class filter, and `wp_validate_redirect()` returns `$location`/`$fallback_url` verbatim without rewriting the query string in any branch. These functions are NOT part of the defect — they correctly preserve whatever query string reaches them. The defect happens one step earlier, in `add_query_arg()`, before these functions ever see the URL.
+  timestamp: 2026-07-01T01:00:00Z (re-confirmed 2026-07-01T04:00:00Z with the corrected root cause)
 
 ## Evidence
 
 - timestamp: 2026-07-01T00:00:00Z
-  checked: includes/class-action-registry.php:511-528 and :732-744 — the `options.wp_sudo` rule is registered TWICE: once for single-site (`pagenow: options.php`, matches core Settings API POST) and once for multisite (`pagenow: edit.php`, `actions: ['wp_sudo_settings']`, matching the network-admin form's `action="edit.php?action=wp_sudo_settings"`, per includes/class-admin.php:1742).
-  found: The multisite variant's stash allowlist is `stash_allowlist([Admin::OPTION_KEY])`, same shape as single-site, so `_wp_http_referer` IS correctly captured and replayed to the multisite handler too.
-  implication: The multisite replay reaches `Admin::handle_network_settings_save()` with a correct, tabbed `_wp_http_referer` in `$_POST` — but that handler doesn't use it.
+  checked: includes/class-admin.php `Admin::handle_network_settings_save()` (multisite).
+  found: Hardcoded redirect, never reads `wp_get_referer()`/`$_POST['_wp_http_referer']`.
+  implication: Multisite root cause — separate mechanism from the single-site finding, already fixed (commit 0ef45f1).
 
-- timestamp: 2026-07-01T00:00:00Z
-  checked: includes/class-admin.php:429-453 `Admin::handle_network_settings_save()`.
-  found: The redirect is hardcoded: `wp_safe_redirect(add_query_arg(['page' => self::PAGE_SLUG, 'updated' => 'true'], network_admin_url('settings.php')))`. It never reads `wp_get_referer()` / `$_POST['_wp_http_referer']` at all — unlike WP core's own `options.php` (which the single-site path delegates to), this custom handler was written without the referer-preserving redirect pattern.
-  implication: This is the sole point in the entire replay chain where the tab is silently dropped, and it only fires for the **multisite network-admin** Settings-tab save. Single-site (delegating to WP core's `options.php`) is unaffected.
+- timestamp: 2026-07-01T04:00:00Z
+  checked: wp-includes/functions.php `add_query_arg()`/`build_query()`/`_http_build_query()`, pulled live from wordpress-develop trunk (raw.githubusercontent.com) this session.
+  found: `build_query( $data )` calls `_http_build_query( $data, null, '&', '', false )` — the final `false` disables `urlencode()`. Inside `_http_build_query()`, when `$urlencode` is false, each pair is emitted as `$k . '=' . $v` with NO encoding at all. Critically, `add_query_arg()` only applies `urlencode_deep()` to values that were already present in the URL's EXISTING query string (parsed via `wp_parse_str()`) — newly supplied `$key => $value` array entries are merged in via `$qs[$k] = $v` AFTER that encoding step and are never touched by it. The function's own docblock states: "Values are expected to be encoded appropriately with urlencode() or rawurlencode()." — callers are contractually responsible for pre-encoding, and WP-Sudo's call sites do not.
+  implication: This is the exact, singular mechanism (Mechanism B from the reinvestigation brief) behind every trigger in the table below.
 
-- timestamp: 2026-07-01T00:00:00Z
-  checked: tests/Unit/AdminTest.php:1435-1477 `test_handle_network_settings_save_updates_site_option_and_redirects` (pre-existing).
-  found: This test stubs `add_query_arg` with `Functions\when('add_query_arg')->justReturn('https://example.com/wp-admin/network/settings.php?page=wp-sudo-settings&updated=true')` — a fixed string, not a real implementation — so it locks in and cannot detect the tab-dropping behavior. It was effectively testing "wp_safe_redirect gets called with a URL containing certain substrings," not "the redirect target is correctly derived from where the user came from."
-  implication: Confirms why this bug shipped unnoticed — existing coverage could not have caught it by construction.
+- timestamp: 2026-07-01T04:00:00Z
+  checked: includes/class-plugin.php `Plugin::enqueue_shortcut()` (lines 218-224) and `get_current_admin_url()` (lines 570-585).
+  found: `get_current_admin_url()` correctly builds a full, correctly-encoded current URL from `$_SERVER['REQUEST_URI']` (this part IS safe). But `enqueue_shortcut()` then does `add_query_arg( array( 'page' => 'wp-sudo-challenge', 'return_url' => $this->get_current_admin_url() ), $base_url )` — nesting that full URL (with its own `&tab=access`) as a raw array value. Empirically confirmed via a byte-for-byte PHP port of real `add_query_arg()` (scratchpad/sim2.php) and via the new failing unit test `tests/Unit/PluginTest.php::test_enqueue_shortcut_challenge_url_preserves_tab_query_arg_from_access_tab`.
+  implication: CONFIRMED root cause of the reported symptom (Ctrl/Cmd+Shift+S shortcut). PHP.
 
-- timestamp: 2026-07-01T00:00:00Z
-  checked: Ran new unit test `test_handle_network_settings_save_redirect_drops_tab_query_arg` (tests/Unit/AdminTest.php, added in this session), which lets `add_query_arg`/`network_admin_url` run with faithful real semantics and seeds `$_POST['_wp_http_referer']` with a tabbed URL (`...settings.php?page=wp-sudo-settings&tab=access`), then asserts the captured `wp_safe_redirect()` argument contains `tab=access`.
-  found: FAILS as predicted — `./vendor/bin/phpunit --filter test_handle_network_settings_save_redirect_drops_tab_query_arg tests/Unit/AdminTest.php` produces: `Failed asserting that 'https://example.com/wp-admin/network/settings.php?page=wp-sudo-settings&updated=true' contains "tab=access".` Full suite run (`composer test:unit`) confirms this is the ONLY failure among 942 tests (941 pass) — the test is isolated and does not regress anything else.
-  implication: Root cause is confirmed empirically, not just by static tracing. The failing test pinpoints exactly the string `handle_network_settings_save()` constructs.
+- timestamp: 2026-07-01T04:00:00Z
+  checked: includes/class-gate.php `Gate::challenge_admin()` (lines 2597-2623, private, reached via `intercept()` for any gated admin-UI action without an active session) and `Gate::build_session_challenge_url()` (lines 2565-2588, private, reached via `intercept_rest()`'s cookie-auth soft-block).
+  found: Both build `$query_args['return_url'] = $return_url` (a full `wp_get_referer()` URL, itself already containing a query string) and pass `$query_args` into `add_query_arg( $query_args, $base_url )` — the identical vulnerable pattern. Empirically confirmed for `challenge_admin()` via the new failing unit test `tests/Unit/GateTest.php::test_intercept_admin_challenge_redirect_preserves_tab_query_arg` (drives the real `intercept()` -> `challenge_admin()` -> `wp_safe_redirect()` path end to end). `build_session_challenge_url()` was traced by direct code comparison (byte-identical construction pattern to `challenge_admin()`) rather than a dedicated new test, since it is structurally the same code shape already proven vulnerable.
+  implication: CONFIRMED for the gated-action bounce (any Save/Activate/Delete-type action intercepted on the admin surface) and for the REST/AJAX soft-block's session-only challenge link. PHP.
 
-- timestamp: 2026-07-01T01:00:00Z
-  checked: admin/js/wp-sudo-challenge.js:15-42 (iframe-breakout guard at the top of the challenge page's own JS, predating this session).
-  found: The code explicitly detects `window.top !== window.self`, tries `window.top.location.href = window.location.href` inside a try/catch, and on failure falls through with the comment: "Cross-origin/sandboxed hosts such as WordPress Playground must keep the challenge functional inside the embedded frame." `git log -p` on this file shows the guard was added/hardened in commit 3ed7e7f ("fix: stabilize playground sudo demo", also 76928bd), i.e. WP Sudo has ALREADY had to special-case WordPress Playground's iframe navigation model once. That same commit's diff to includes/class-admin-bar.php shows the PRE-existing bug pattern this investigation is looking for: the old admin-bar sudo-deactivate handler built its redirect via a bare `remove_query_arg([...])` call (no explicit base URL), which defaults to `$_SERVER['REQUEST_URI']` of the deactivation request ITSELF (`admin.php?wp_sudo_deactivate=1&_wpnonce=...`) rather than the page the user deactivated from — silently dropping any `&tab=`/query context, exactly this bug's shape. It was fixed by threading a `REDIRECT_PARAM` round-trip (mirrors `return_url` elsewhere).
-  implication: (1) The one *known* WP-Sudo-side instance of this exact bug pattern (bare `remove_query_arg()`/lost-referer redirect) was in Admin_Bar and is already fixed; a `grep` for the same anti-pattern (`remove_query_arg(` with no second argument) elsewhere in includes/*.php returns zero further hits — this specific anti-pattern is not recurring in currently-shipped code. (2) WordPress Playground is independently, externally documented (searched via WebSearch) as running wp-admin inside a **sandboxed iframe without `allow-top-navigation`, behind a Service Worker that intercepts every HTTP request, with a custom outer "browser chrome" that Playground itself says needs special handling because "interacting with the browser's address bar... has no effect on the WordPress instance that runs inside it."** This uniquely affects *programmatic* `window.location.href = ...` assignments (used for the session-only "authenticated" redirect and the GET-stash-replay redirect, admin/js/wp-sudo-challenge.js:148/245/251/320-322) as distinct from genuine `<a href>` clicks (the tab-nav links) and genuine `<form>` submissions (POST-replay, admin/js/wp-sudo-challenge.js:326-341) — both of which were independently traced/tested this session and confirmed tab-preserving.
-  timestamp: 2026-07-01T01:00:00Z
+- timestamp: 2026-07-01T04:00:00Z
+  checked: includes/class-gate.php `Gate::render_blocked_notice()` (lines 2764-2786) and `Gate::render_gate_notice()` (lines 2797-2850).
+  found: Both build `$query_args['return_url'] = $current_url` (from `Gate::get_current_admin_url()`, lines 3037-3052 — itself correctly built, same as Plugin's version) and pass `$query_args` into `add_query_arg()` — identical vulnerable pattern, byte-identical code shape between the two methods. Empirically confirmed for `render_gate_notice()` via the new failing unit test `tests/Unit/GateTest.php::test_gate_notice_challenge_link_preserves_query_string_on_current_page` (a `plugins.php?plugin_status=active&paged=2` query string is truncated to `plugin_status=active` in the rendered "Confirm your identity" link's `return_url`). `render_blocked_notice()` was not given its own dedicated new test because it is textually identical in construction (same `$query_args`/`add_query_arg()` shape) — the `render_gate_notice()` test is dispositive for both.
+  implication: CONFIRMED for the persistent gate notice (shown on every load of a gated page without an active session) and the one-shot blocked-transient notice. These fire on `themes.php`/`theme-install.php`/`plugins.php`/`plugin-install.php`, not directly on `options-general.php?page=wp-sudo-settings`, so they are not literally how the user reproduced THIS report's exact tab, but they share the identical defect and will drop any query string (tab, pagination, filters, etc.) on those pages. PHP.
 
-- timestamp: 2026-07-01T01:00:00Z
-  checked: Whether any single-site code path can even PRODUCE a full-page challenge navigation while `tab=access` is displayed, given `render_access_tab()` has zero `<form>` elements.
-  found: The ONLY way to reach the full-page challenge (`wp-sudo-challenge`) screen from `tab=access` is (a) the Ctrl+Shift+S/Cmd+Shift+S keyboard shortcut (session-only, no stash), or (b) clicking the "Confirm your identity" link in the one-shot `render_blocked_notice()` admin notice after a blocked Access-tab AJAX action. Both were traced and empirically tested this session (see Eliminated) and both correctly preserve `&tab=access` all the way through `cancelUrl`.
-  implication: No WP-Sudo PHP/JS code defect was found that drops the tab from `tab=access` on single-site. Every reachable path is provably correct in isolation. The reported symptom is real (per the user's live observation) but its mechanism was not reproduced in this codebase's own logic; the leading remaining candidate is the Playground iframe/Service-Worker navigation environment interacting with the plugin's `window.location.href` assignments specifically (as opposed to link/form navigation), which is consistent with (1) the symptom being full-page-content loss (not just an address-bar cosmetic issue), (2) the plugin's own prior, documented need to special-case Playground's navigation model, and (3) every other (non-JS-driven) navigation in the plugin being independently verified tab-safe.
-  timestamp: 2026-07-01T01:00:00Z
+- timestamp: 2026-07-01T04:00:00Z
+  checked: includes/class-admin-bar.php `Admin_Bar::admin_bar_node()` (lines 82-94) — the "Sudo: M:SS" countdown node's deactivate link, and `handle_deactivate()` (lines 122-195) which reads `$_GET[REDIRECT_PARAM]` back.
+  found: `admin_bar_node()` builds `add_query_arg( array( DEACTIVATE_PARAM => '1', REDIRECT_PARAM => $current_url ), admin_url() )`, nesting `$current_url` (from `self::current_url()`, itself correctly built) as a raw array value — the identical vulnerable pattern, now confirmed at a 4th, previously unidentified trigger point. Empirically confirmed via the new failing unit test `tests/Unit/AdminBarTest.php::test_admin_bar_node_deactivate_url_preserves_tab_query_arg`. Note: the EXISTING test `test_admin_bar_node_shows_for_active_session()` cannot detect this because it (a) hand-fabricates the entire `add_query_arg()`/`wp_nonce_url()` return chain via `Mockery::andReturn()` with a manually pre-percent-encoded string, and (b) uses a REQUEST_URI with no query string at all (`/sample-page/`), which cannot expose a "nested `&` becomes a sibling param" bug by construction.
+  implication: CONFIRMED — a 4th, independent trigger for the same root cause: clicking the admin-bar "Sudo: M:SS" countdown to deactivate a session from any tabbed/query-string admin page (including `options-general.php?page=wp-sudo-settings&tab=access` itself) loses the intended post-deactivation return page's tab/query string. PHP.
 
-- timestamp: 2026-07-01T02:00:00Z
-  checked: FOCUSED PASS — the post-auth SUCCESS redirect specifically (not the outbound return_url capture, which was already proven safe). Re-verified `handle_ajax_auth()`'s `case 'success'` with empty `$stash_key` (admin/js/wp-sudo-challenge.js:147-150, :244-246, :250-253 — all three `code==='authenticated'`/`sessionOnly` branches do `window.location.href = config.cancelUrl`) and `render_resume_page()`'s no-stash branch (includes/class-challenge.php:707-710, :751-757 — identical `$cancel_url` fallback, same `window.location.href` pattern). Pulled REAL WordPress core source from wordpress-develop trunk (not the prior session's Brain\Monkey stubs) for every function in the chain: `add_query_arg()` (wp-includes/functions.php:1144), `esc_url()`/`esc_url_raw()` (wp-includes/formatting.php:4514, :4632), `wp_validate_redirect()` and `wp_sanitize_redirect()` (wp-includes/pluggable.php:1553, :1665).
-  found: (1) `add_query_arg()` uses `wp_parse_str()` + `urlencode_deep()` + `build_query()` (which calls `_http_build_query(..., '&', ...)` — a literal `&` separator, never `&amp;`), so nesting a tabbed URL as the VALUE of `return_url` round-trips byte-for-byte (verified with a standalone PHP script: `add_query_arg`-equivalent `http_build_query`/`parse_str` round trip on `https://example.com/wp-admin/options-general.php?page=wp-sudo-settings&tab=access` reproduces the exact original string). (2) `esc_url_raw()` calls `esc_url($url, $protocols, 'db')` — the `'db'` context SKIPS the `wp_kses_normalize_entities()` + `'&' -> '&#038;'` replacement block, which only runs when `$_context === 'display'` (formatting.php:4547-4552). So `esc_url_raw()` on a `return_url` value leaves its embedded `&tab=access` completely untouched — this was previously only stubbed as `returnArg()` in the unit test, never verified against the real implementation until now. (3) `wp_validate_redirect()` calls `wp_sanitize_redirect()` first, whose character-class filter `[^a-z0-9-~+_.?#=&;,/:%!*\[\]()@]` explicitly ALLOWS `&` and `=` — the tab param survives this filter untouched. (4) `render_resume_page()`'s no-stash `$redirect_url` is exactly `$cancel_url`, constructed identically to `enqueue_assets()`'s `cancel_url` (both read `$_GET['return_url']` -> `esc_url_raw()` -> `wp_validate_redirect()`) — no divergent logic exists between the two success-path renderers.
-  implication: Every real WordPress core function in the single-site success-redirect chain — not just the plugin's own code, and not just what the existing unit test's stubs simulated — is independently confirmed, against live trunk source, to preserve a `&tab=` query argument end-to-end. No new hypothesis could be constructed this pass that predicts single-site tab loss from ANY reachable WP-Sudo code path. This closes out the one specific gap named in this session's brief (the SUCCESS redirect, as distinct from the already-tested CANCEL/outbound path) with the same "no defect" conclusion — now on stronger evidence (real implementations, not test doubles). No new failing test was written, because no falsifiable code-level hypothesis remained to test.
+- timestamp: 2026-07-01T04:00:00Z
+  checked: Whether the existing test suite could have caught any of this, i.e. why 3 prior debugging sessions in this file concluded "no defect found."
+  found: Every "real add_query_arg semantics" stub across the ENTIRE test suite (`tests/Unit/AdminTest.php::stub_real_add_query_arg_semantics()`, `tests/Unit/GateTest.php::mock_rest_challenge_url_helpers()`, and more than a dozen inline `Functions\when('add_query_arg')->alias(...)` closures across AdminTest.php, GateTest.php, and elsewhere) uses PHP's native `http_build_query()` to emulate the WordPress function. `http_build_query()` URL-encodes every value by default — the OPPOSITE of what real `add_query_arg()` does for newly-added array values. So every test in this codebase that call itself "real semantics" was actually testing an idealized, bug-free reimplementation of `add_query_arg()`, not WordPress's actual (contractually documented, intentional) behavior. `Challenge::enqueue_assets()`'s existing passing test (`test_enqueue_assets_cancel_url_preserves_tab_query_arg_from_access_tab`) additionally tested only the downstream half of the pipeline (starting from an already-correct `$_GET['return_url']`), never the upstream construction of `challengeUrl`/`return_url` where the actual corruption occurs.
+  implication: This is a systemic test-authoring blind spot, not a one-off mistake, and likely affects other `add_query_arg()`-based assertions in the suite beyond the 4 confirmed triggers here (any test using `http_build_query()`-style stubs to check output correctness of a URL built by nesting another URL as a value would have the same blind spot — a broader sweep is recommended but out of scope for this root-cause-only session). Fixed going forward in this file's own new tests via `TestCase::stub_faithful_add_query_arg()`, a byte-for-byte port of the real WordPress implementation.
 
 ## Resolution
 
 root_cause: |
-  `WP_Sudo\Admin::handle_network_settings_save()` (includes/class-admin.php:429-453) is the
-  POST handler for the multisite network-admin Sudo Settings form
-  (`<form action="{network_admin_url}edit.php?action=wp_sudo_settings">`, rendered at
-  includes/class-admin.php:1742-1748). Unlike WordPress core's own `options.php` handler
-  (which single-site delegates to, and which builds its post-save redirect from
-  `wp_get_referer()` — see wp-admin/options.php line 374 in wordpress-develop trunk),
-  `handle_network_settings_save()` hardcodes its redirect target:
+  ONE shared root cause, occurring independently at FOUR confirmed PHP call sites (not a
+  WordPress Playground artifact, not JS, not multisite-specific):
 
-      wp_safe_redirect(
-          add_query_arg(
-              array( 'page' => self::PAGE_SLUG, 'updated' => 'true' ),
-              network_admin_url( 'settings.php' )
-          )
-      );
+  WordPress core's `add_query_arg( array $args, string $url )` does NOT URL-encode values
+  supplied via the `$args` array — only values already present in `$url`'s own existing query
+  string get `urlencode_deep()`'d (they are parsed out via `wp_parse_str()` first, encoded, then
+  the caller's NEW `$args` are merged in afterward, unencoded). `build_query()` — which
+  `add_query_arg()` calls internally — explicitly passes `$urlencode = false` to
+  `_http_build_query()`. This is documented plugin-author-facing WordPress behavior: the
+  `add_query_arg()` docblock states "Values are expected to be encoded appropriately with
+  urlencode() or rawurlencode()." — it is the CALLER's responsibility.
 
-  It never reads `_wp_http_referer` (present in the POST body — including the replayed POST
-  body during a sudo challenge replay — because `_wp_http_referer` is unconditionally part of
-  `Action_Registry::DEFAULT_REPLAY_POST_FIELDS`, includes/class-action-registry.php:73-80).
-  As a result, EVERY network-admin settings save — reauth-gated or not — redirects to the bare
-  `?page=wp-sudo-settings&updated=true`, discarding whatever `&tab=` the user was on. The sudo
-  reauth replay round-trip (stash/challenge/JS self-submitting form) is NOT where the tab is
-  lost; it faithfully carries `_wp_http_referer` all the way to this handler. The bug is a
-  pre-existing defect in the network-admin settings-save redirect itself, which the reauth
-  flow merely surfaces because it re-POSTs the same form via replay.
+  Every one of the following WP-Sudo call sites nests a FULL URL — itself already containing a
+  query string with its own `&`-separated pairs (e.g. `.../options-general.php?page=wp-sudo-settings&tab=access`)
+  — as a raw, un-pre-encoded VALUE inside the `$args` array passed to `add_query_arg()`. Because
+  that value is never encoded, its embedded `&tab=access` is emitted as a literal `&` in the
+  output, becoming a NEW top-level sibling query parameter instead of remaining part of the
+  value. When a later request's query string is parsed back into `$_GET` (or `$_POST`), the
+  intended value is truncated at the first `&` and everything after it — including `tab=access`
+  — is silently lost.
 
-  Single-site (`options-general.php?page=wp-sudo-settings&tab=...`, `<form action="options.php">`)
-  is NOT affected by THIS mechanism — it uses WordPress core's Settings API end-to-end, and
-  core's `options.php` already redirects via `wp_get_referer()`, which correctly resolves to the
-  tabbed URL both on direct save and on sudo-challenge replay. This was re-verified in this
-  session (not just re-asserted): render_access_tab() has no <form> at all, so the Settings-tab
-  save form cannot be what the user submitted while `tab=access` was showing, and the tab-nav
-  links + Settings-save POST-replay path were re-traced against live wordpress-develop trunk
-  source with no change to the original conclusion.
+  | # | Trigger | File:Line | Mechanism | Layer |
+  |---|---------|-----------|-----------|-------|
+  | 1 | Ctrl/Cmd+Shift+S keyboard shortcut (session-only reauth) | `includes/class-plugin.php:218-224` (`Plugin::enqueue_shortcut()`) | B — `return_url` (full URL) nested as array value in `add_query_arg()`, unencoded | PHP |
+  | 2 | Gated-action bounce (Save/Activate/Delete/any admin-surface gated request) | `includes/class-gate.php:2611-2619` (`Gate::challenge_admin()`, private, called from `intercept()`) | B — identical pattern, `return_url` from `wp_get_referer()` | PHP |
+  | 3 | REST/AJAX cookie-auth soft-block session-only challenge link | `includes/class-gate.php:2582-2587` (`Gate::build_session_challenge_url()`, private, called from `intercept_rest()`) | B — identical pattern | PHP |
+  | 4 | Persistent gate notice on gated pages (themes/plugins list, install screens) | `includes/class-gate.php:2831-2839` (`Gate::render_gate_notice()`) | B — identical pattern, `current_url` from `Gate::get_current_admin_url()` | PHP |
+  | 5 | One-shot "blocked action" admin notice (after a blocked Access-tab AJAX action) | `includes/class-gate.php:2766-2774` (`Gate::render_blocked_notice()`) | B — byte-identical construction to #4 | PHP |
+  | 6 | Admin-bar "Sudo: M:SS" countdown deactivate link | `includes/class-admin-bar.php:84-94` (`Admin_Bar::admin_bar_node()`) | B — `REDIRECT_PARAM` (full URL) nested as array value | PHP |
+  | — | Settings-tab Save (`<form action="options.php">`) POST-replay | `includes/class-request-stash.php` / WP core `options.php` | SAFE — uses `wp_get_referer()`'s value directly as a redirect target `$location`, never as a nested array value inside `add_query_arg()` | PHP |
+  | — | GET-stash-replay redirect (`Challenge::build_replay_response_data()`, non-redacted GET stash) | `includes/class-challenge.php:838-843` | SAFE — redirects to `$safe_url` (the stash's own `url`) directly, no nested-value `add_query_arg()` call | PHP |
+  | — | Redacted/blocked-replay notice query arg | `includes/class-challenge.php:818` | SAFE — uses the SCALAR two-arg form `add_query_arg( 'key', 'value', $existing_url )`, which parses `$existing_url`'s query string via `wp_parse_str()` and re-encodes it with `urlencode_deep()`; no full URL is ever nested as a VALUE here | PHP |
+  | — | `Challenge::enqueue_assets()` / `render_page()` — consuming `$_GET['return_url']` into `cancelUrl` | `includes/class-challenge.php:200-205, 260-263` | SAFE (downstream only) — `esc_url_raw()` and `wp_validate_redirect()`/`wp_sanitize_redirect()` do not strip or corrupt an already-intact query string; they cannot "fix" a `return_url` that was already truncated by an upstream `add_query_arg()` call, but they do not introduce any additional corruption of their own | PHP |
+  | — | Challenge JS `window.location.href = config.cancelUrl` assignments | `admin/js/wp-sudo-challenge.js:148, 245, 251, 379` | SAFE (not implicated) — consumes an already-server-computed value; performs no URL construction of its own | JS |
+  | — | Shortcut JS `window.location.href = config.challengeUrl` | `admin/js/wp-sudo-shortcut.js:26` | SAFE (not implicated) — same, purely a value consumer | JS |
 
-  ---
+  The bug is NOT the JS layer (no client-side URL construction happens anywhere in this chain —
+  every `window.location.href` assignment consumes an already-fully-formed URL string handed to
+  it via `wp_localize_script()`), and it is NOT specific to WordPress Playground (it reproduces
+  identically in a pure PHP unit test with zero browser involvement, e.g. the admin-bar
+  deactivate-link case, which round-trips entirely through `$_GET` on ordinary WordPress admin
+  requests). The prior session's "environmental artifact" conclusion is retracted.
 
-  SINGLE-SITE re-investigation (this session, per live user report on WP Playground/WP 7.0/
-  single-site): the user's report is real (they observed it), but its mechanism is NOT a defect
-  in `handle_network_settings_save()`'s sibling logic, nor in any WP-Sudo PHP or JS code path
-  reachable from `tab=access`, all of which were traced AND empirically unit-tested this session:
-
-    - Ctrl+Shift+S/Cmd+Shift+S keyboard shortcut (session-only challenge, `Plugin::enqueue_shortcut()`
-      -> `Challenge::enqueue_assets()`'s `cancelUrl`): new test
-      `test_enqueue_assets_cancel_url_preserves_tab_query_arg_from_access_tab`
-      (tests/Unit/ChallengeTest.php) PASSES — the tab survives the round trip.
-    - `Gate::render_blocked_notice()`'s one-shot "Confirm your identity" link after a blocked
-      Access-tab AJAX action: structurally identical `return_url`/`cancelUrl` mechanism, verified
-      by code diff against the already-tested shortcut path.
-    - `sendAccessAction()` (admin/js/wp-sudo-admin.js): re-read line-by-line; never reads
-      `challenge_url`, never issues any redirect on a `sudo_required` error — only an inline
-      message. Confirmed not a navigation path at all.
-
-  No single-site code defect was reproduced. The leading remaining candidate, supported by
-  external evidence (WebSearch) and by this codebase's own prior history, is an ENVIRONMENTAL
-  interaction specific to WordPress Playground: Playground runs wp-admin inside a sandboxed
-  iframe (documented as lacking `allow-top-navigation`) behind a Service Worker that intercepts
-  every HTTP request, with a custom outer "browser chrome" that Playground's own docs say is
-  needed because "interacting with the browser's address bar... has no effect on the WordPress
-  instance that runs inside it." WP Sudo's own challenge JS (admin/js/wp-sudo-challenge.js:15-42)
-  already has a dedicated, Playground-referencing workaround for this iframe model (added in
-  commit 3ed7e7f / 76928bd, "fix: stabilize playground sudo demo") — and that SAME commit fixed
-  an admin-bar redirect bug with exactly this bug's shape (a lost referer/query context on
-  redirect, caused by a bare `remove_query_arg()` call defaulting to the WRONG page's
-  REQUEST_URI). A `grep` for that specific anti-pattern elsewhere in includes/*.php found no
-  further instances, so it is not recurring in currently-shipped code — but it establishes that
-  this exact bug SHAPE has hit WP Sudo once before in a Playground-adjacent code path.
-
-  The single-site session-only/AJAX-notice redirects use `window.location.href = <url>`
-  (a JS-programmatic navigation) — distinct in kind from every other navigation in the plugin
-  (tab-nav `<a href>` clicks, and the Settings-save POST-replay's genuine auto-submitted
-  `<form>`), both of which were independently confirmed tab-safe this session. This asymmetry —
-  JS-driven navigation is the one kind of navigation NOT yet proven safe under Playground's
-  iframe/Service-Worker interception, while link- and form-driven navigation are — is consistent
-  with the symptom being full PAGE CONTENT loss (not just an address-bar cosmetic artifact) while
-  no corresponding PHP/JS logic defect could be found or reproduced in a unit test.
-
-  Scope note: the CONFIRMED root cause (handle_network_settings_save) is multisite-only. The
-  SINGLE-SITE report could not be attributed to a WP-Sudo code defect after exhaustive tracing
-  and testing of every reachable path; see `fix` below for what is and is not recommended.
+  Root-cause discovery was blocked for 3 prior sessions by a systemic test-suite blind spot: every
+  "real add_query_arg() semantics" stub in this codebase (`AdminTest::stub_real_add_query_arg_semantics()`,
+  `GateTest::mock_rest_challenge_url_helpers()`, and numerous inline closures) used PHP's native
+  `http_build_query()`, which DOES urlencode by default — silently curing the exact defect under
+  test before it could be observed. This session confirmed the mechanism first via a standalone
+  byte-for-byte port of the real WordPress function (not `http_build_query()`), then via a new
+  shared test helper (`TestCase::stub_faithful_add_query_arg()`) used to write 4 failing tests
+  against the actual production code paths.
 
 fix: |
-  NOT IMPLEMENTED (goal: find_root_cause_only). Proposed minimal fix:
+  NOT IMPLEMENTED (goal: reproduce_and_root_cause_ONLY, per this session's constraints — return_url
+  feeds redirects, so a Pre-Implementation Design Review is required before any production change).
 
-  In `handle_network_settings_save()`, replace the hardcoded redirect target with one derived
-  from the request's own referer, mirroring core's `options.php` pattern, falling back to the
-  bare settings URL only when no referer is available or it fails validation:
+  Consolidated fix direction covering all 6 affected call sites with ONE pattern change: stop
+  nesting a full URL as a raw array VALUE inside `add_query_arg()`. Two equivalent options, in
+  order of preference:
 
-      $fallback = add_query_arg(
-          array( 'page' => self::PAGE_SLUG ),
-          network_admin_url( 'settings.php' )
-      );
-      $referer  = wp_get_referer();
-      $goback   = $referer ? wp_validate_redirect( $referer, $fallback ) : $fallback;
+  1. **Pre-encode the nested value before merge (minimal diff, preferred):** wrap each
+     `return_url`/`redirect_to`/`REDIRECT_PARAM` value in `rawurlencode()` before placing it in the
+     `$args` array, e.g.:
 
-      wp_safe_redirect( add_query_arg( 'updated', 'true', $goback ) );
-      exit;
+         $query_args['return_url'] = rawurlencode( $return_url );
+         // ... then when CONSUMING it back out of $_GET, the existing esc_url_raw()/
+         // wp_unslash() call sites already correctly decode standard urlencoded values
+         // (PHP's own $_GET parsing rawurldecode()s automatically) — no downstream change needed.
 
-  This is the smallest change: one method, no new stash/replay plumbing needed (the referer is
-  already present in `$_POST['_wp_http_referer']` both for direct saves and reauth replays,
-  since `wp_get_referer()` reads `$_REQUEST['_wp_http_referer']`, which includes `$_POST`).
+     This is the smallest, most mechanical fix: one `rawurlencode()` call at each of the 6 sites
+     listed above (`Plugin::enqueue_shortcut()`, `Gate::challenge_admin()`,
+     `Gate::build_session_challenge_url()`, `Gate::render_gate_notice()`,
+     `Gate::render_blocked_notice()`, `Admin_Bar::admin_bar_node()`), no change to any consuming
+     code, since PHP's native query-string parsing already decodes standard percent-encoding.
+
+  2. **Use `add_query_arg()`'s scalar two-arg form against a URL that already has the base query
+     string**, mirroring the ALREADY-SAFE pattern proven correct in
+     `Challenge::build_replay_response_data()` (`add_query_arg( 'key', 'value', $existing_url )`,
+     class-challenge.php:818) — not applicable here since these 6 sites are adding NEW keys to a
+     FRESH base URL (`admin_url('admin.php')`, etc.), not modifying an existing URL's own query
+     string, so option 1 is the more direct fix for this shape of call.
 
   Must NOT break:
-    - `wp_validate_redirect()`'s open-redirect protection — keep using it (as shown above),
-      do not swap in a raw `$_POST['_wp_http_referer']` echo.
-    - The existing `updated=true` notice query arg and its consumption at
-      includes/class-admin.php:1698-1702 (`$is_network && isset($_GET['updated'])`) — that
-      check is tab-agnostic already, so it will keep working regardless of which tab is in
-      the redirect.
-    - POST-replay redaction/blocking semantics in `Challenge::build_replay_response_data()`
-      are untouched by this fix — `options.wp_sudo`'s stash is not redacted/blocked, so it
-      already reaches `handle_network_settings_save()` via the normal replay-form POST path;
-      only the redirect target inside that handler changes.
-    - The existing test `test_handle_network_settings_save_updates_site_option_and_redirects`
-      (tests/Unit/AdminTest.php:1435) currently stubs `add_query_arg` to a fixed string and
-      does not set `_wp_http_referer`; it will need `wp_get_referer()`/`wp_validate_redirect()`
-      stubbed (e.g. `Functions\when('wp_get_referer')->justReturn(false)` to keep exercising
-      the no-referer fallback branch) so it continues to assert the `updated=true` bare-URL
-      case explicitly, while the new `test_handle_network_settings_save_redirect_drops_tab_query_arg`
-      test (added in this session) is updated to assert the tab IS preserved once the fix lands
-      (currently asserts the failure).
+    - `wp_validate_redirect()`'s open-redirect protection at the consuming end (`Challenge::enqueue_assets()`,
+      `render_page()`, `handle_deactivate()`) — these are unaffected either way; they operate on
+      whatever `esc_url_raw( wp_unslash( $_GET[...] ) )` decodes to, which will simply be correct
+      once the value is properly encoded going in.
+    - The scalar-form `add_query_arg( 'key', 'value', $redirect_url )` call in
+      `Challenge::build_replay_response_data()` (class-challenge.php:818) — already safe, must not
+      be "fixed" (it isn't broken) or accidentally double-encoded by a broad find/replace.
+    - Existing passing tests for `Challenge::enqueue_assets()`/`render_page()` that seed
+      `$_GET['return_url']` directly — those remain valid regression coverage for the downstream
+      half of the pipeline and require no change.
+    - Any test currently using an `http_build_query()`-based `add_query_arg()` stub — those tests
+      will continue to pass unchanged (they were never testing the defective behavior in the first
+      place), but should NOT be relied upon as regression coverage for this fix. The 4 new tests
+      added this session (using `TestCase::stub_faithful_add_query_arg()`) are the correct
+      regression coverage and should be updated from `assertStringContainsString` on the CURRENT
+      (broken) truncated value to asserting the FULL tab/query-string survives, once the fix lands.
+    - Should also consider (not required, flagged for the design review): a broader sweep of the
+      test suite's other `http_build_query()`-based `add_query_arg()` stubs, since this same blind
+      spot could be masking other, unrelated `add_query_arg()` misuse elsewhere in the plugin. Out
+      of scope for this root-cause session.
 
-  ---
+verification: |
+  4 new failing PHPUnit tests added and confirmed to fail against current `main`, using a new
+  faithful `add_query_arg()` stub (`TestCase::stub_faithful_add_query_arg()`, a byte-for-byte port
+  of wordpress-develop trunk's `add_query_arg()`/`build_query()`/`_http_build_query()`, verified
+  against live trunk source this session):
+    - `tests/Unit/PluginTest.php::test_enqueue_shortcut_challenge_url_preserves_tab_query_arg_from_access_tab`
+    - `tests/Unit/GateTest.php::test_intercept_admin_challenge_redirect_preserves_tab_query_arg`
+    - `tests/Unit/GateTest.php::test_gate_notice_challenge_link_preserves_query_string_on_current_page`
+    - `tests/Unit/AdminBarTest.php::test_admin_bar_node_deactivate_url_preserves_tab_query_arg`
 
-  SINGLE-SITE: no fix is proposed for a WP-Sudo code defect, because none was found or
-  reproduced. The multisite fix above and the single-site report do NOT share a root cause or a
-  fix — they are two distinct findings:
-    - Multisite: a real, confirmed, reproducible WP-Sudo logic defect (hardcoded redirect
-      ignoring `_wp_http_referer`), independent of any hosting environment.
-    - Single-site: an unreproduced report whose likely mechanism (if the leading environmental
-      hypothesis is correct) lies in WordPress Playground's iframe/Service-Worker navigation
-      model interacting with the plugin's `window.location.href` JS redirects, not in WP-Sudo's
-      PHP or JS logic itself.
+  `composer test:unit` (full suite): 949 tests, 945 pass, exactly these 4 fail — confirming
+  isolation (the new shared test helper causes zero regressions elsewhere) and confirming the
+  defect is reproducible via ordinary PHPUnit + Brain\Monkey, with no browser, iframe, or
+  WordPress Playground involved.
 
-  If the orchestrator wants defense-in-depth regardless of attribution, the lowest-risk,
-  narrowly-scoped option (NOT implemented, would need its own design review per
-  CLAUDE.md — it changes an existing UX contract) would be to make the session-only/AJAX-notice
-  challenge redirects behave more like the already-safe POST-replay path, e.g. by round-tripping
-  through a real navigation primitive (a genuine `<a>` click simulation, or a same-document
-  `history.pushState`-based approach) instead of a bare `window.location.href` assignment — but
-  this should NOT be implemented speculatively without first reproducing the failure in an actual
-  WP Playground browser session, per the reinvestigate instructions' own disambiguation ask.
-  Reproducing this requires a live browser (Playground) session, which is out of scope for this
-  agent per CLAUDE.md's browser/Playwright handoff policy — restart with
-  `/Users/danknauss/bin/claude-playwright` or `/Users/danknauss/bin/claude-browser-handoff` and
-  capture: (1) whether `window.top !== window.self` and the `canNavigateTop` catch branch fires,
-  (2) the live value of `window.wpSudoChallenge.cancelUrl` immediately before the post-auth
-  redirect, and (3) a HAR/network trace of the admin-ajax.php challenge POST and the subsequent
-  navigation inside the Playground iframe.
+  Per this session's mode (`goal: reproduce_and_root_cause_ONLY`): NO fix implemented, NO commit,
+  NO `reviewer-approved` flag written, NO version/tag bump. All 4 new tests are LEFT FAILING
+  (uncommitted) as the reproduction artifact for the next session's fix-and-verify pass, which
+  must first pass a Pre-Implementation Design Review per CLAUDE.md (return_url feeds redirects —
+  security-sensitive).
 
-  ---
-
-  FOCUSED SUCCESS-REDIRECT PASS (this session, single-site only): re-verified the ONE remaining
-  untested angle — the post-auth SUCCESS redirect for a proactive (no-stash) reauth — against REAL
-  WordPress core source (add_query_arg, esc_url/esc_url_raw, wp_validate_redirect,
-  wp_sanitize_redirect pulled from wordpress-develop trunk), not just the prior session's
-  Brain\Monkey test stubs. Every hop of `return_url` (query-string capture) -> `cancelUrl`
-  (Challenge::enqueue_assets()/render_page()) -> `window.location.href` (challenge JS's
-  `code==='authenticated'` branches, admin/js/wp-sudo-challenge.js:148/245/251, and
-  render_resume_page()'s identical no-stash fallback) is confirmed tab-preserving using the actual
-  WordPress implementations of every function in the chain, not simulated behavior. No divergence
-  was found between this SUCCESS path and the already-tested CANCEL path — both use the same
-  `cancel_url`/`return_url` construction. No new single-site code defect was found or reproduced.
-
-  CONCLUSION FOR THIS PASS: the single-site symptom is NOT attributable to the success-redirect
-  code path either. Combined with the prior session's exhaustive elimination of the stash/replay,
-  shortcut, and AJAX-notice paths, EVERY reachable single-site WP-Sudo code path (PHP and JS) that
-  could plausibly drop `&tab=` has now been traced and verified against real implementations with
-  no defect found. The environmental-artifact hypothesis (WordPress Playground's sandboxed-iframe +
-  Service-Worker navigation model intercepting the plugin's `window.location.href` JS-programmatic
-  redirects specifically) remains the sole standing explanation for the live user report.
-
-  EXACT CAPTURE NEEDED TO CONFIRM (from a live WP Playground browser, single-site, WP 7.0,
-  reproducing: be on options-general.php?page=wp-sudo-settings&tab=access, trigger Ctrl/Cmd+Shift+S,
-  pass the password/2FA challenge, observe landing on bare ?page=wp-sudo-settings):
-    1. In the browser console on the CHALLENGE page (before pressing Confirm & Continue), run
-       `window.wpSudoChallenge.cancelUrl` and record the exact string. PREDICTION if the plugin's
-       own construction is correct: it will already contain `&tab=access`. If it does NOT, that
-       would falsify this session's entire chain of reasoning and reopen the PHP-side
-       investigation — this is the single highest-value data point.
-    2. Immediately after passing the challenge (before the page finishes navigating), open DevTools
-       Network tab and find the `admin-ajax.php` POST for `action=wp_sudo_challenge_auth`. Inspect
-       the JSON response body; confirm `data.code === 'authenticated'` and that no `redirect` field
-       is present that could override `cancelUrl` (per this session's trace, none should be, but
-       Playground's Service Worker could theoretically be rewriting the response body in flight).
-    3. Add a temporary one-line `console.log('wp-sudo redirecting to:', config.cancelUrl)`
-       immediately before each of the three `window.location.href = config.cancelUrl` assignments
-       in admin/js/wp-sudo-challenge.js (lines 148, 245, 251), reload, and repeat the repro. Compare
-       the logged value to the URL the browser's address bar actually ends up showing after the
-       navigation settles. A MISMATCH between the logged value and the final address bar URL — with
-       the logged value correctly containing `&tab=access` — would conclusively confirm the
-       Playground iframe/Service-Worker navigation layer (not WP-Sudo's own JS or PHP) is the
-       mechanism that drops the tab.
-    4. Check `window.top !== window.self` and, if true, whether Playground's outer iframe has a
-       `sandbox` attribute and whether it includes `allow-top-navigation` — this determines which
-       branch of the iframe-breakout guard at admin/js/wp-sudo-challenge.js:15-42 executes, and
-       specifically whether `window.top.location.href = window.location.href` throws (caught
-       silently) versus succeeds.
-  verification: n/a — no fix implemented for either finding in this session (goal: root-cause only).
 files_changed: []

--- a/docs/current-metrics.md
+++ b/docs/current-metrics.md
@@ -9,21 +9,21 @@ Verification environment: local workspace, PHP 8.x
 
 | Metric | Value | Verification |
 |---|---:|---|
-| Unit tests | 945 tests | `composer test:unit` |
-| Unit assertions | 2,855 assertions | `composer test:unit` |
+| Unit tests | 956 tests | `composer test:unit` |
+| Unit assertions | 2,888 assertions | `composer test:unit` |
 | Integration tests in suite | 208 test methods | `rg -c "function test" tests/Integration/*.php | awk -F: '{sum+=$2} END{print sum}'` |
-| Unit test files | 28 | `ls tests/Unit/*.php | wc -l` |
+| Unit test files | 29 | `ls tests/Unit/*.php | wc -l` |
 | Integration test files | 28 | `ls tests/Integration/*.php | wc -l` |
 
 ## Size Metrics
 
 | Metric | Value | Verification |
 |---|---:|---|
-| Production PHP lines (`includes/`, `wp-sudo.php`, `uninstall.php`, `mu-plugin/`, `bridges/`) | 16,719 | `find ./includes ./wp-sudo.php ./uninstall.php ./mu-plugin ./bridges -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
-| Tests PHP lines (`tests/`) | 34,296 | `find ./tests -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
-| Production + tests PHP lines | 51,015 | sum of the two rows above |
-| Test-to-production ratio | 2.05:1 | `34296 / 16719` |
-| Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`) | 51,287 | `find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/vendor_test/*" ! -path "*/.tmp/*" ! -path "*/.git/*" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Production PHP lines (`includes/`, `wp-sudo.php`, `uninstall.php`, `mu-plugin/`, `bridges/`) | 16,756 | `find ./includes ./wp-sudo.php ./uninstall.php ./mu-plugin ./bridges -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Tests PHP lines (`tests/`) | 34,896 | `find ./tests -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Production + tests PHP lines | 51,652 | sum of the two rows above |
+| Test-to-production ratio | 2.08:1 | `34896 / 16756` |
+| Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`) | 51,924 | `find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/vendor_test/*" ! -path "*/.tmp/*" ! -path "*/.git/*" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
 
 ## Architectural Facts
 
@@ -66,7 +66,7 @@ Source: `.github/workflows/phpunit.yml`, `.github/workflows/e2e.yml`, `.github/w
 
 ## Verification Notes
 
-- `composer test:unit` passed on 2026-07-01 (`945 tests`, `2855 assertions`). Phase 24 (Session Revocation UI) added the shared revoke-all/liveness methods, the factored revocation core, the Users-list row action + revoke-all interstitial + distinct result notices, and removed the Access-tab session-revoke button and the orphaned AJAX path; a follow-up fix preserves the settings `tab` on multisite network settings save (+4 tests).
+- `composer test:unit` passed on 2026-07-01 (`956 tests`, `2888 assertions`). Phase 24 (Session Revocation UI) added the shared revoke-all/liveness methods, the factored revocation core, the Users-list row action + revoke-all interstitial + distinct result notices, and removed the Access-tab session-revoke button and the orphaned AJAX path. Follow-up fixes preserve the settings `tab` across a sudo reauth: on multisite network settings save, and single-site via a shared `wp_sudo_build_challenge_url()` helper that rawurlencodes the nested return_url across all challenge-URL builders + the admin-bar deactivate link (+11 tests, incl. a faithful add_query_arg test stub).
 - `composer lint` passed on 2026-06-30.
 - Static analysis passed on 2026-06-30 (PHPStan L6 `[OK] No errors`; Psalm `No errors found!`, baseline current).
 - `composer verify:metrics` passed on 2026-06-30 (after this update).

--- a/includes/class-admin-bar.php
+++ b/includes/class-admin-bar.php
@@ -85,7 +85,7 @@ class Admin_Bar {
 			add_query_arg(
 				array(
 					self::DEACTIVATE_PARAM => '1',
-					self::REDIRECT_PARAM   => $current_url,
+					self::REDIRECT_PARAM   => rawurlencode( $current_url ),
 				),
 				admin_url()
 			),

--- a/includes/class-gate.php
+++ b/includes/class-gate.php
@@ -2579,12 +2579,7 @@ class Gate {
 			}
 		}
 
-		$query_args = array( 'page' => 'wp-sudo-challenge' );
-		if ( $return_url ) {
-			$query_args['return_url'] = $return_url;
-		}
-
-		return add_query_arg( $query_args, $base_url );
+		return wp_sudo_build_challenge_url( $base_url, $return_url, array( 'page' => 'wp-sudo-challenge' ) );
 	}
 
 	/**
@@ -2608,15 +2603,14 @@ class Gate {
 			$return_url = '';
 		}
 
-		$query_args = array(
-			'page'      => 'wp-sudo-challenge',
-			'stash_key' => $stash_key,
+		$challenge_url = wp_sudo_build_challenge_url(
+			$base_url,
+			$return_url,
+			array(
+				'page'      => 'wp-sudo-challenge',
+				'stash_key' => $stash_key,
+			)
 		);
-		if ( $return_url ) {
-			$query_args['return_url'] = $return_url;
-		}
-
-		$challenge_url = add_query_arg( $query_args, $base_url );
 
 		if ( wp_safe_redirect( $challenge_url ) ) {
 			exit;
@@ -2763,14 +2757,10 @@ class Gate {
 
 		$current_url = $this->get_current_admin_url();
 
-		$query_args = array( 'page' => 'wp-sudo-challenge' );
-		if ( $current_url ) {
-			$query_args['return_url'] = $current_url;
-		}
-
-		$challenge_url = add_query_arg(
-			$query_args,
-			is_network_admin() ? network_admin_url( 'admin.php' ) : admin_url( 'admin.php' )
+		$challenge_url = wp_sudo_build_challenge_url(
+			is_network_admin() ? network_admin_url( 'admin.php' ) : admin_url( 'admin.php' ),
+			$current_url,
+			array( 'page' => 'wp-sudo-challenge' )
 		);
 
 		printf(
@@ -2828,14 +2818,10 @@ class Gate {
 
 		$current_url = $this->get_current_admin_url();
 
-		$query_args = array( 'page' => 'wp-sudo-challenge' );
-		if ( $current_url ) {
-			$query_args['return_url'] = $current_url;
-		}
-
-		$challenge_url = add_query_arg(
-			$query_args,
-			is_network_admin() ? network_admin_url( 'admin.php' ) : admin_url( 'admin.php' )
+		$challenge_url = wp_sudo_build_challenge_url(
+			is_network_admin() ? network_admin_url( 'admin.php' ) : admin_url( 'admin.php' ),
+			$current_url,
+			array( 'page' => 'wp-sudo-challenge' )
 		);
 
 		printf(

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -215,12 +215,10 @@ class Plugin {
 			true
 		);
 
-		$challenge_url = add_query_arg(
-			array(
-				'page'       => 'wp-sudo-challenge',
-				'return_url' => $this->get_current_admin_url(),
-			),
-			is_network_admin() ? network_admin_url( 'admin.php' ) : admin_url( 'admin.php' )
+		$challenge_url = wp_sudo_build_challenge_url(
+			is_network_admin() ? network_admin_url( 'admin.php' ) : admin_url( 'admin.php' ),
+			$this->get_current_admin_url(),
+			array( 'page' => 'wp-sudo-challenge' )
 		);
 
 		wp_localize_script(

--- a/includes/class-public-api.php
+++ b/includes/class-public-api.php
@@ -182,15 +182,7 @@ class Public_API {
 	private static function build_challenge_url( string $return_url ): string {
 		$base_url = is_network_admin() ? network_admin_url( 'admin.php' ) : admin_url( 'admin.php' );
 
-		$query_args = array(
-			'page' => 'wp-sudo-challenge',
-		);
-
-		if ( '' !== $return_url ) {
-			$query_args['return_url'] = $return_url;
-		}
-
-		return add_query_arg( $query_args, $base_url );
+		return wp_sudo_build_challenge_url( $base_url, $return_url, array( 'page' => 'wp-sudo-challenge' ) );
 	}
 
 	/**

--- a/includes/functions-challenge-url.php
+++ b/includes/functions-challenge-url.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Challenge URL helper functions.
+ *
+ * Provides the centralized wp_sudo_build_challenge_url() helper used by every
+ * surface that builds a link to the sudo challenge page carrying a
+ * `return_url`. Nesting a full URL (which already contains its own `&`
+ * -delimited query string) as a raw, un-pre-encoded array VALUE inside
+ * add_query_arg()'s $args array is unsafe: WordPress core's add_query_arg()/
+ * build_query() do NOT urlencode newly-added array values (only values
+ * already present in the URL's existing query string get urlencode_deep()'d
+ * on the way back out). The nested "&" therefore leaks out as a new
+ * top-level query separator, truncating the return_url at the first "&"
+ * once the browser round-trips the link through $_GET.
+ *
+ * This file is loaded unconditionally at plugin boot (wp-sudo.php) and in
+ * the unit-test bootstrap, making wp_sudo_build_challenge_url() available
+ * as a testable global function — mirroring functions-governance.php.
+ *
+ * @since      4.6.0
+ * @package    WP_Sudo
+ */
+
+// Abort if this file is called directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Build a challenge-page URL, safely encoding a nested return_url.
+ *
+ * Encodes $return_url with rawurlencode() exactly once before handing it to
+ * add_query_arg(), so a return_url that itself carries a query string (e.g.
+ * "...options-general.php?page=wp-sudo-settings&tab=access") survives the
+ * browser's query-string round trip intact. The read side is unchanged:
+ * $_GET auto-decodes exactly once, then Challenge reads it via
+ * esc_url_raw( wp_unslash( $_GET['return_url'] ) ) followed by
+ * wp_validate_redirect() (see class-challenge.php).
+ *
+ * This helper intentionally does NOT call wp_validate_redirect() at build
+ * time — that is a read-side concern. Validating here could pre-strip a
+ * legitimate different-host referer before the value is even encoded.
+ *
+ * @since 4.6.0
+ *
+ * @param string               $base       Base admin URL (e.g. admin_url( 'admin.php' )).
+ * @param string               $return_url Optional return URL. Encoded once via rawurlencode()
+ *                                         when non-empty; omitted from the args entirely when empty.
+ * @param array<string, mixed> $extra      Additional query args (e.g. 'page', 'stash_key').
+ * @return string
+ */
+function wp_sudo_build_challenge_url( string $base, string $return_url, array $extra = array() ): string {
+	$query_args = $extra;
+
+	if ( '' !== $return_url ) {
+		$query_args['return_url'] = rawurlencode( $return_url );
+	}
+
+	return add_query_arg( $query_args, $base );
+}

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -264,6 +264,27 @@
 				is_array( $post_params ) ? $post_params : array()
 			)]]></code>
     </InvalidArgument>
+    <UndefinedFunction>
+      <code><![CDATA[wp_sudo_build_challenge_url(
+			$base_url,
+			$return_url,
+			array(
+				'page'      => 'wp-sudo-challenge',
+				'stash_key' => $stash_key,
+			)
+		)]]></code>
+      <code><![CDATA[wp_sudo_build_challenge_url(
+			is_network_admin() ? network_admin_url( 'admin.php' ) : admin_url( 'admin.php' ),
+			$current_url,
+			array( 'page' => 'wp-sudo-challenge' )
+		)]]></code>
+      <code><![CDATA[wp_sudo_build_challenge_url(
+			is_network_admin() ? network_admin_url( 'admin.php' ) : admin_url( 'admin.php' ),
+			$current_url,
+			array( 'page' => 'wp-sudo-challenge' )
+		)]]></code>
+      <code><![CDATA[wp_sudo_build_challenge_url( $base_url, $return_url, array( 'page' => 'wp-sudo-challenge' ) )]]></code>
+    </UndefinedFunction>
   </file>
   <file src="includes/class-plugin.php">
     <UndefinedConstant>
@@ -275,6 +296,18 @@
       <code><![CDATA[WP_SUDO_VERSION]]></code>
       <code><![CDATA[WP_SUDO_VERSION]]></code>
     </UndefinedConstant>
+    <UndefinedFunction>
+      <code><![CDATA[wp_sudo_build_challenge_url(
+			is_network_admin() ? network_admin_url( 'admin.php' ) : admin_url( 'admin.php' ),
+			$this->get_current_admin_url(),
+			array( 'page' => 'wp-sudo-challenge' )
+		)]]></code>
+    </UndefinedFunction>
+  </file>
+  <file src="includes/class-public-api.php">
+    <UndefinedFunction>
+      <code><![CDATA[wp_sudo_build_challenge_url( $base_url, $return_url, array( 'page' => 'wp-sudo-challenge' ) )]]></code>
+    </UndefinedFunction>
   </file>
   <file src="includes/class-request-stash.php">
     <InvalidArgument>

--- a/tests/Integration/RestGatingTest.php
+++ b/tests/Integration/RestGatingTest.php
@@ -86,7 +86,7 @@ class RestGatingTest extends TestCase {
 		$challenge_url = (string) $error_data['challenge_url'];
 		$this->assertStringStartsWith( admin_url( 'admin.php' ), $challenge_url );
 		$this->assertStringContainsString( 'page=wp-sudo-challenge', $challenge_url );
-		$this->assertStringContainsString( 'return_url=' . admin_url( 'site-editor.php' ), $challenge_url );
+		$this->assertStringContainsString( 'return_url=' . rawurlencode( admin_url( 'site-editor.php' ) ), $challenge_url );
 		$this->assertStringNotContainsString( 'stash_key=', $challenge_url );
 	}
 
@@ -120,7 +120,7 @@ class RestGatingTest extends TestCase {
 		$challenge_url = (string) $error_data['challenge_url'];
 		$this->assertStringStartsWith( network_admin_url( 'admin.php' ), $challenge_url );
 		$this->assertStringContainsString( 'page=wp-sudo-challenge', $challenge_url );
-		$this->assertStringContainsString( 'return_url=' . network_admin_url( 'plugins.php' ), $challenge_url );
+		$this->assertStringContainsString( 'return_url=' . rawurlencode( network_admin_url( 'plugins.php' ) ), $challenge_url );
 		$this->assertStringNotContainsString( 'stash_key=', $challenge_url );
 	}
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -65,6 +65,107 @@ abstract class TestCase extends PHPUnitTestCase {
 		);
 	}
 
+	/**
+	 * Stub add_query_arg()/wp_parse_url() with FAITHFUL WordPress core semantics.
+	 *
+	 * This mirrors wp-includes/functions.php add_query_arg()/build_query()/
+	 * _http_build_query() byte-for-byte, including the behavior most other
+	 * stubs in this suite get wrong: newly-added array values are concatenated
+	 * WITHOUT urlencode() (build_query() calls _http_build_query() with
+	 * $urlencode = false). Only values already present in the URL's existing
+	 * query string get urlencode_deep()'d, because they were parsed back out
+	 * of a real (already-encoded) query string via wp_parse_str().
+	 *
+	 * This distinction is load-bearing: a caller that nests a full URL
+	 * (itself containing '&') as a raw, un-pre-encoded VALUE inside the
+	 * array passed to add_query_arg() will have that nested '&' become a
+	 * new top-level query separator in the output — silently truncating
+	 * the nested URL's own query string. Do NOT use http_build_query()
+	 * (which encodes by default) to stub this function; it hides that bug.
+	 *
+	 * @return void
+	 */
+	protected function stub_faithful_add_query_arg(): void {
+		Functions\when( 'wp_parse_str' )->alias(
+			static function ( $string, &$array ) {
+				parse_str( (string) $string, $array );
+			}
+		);
+
+		Functions\when( 'add_query_arg' )->alias(
+			static function ( ...$args ) {
+				if ( is_array( $args[0] ) ) {
+					$uri = ( count( $args ) < 2 || false === $args[1] ) ? ( $_SERVER['REQUEST_URI'] ?? '' ) : $args[1];
+				} else {
+					$uri = ( count( $args ) < 3 || false === $args[2] ) ? ( $_SERVER['REQUEST_URI'] ?? '' ) : $args[2];
+				}
+
+				$frag = strstr( $uri, '#' );
+				if ( $frag ) {
+					$uri = substr( $uri, 0, -strlen( $frag ) );
+				} else {
+					$frag = '';
+				}
+
+				$protocol = '';
+				if ( 0 === stripos( $uri, 'http://' ) ) {
+					$protocol = 'http://';
+					$uri      = substr( $uri, 7 );
+				} elseif ( 0 === stripos( $uri, 'https://' ) ) {
+					$protocol = 'https://';
+					$uri      = substr( $uri, 8 );
+				}
+
+				if ( str_contains( $uri, '?' ) ) {
+					list( $base, $query ) = explode( '?', $uri, 2 );
+					$base                .= '?';
+				} elseif ( $protocol || ! str_contains( $uri, '=' ) ) {
+					$base  = $uri . '?';
+					$query = '';
+				} else {
+					$base  = '';
+					$query = $uri;
+				}
+
+				parse_str( $query, $qs );
+				$qs = array_map(
+					static function ( $v ) {
+						return is_array( $v ) ? $v : urlencode( (string) $v );
+					},
+					$qs
+				);
+
+				if ( is_array( $args[0] ) ) {
+					foreach ( $args[0] as $k => $v ) {
+						$qs[ $k ] = $v; // NOT urlencoded — matches real WP behavior.
+					}
+				} else {
+					$qs[ $args[0] ] = $args[1]; // NOT urlencoded.
+				}
+
+				foreach ( $qs as $k => $v ) {
+					if ( false === $v ) {
+						unset( $qs[ $k ] );
+					}
+				}
+
+				$pairs = array();
+				foreach ( $qs as $k => $v ) {
+					if ( null === $v ) {
+						continue;
+					}
+					$pairs[] = $k . '=' . ( false === $v ? '0' : $v );
+				}
+				$ret = implode( '&', $pairs );
+				$ret = trim( $ret, '?' );
+				$ret = preg_replace( '#=(&|$)#', '$1', $ret );
+				$ret = $protocol . $base . $ret . $frag;
+				$ret = rtrim( $ret, '?' );
+				return str_replace( '?#', '#', $ret );
+			}
+		);
+	}
+
 	protected function tearDown(): void {
 		unset( $_COOKIE[ \WP_Sudo\Sudo_Session::CHALLENGE_COOKIE ] );
 		unset( $_COOKIE[ \WP_Sudo\Sudo_Session::TOKEN_COOKIE ] );

--- a/tests/Unit/AdminBarTest.php
+++ b/tests/Unit/AdminBarTest.php
@@ -109,7 +109,7 @@ class AdminBarTest extends TestCase {
 					static function ( array $args ): bool {
 						return isset( $args[ Admin_Bar::DEACTIVATE_PARAM ], $args[ Admin_Bar::REDIRECT_PARAM ] )
 							&& '1' === $args[ Admin_Bar::DEACTIVATE_PARAM ]
-							&& 'https://example.com/sample-page/' === $args[ Admin_Bar::REDIRECT_PARAM ];
+							&& rawurlencode( 'https://example.com/sample-page/' ) === $args[ Admin_Bar::REDIRECT_PARAM ];
 					}
 				),
 				'https://example.com/wp-admin/'
@@ -150,6 +150,79 @@ class AdminBarTest extends TestCase {
 		$this->assertSame(
 			'https://example.com/wp-admin/?wp_sudo_deactivate=1&wp_sudo_redirect_to=https%3A%2F%2Fexample.com%2Fsample-page%2F&_wpnonce=abc',
 			$nodes['wp-sudo-active']['href']
+		);
+	}
+
+	/**
+	 * Bug: settings-tab-lost-on-reauth-replay (single-site, CONFIRMED — 4th
+	 * trigger: admin-bar sudo deactivation from a tabbed/query-string page).
+	 *
+	 * admin_bar_node() builds the deactivate URL by nesting $current_url — a
+	 * full URL that already contains its own query string (e.g.
+	 * "...options-general.php?page=wp-sudo-settings&tab=access") — as a raw
+	 * VALUE inside the array given to add_query_arg() (self::REDIRECT_PARAM).
+	 * Real WP core's add_query_arg()/build_query() do not urlencode newly-added
+	 * array values, so the nested "&tab=access" becomes a new sibling
+	 * top-level query parameter on the deactivate URL instead of staying part
+	 * of the REDIRECT_PARAM value. When handle_deactivate() later reads
+	 * $_GET[REDIRECT_PARAM] back (class-admin-bar.php:186-188), it is
+	 * truncated at the first "&" and "tab=access" is lost.
+	 *
+	 * This test uses FAITHFUL add_query_arg() semantics
+	 * (TestCase::stub_faithful_add_query_arg()) rather than the fully
+	 * hand-fabricated Mockery expectation/andReturn() string used by
+	 * test_admin_bar_node_shows_for_active_session() above (which hardcodes
+	 * a pre-percent-encoded fake result and does not exercise a query-string
+	 * REQUEST_URI at all), so it can actually detect the defect.
+	 */
+	public function test_admin_bar_node_deactivate_url_preserves_tab_query_arg(): void {
+		Functions\when( 'get_current_user_id' )->justReturn( 5 );
+		Functions\when( '__' )->returnArg();
+		Functions\when( 'admin_url' )->alias( static fn( string $path = '' ): string => 'https://example.com/wp-admin/' . $path );
+		Functions\when( 'is_ssl' )->justReturn( true );
+		Functions\when( 'esc_url_raw' )->returnArg();
+		Functions\when( 'wp_nonce_url' )->alias(
+			static fn( string $url, $action = -1, string $name = '_wpnonce' ): string => $url . '&' . $name . '=abc'
+		);
+		$this->stub_faithful_add_query_arg();
+
+		$_SERVER['REQUEST_URI'] = '/wp-admin/options-general.php?page=wp-sudo-settings&tab=access';
+		$_SERVER['HTTP_HOST']   = 'example.com';
+
+		$future = time() + 300;
+		$token  = 'bar-token-tab';
+
+		Functions\when( 'get_user_meta' )->alias(
+			function ( $uid, $key, $single ) use ( $future, $token ) {
+				if ( Sudo_Session::META_KEY === $key ) {
+					return $future;
+				}
+				if ( Sudo_Session::TOKEN_META_KEY === $key ) {
+					return hash( 'sha256', $token );
+				}
+				return '';
+			}
+		);
+
+		$_COOKIE[ Sudo_Session::TOKEN_COOKIE ] = $token;
+
+		$bar = new \WP_Admin_Bar();
+		$this->admin_bar->admin_bar_node( $bar );
+
+		$nodes = $bar->get_nodes();
+		$this->assertArrayHasKey( 'wp-sudo-active', $nodes );
+
+		// Simulate the browser navigating to the deactivate href and PHP
+		// parsing its query string into $_GET, exactly as handle_deactivate()
+		// would see it via $_GET[ Admin_Bar::REDIRECT_PARAM ].
+		$parts = parse_url( $nodes['wp-sudo-active']['href'] );
+		parse_str( $parts['query'] ?? '', $get );
+
+		$this->assertArrayHasKey( Admin_Bar::REDIRECT_PARAM, $get );
+		$this->assertStringContainsString(
+			'tab=access',
+			$get[ Admin_Bar::REDIRECT_PARAM ],
+			'The admin-bar deactivate URL\'s redirect_to must survive the browser\'s query-string round trip with &tab=access intact.'
 		);
 	}
 

--- a/tests/Unit/ChallengeUrlFunctionsTest.php
+++ b/tests/Unit/ChallengeUrlFunctionsTest.php
@@ -1,0 +1,145 @@
+<?php
+/**
+ * Tests for the wp_sudo_build_challenge_url() helper.
+ *
+ * @package WP_Sudo\Tests\Unit
+ */
+
+namespace WP_Sudo\Tests\Unit;
+
+use Brain\Monkey\Functions;
+use WP_Sudo\Tests\TestCase;
+
+/**
+ * Class ChallengeUrlFunctionsTest
+ *
+ * Covers wp_sudo_build_challenge_url(), the shared helper that owns the
+ * rawurlencode(return_url) contract for every challenge-URL builder.
+ *
+ * @covers ::wp_sudo_build_challenge_url
+ */
+class ChallengeUrlFunctionsTest extends TestCase {
+
+	public function test_encodes_return_url_containing_nested_query_string(): void {
+		$this->stub_faithful_add_query_arg();
+
+		$url = wp_sudo_build_challenge_url(
+			'https://example.com/wp-admin/admin.php',
+			'https://example.com/wp-admin/options-general.php?page=wp-sudo-settings&tab=access',
+			array( 'page' => 'wp-sudo-challenge' )
+		);
+
+		$parts = parse_url( $url );
+		parse_str( $parts['query'] ?? '', $get );
+
+		$this->assertArrayHasKey( 'return_url', $get );
+		$this->assertStringContainsString( 'tab=access', $get['return_url'] );
+	}
+
+	public function test_omits_return_url_arg_when_empty(): void {
+		$this->stub_faithful_add_query_arg();
+
+		$url = wp_sudo_build_challenge_url(
+			'https://example.com/wp-admin/admin.php',
+			'',
+			array( 'page' => 'wp-sudo-challenge' )
+		);
+
+		$parts = parse_url( $url );
+		parse_str( $parts['query'] ?? '', $get );
+
+		$this->assertArrayNotHasKey( 'return_url', $get );
+		$this->assertSame( 'wp-sudo-challenge', $get['page'] );
+	}
+
+	public function test_passes_extra_args_through_unmodified(): void {
+		Functions\expect( 'add_query_arg' )
+			->once()
+			->with(
+				array(
+					'page'      => 'wp-sudo-challenge',
+					'stash_key' => 'abc123',
+					'return_url' => rawurlencode( 'https://example.com/wp-admin/plugins.php?foo=1' ),
+				),
+				'https://example.com/wp-admin/admin.php'
+			)
+			->andReturn( 'stubbed-url' );
+
+		$result = wp_sudo_build_challenge_url(
+			'https://example.com/wp-admin/admin.php',
+			'https://example.com/wp-admin/plugins.php?foo=1',
+			array(
+				'page'      => 'wp-sudo-challenge',
+				'stash_key' => 'abc123',
+			)
+		);
+
+		$this->assertSame( 'stubbed-url', $result );
+	}
+
+	/**
+	 * Round-trip edge case: a return_url containing a literal '+' must
+	 * survive rawurlencode() → $_GET's single implicit decode without
+	 * being mangled into a space (the historical urlencode()/+ pitfall).
+	 */
+	public function test_round_trip_preserves_literal_plus_character(): void {
+		$this->stub_faithful_add_query_arg();
+
+		$original = 'https://example.com/wp-admin/edit.php?s=a+b&paged=2';
+
+		$url = wp_sudo_build_challenge_url(
+			'https://example.com/wp-admin/admin.php',
+			$original,
+			array( 'page' => 'wp-sudo-challenge' )
+		);
+
+		$parts = parse_url( $url );
+		parse_str( $parts['query'] ?? '', $get );
+
+		$this->assertSame( $original, $get['return_url'] );
+	}
+
+	/**
+	 * Round-trip edge case: a return_url containing a pre-encoded %XX
+	 * sequence must decode to exactly one original value — proving the
+	 * helper applies rawurlencode() exactly once (double-encoding would
+	 * leave a literal "%25" in the decoded value).
+	 */
+	public function test_round_trip_preserves_pre_encoded_percent_sequence(): void {
+		$this->stub_faithful_add_query_arg();
+
+		$original = 'https://example.com/wp-admin/edit.php?s=100%25+done&paged=2';
+
+		$url = wp_sudo_build_challenge_url(
+			'https://example.com/wp-admin/admin.php',
+			$original,
+			array( 'page' => 'wp-sudo-challenge' )
+		);
+
+		$parts = parse_url( $url );
+		parse_str( $parts['query'] ?? '', $get );
+
+		$this->assertSame( $original, $get['return_url'] );
+	}
+
+	/**
+	 * Round-trip edge case: a return_url containing a multibyte character
+	 * must survive the encode/decode cycle unchanged.
+	 */
+	public function test_round_trip_preserves_multibyte_character(): void {
+		$this->stub_faithful_add_query_arg();
+
+		$original = 'https://example.com/wp-admin/edit.php?s=caf%C3%A9&paged=2';
+
+		$url = wp_sudo_build_challenge_url(
+			'https://example.com/wp-admin/admin.php',
+			$original,
+			array( 'page' => 'wp-sudo-challenge' )
+		);
+
+		$parts = parse_url( $url );
+		parse_str( $parts['query'] ?? '', $get );
+
+		$this->assertSame( $original, $get['return_url'] );
+	}
+}

--- a/tests/Unit/GateTest.php
+++ b/tests/Unit/GateTest.php
@@ -1696,6 +1696,78 @@ class GateTest extends TestCase {
 	}
 
 	/**
+	 * Bug: settings-tab-lost-on-reauth-replay (single-site, CONFIRMED).
+	 *
+	 * Root cause: challenge_admin() builds $query_args['return_url'] from
+	 * wp_get_referer() — a full URL that already contains its own query
+	 * string (e.g. "...options-general.php?page=wp-sudo-settings&tab=access")
+	 * — then passes that array into add_query_arg(). Real WP core's
+	 * add_query_arg()/build_query() do NOT urlencode newly-added array
+	 * values, so the nested "&tab=access" becomes a new sibling top-level
+	 * query parameter in the emitted challenge_url instead of staying part
+	 * of the return_url value. This test uses FAITHFUL add_query_arg()
+	 * semantics (TestCase::stub_faithful_add_query_arg()) rather than the
+	 * http_build_query()-based / hardcoded-string stubs used elsewhere in
+	 * this file, which encode-away the defect and cannot detect it.
+	 */
+	public function test_intercept_admin_challenge_redirect_preserves_tab_query_arg(): void {
+		Functions\when( 'get_current_user_id' )->justReturn( 5 );
+		Functions\when( 'wp_doing_ajax' )->justReturn( false );
+		Functions\when( 'wp_doing_cron' )->justReturn( false );
+		Functions\when( 'is_admin' )->justReturn( true );
+		Functions\when( '__' )->returnArg();
+		Functions\when( 'apply_filters' )->returnArg( 2 );
+		Functions\when( 'admin_url' )->alias( static fn( string $path = '' ): string => 'https://example.com/wp-admin/' . $path );
+		Functions\when( 'get_user_meta' )->justReturn( 0 );
+		Functions\when( 'wp_get_referer' )->justReturn( 'https://example.com/wp-admin/options-general.php?page=wp-sudo-settings&tab=access' );
+		$this->stub_faithful_add_query_arg();
+
+		$GLOBALS['pagenow']        = 'plugins.php';
+		$_REQUEST['action']        = 'activate';
+		$_SERVER['REQUEST_METHOD'] = 'GET';
+
+		$this->stash->shouldReceive( 'save' )
+			->once()
+			->with( 5, \Mockery::type( 'array' ) )
+			->andReturn( 'abc123' );
+
+		$captured_url = null;
+		Functions\expect( 'wp_safe_redirect' )
+			->once()
+			->andReturnUsing(
+				function ( $url ) use ( &$captured_url ) {
+					$captured_url = $url;
+					throw new \RuntimeException( 'redirect' );
+				}
+			);
+
+		Actions\expectDone( 'wp_sudo_action_gated' )
+			->once()
+			->with( 5, 'plugin.activate', 'admin' );
+
+		try {
+			$this->gate->intercept();
+			$this->fail( 'Expected RuntimeException from wp_safe_redirect stub.' );
+		} catch ( \RuntimeException $e ) {
+			$this->assertSame( 'redirect', $e->getMessage() );
+		}
+
+		$this->assertIsString( $captured_url );
+
+		// Simulate the browser navigating to $captured_url and PHP parsing its
+		// query string into $_GET, exactly as Challenge::enqueue_assets() would see it.
+		$parts = parse_url( $captured_url );
+		parse_str( $parts['query'] ?? '', $get );
+
+		$this->assertArrayHasKey( 'return_url', $get );
+		$this->assertStringContainsString(
+			'tab=access',
+			$get['return_url'],
+			'The gated-action bounce challenge_url must carry a return_url that survives the browser\'s query-string round trip with &tab=access intact.'
+		);
+	}
+
+	/**
 	 * Test intercept sends JSON error for gated AJAX request.
 	 *
 	 * Verifies that when a gated AJAX request arrives without an active
@@ -3055,6 +3127,59 @@ class GateTest extends TestCase {
 		$this->gate->render_gate_notice();
 	}
 
+	/**
+	 * Bug: settings-tab-lost-on-reauth-replay (single-site, CONFIRMED — general
+	 * form, not tab-specific: any gated page reached with a query string).
+	 *
+	 * render_gate_notice() (and, structurally identically, render_blocked_notice())
+	 * builds $query_args['return_url'] from get_current_admin_url() — a full URL
+	 * that includes its own query string — then passes that array into
+	 * add_query_arg(). Real WP core's add_query_arg()/build_query() do not
+	 * urlencode newly-added array values, so a nested "&" in return_url becomes
+	 * a new sibling top-level query parameter in the emitted challenge_url,
+	 * truncating return_url at the first "&". This test uses FAITHFUL
+	 * add_query_arg() semantics rather than the hardcoded-return-value stub
+	 * used by the passing tests above, which cannot detect this defect.
+	 */
+	public function test_gate_notice_challenge_link_preserves_query_string_on_current_page(): void {
+		Functions\when( 'get_current_user_id' )->justReturn( 1 );
+		Functions\when( 'get_user_meta' )->justReturn( 0 );
+		Functions\when( '__' )->returnArg();
+		Functions\when( 'esc_html__' )->returnArg();
+		Functions\when( 'esc_html' )->returnArg();
+		Functions\when( 'esc_url' )->alias( static fn( string $url ): string => $url );
+		Functions\when( 'admin_url' )->alias( static fn( string $path = '' ): string => 'https://example.com/wp-admin/' . $path );
+		Functions\when( 'is_ssl' )->justReturn( true );
+		Functions\when( 'esc_url_raw' )->returnArg();
+		Functions\when( 'sanitize_text_field' )->returnArg();
+		Functions\when( 'wp_unslash' )->returnArg();
+		$this->stub_faithful_add_query_arg();
+
+		$_SERVER['REQUEST_URI'] = '/wp-admin/plugins.php?plugin_status=active&paged=2';
+		$_SERVER['HTTP_HOST']   = 'example.com';
+		$GLOBALS['pagenow']     = 'plugins.php';
+
+		ob_start();
+		$this->gate->render_gate_notice();
+		$html = ob_get_clean();
+
+		// Extract the challenge_url from the rendered <a href="...">.
+		$this->assertMatchesRegularExpression( '/href="([^"]*wp-sudo-challenge[^"]*)"/', $html );
+		preg_match( '/href="([^"]*wp-sudo-challenge[^"]*)"/', $html, $matches );
+
+		$parts = parse_url( $matches[1] );
+		parse_str( $parts['query'] ?? '', $get );
+
+		$this->assertArrayHasKey( 'return_url', $get );
+		$this->assertStringContainsString(
+			'paged=2',
+			$get['return_url'],
+			'The gate-notice challenge_url must carry a return_url that survives the browser\'s query-string round trip with the full current query string intact.'
+		);
+
+		unset( $_SERVER['REQUEST_URI'], $_SERVER['HTTP_HOST'] );
+	}
+
 	public function test_gate_notice_uses_current_network_admin_request_url(): void {
 		Functions\when( 'get_current_user_id' )->justReturn( 1 );
 		Functions\when( 'get_user_meta' )->justReturn( 0 );
@@ -3094,7 +3219,7 @@ class GateTest extends TestCase {
 		ob_end_clean();
 
 		$this->assertSame(
-			'http://multisite-subdomains.local/wp-admin/network/plugins.php',
+			rawurlencode( 'http://multisite-subdomains.local/wp-admin/network/plugins.php' ),
 			$captured_args['return_url'] ?? '',
 			'Gate notice should point back to the current network admin page, not a subsite home_url().'
 		);

--- a/tests/Unit/PluginTest.php
+++ b/tests/Unit/PluginTest.php
@@ -285,6 +285,14 @@ class PluginTest extends TestCase {
 		unset( $_GET['page'] );
 	}
 
+	/**
+	 * Bug fix: settings-tab-lost-on-reauth-replay. return_url must be encoded
+	 * EXACTLY ONCE via rawurlencode() before being handed to add_query_arg() —
+	 * add_query_arg() does not encode newly-added array values, so leaving
+	 * return_url raw let its nested "&" leak out as a new top-level query
+	 * separator. This test locks in single-encoding: not raw, and not
+	 * double-encoded (no literal "%25").
+	 */
 	public function test_enqueue_shortcut_return_url_is_not_double_encoded(): void {
 		Functions\when( 'get_current_user_id' )->justReturn( 1 );
 		Functions\when( 'get_user_meta' )->justReturn( 0 );
@@ -321,11 +329,86 @@ class PluginTest extends TestCase {
 		$plugin->enqueue_shortcut();
 
 		$this->assertArrayHasKey( 'return_url', $captured_args );
-		// The return_url must NOT be URL-encoded before add_query_arg (which encodes it itself).
-		$this->assertStringNotContainsString( '%3A', $captured_args['return_url'], 'return_url should not be pre-encoded before add_query_arg.' );
-		$this->assertStringNotContainsString( '%2F', $captured_args['return_url'], 'return_url should not be pre-encoded before add_query_arg.' );
+		// The return_url must be rawurlencode()'d exactly once before add_query_arg
+		// (which does NOT encode newly-added array values itself).
+		$this->assertSame(
+			rawurlencode( 'https://example.com/wp-admin/admin.php?page=plugins&plugin_status=active' ),
+			$captured_args['return_url'],
+			'return_url should be encoded exactly once before add_query_arg.'
+		);
+		// Guard against double-encoding: a single rawurlencode() never produces a literal "%25".
+		$this->assertStringNotContainsString( '%25', $captured_args['return_url'], 'return_url must not be double-encoded.' );
 
 		unset( $_GET['page'], $_SERVER['REQUEST_URI'], $_SERVER['HTTP_HOST'], $_SERVER['REQUEST_SCHEME'] );
+	}
+
+	/**
+	 * Bug: settings-tab-lost-on-reauth-replay (single-site, CONFIRMED).
+	 *
+	 * Root cause: enqueue_shortcut() passes return_url — a full URL that
+	 * itself already contains a query string (e.g. "...?page=wp-sudo-settings&tab=access")
+	 * — as a raw VALUE inside the array given to add_query_arg(). Real WP core's
+	 * add_query_arg()/build_query() do NOT urlencode newly-added array values
+	 * (build_query() calls _http_build_query() with $urlencode = false), so the
+	 * nested "&tab=access" is emitted as a literal "&" in the output URL,
+	 * becoming a new *sibling* top-level query parameter instead of staying
+	 * part of the return_url value. When the browser then parses the resulting
+	 * challengeUrl's query string into $_GET, $_GET['return_url'] is truncated
+	 * at the first "&" and "tab=access" is lost entirely.
+	 *
+	 * This test uses FAITHFUL add_query_arg() semantics (TestCase::stub_faithful_add_query_arg(),
+	 * a byte-for-byte port of wordpress-develop trunk's add_query_arg()/build_query()/
+	 * _http_build_query()) — not the http_build_query()-based stub used elsewhere in
+	 * this suite, which silently urlencodes and therefore cannot detect this defect.
+	 */
+	public function test_enqueue_shortcut_challenge_url_preserves_tab_query_arg_from_access_tab(): void {
+		Functions\when( 'get_current_user_id' )->justReturn( 1 );
+		Functions\when( 'get_user_meta' )->justReturn( 0 );
+		Functions\when( 'admin_url' )->alias( fn( $path = '' ) => 'https://example.com/wp-admin/' . $path );
+		Functions\when( 'is_ssl' )->justReturn( true );
+		Functions\when( 'esc_url_raw' )->returnArg();
+		Functions\when( 'sanitize_text_field' )->returnArg();
+		Functions\when( 'wp_unslash' )->returnArg();
+		Functions\when( 'wp_enqueue_script' )->justReturn();
+		$this->stub_faithful_add_query_arg();
+
+		$_GET['page']           = 'wp-sudo-settings';
+		$_SERVER['REQUEST_URI'] = '/wp-admin/options-general.php?page=wp-sudo-settings&tab=access';
+		$_SERVER['HTTP_HOST']   = 'example.com';
+
+		$captured = null;
+		Functions\expect( 'wp_localize_script' )
+			->once()
+			->with(
+				'wp-sudo-shortcut',
+				'wpSudoShortcut',
+				\Mockery::on(
+					function ( $data ) use ( &$captured ) {
+						$captured = $data;
+						return true;
+					}
+				)
+			);
+
+		$plugin = new Plugin();
+		$plugin->enqueue_shortcut();
+
+		$this->assertIsArray( $captured );
+		$this->assertArrayHasKey( 'challengeUrl', $captured );
+
+		// Simulate the browser navigating to challengeUrl and PHP parsing its
+		// query string into $_GET, exactly as Challenge::enqueue_assets() would see it.
+		$parts = parse_url( $captured['challengeUrl'] );
+		parse_str( $parts['query'] ?? '', $get );
+
+		$this->assertArrayHasKey( 'return_url', $get );
+		$this->assertStringContainsString(
+			'tab=access',
+			$get['return_url'],
+			'The shortcut challengeUrl must carry a return_url that survives the browser\'s query-string round trip with &tab=access intact.'
+		);
+
+		unset( $_GET['page'], $_SERVER['REQUEST_URI'], $_SERVER['HTTP_HOST'] );
 	}
 
 	public function test_enqueue_shortcut_uses_current_network_admin_request_url(): void {
@@ -367,7 +450,7 @@ class PluginTest extends TestCase {
 		$plugin->enqueue_shortcut();
 
 		$this->assertSame(
-			'http://multisite-subdomains.local/wp-admin/network/plugins.php',
+			rawurlencode( 'http://multisite-subdomains.local/wp-admin/network/plugins.php' ),
 			$captured_args['return_url'] ?? '',
 			'Network admin shortcut should return to the current network admin URL, not a subsite home_url().'
 		);

--- a/tests/Unit/PublicApiTest.php
+++ b/tests/Unit/PublicApiTest.php
@@ -235,7 +235,7 @@ class PublicApiTest extends TestCase {
 				\Mockery::on(
 					static function ( array $args ): bool {
 						return 'wp-sudo-challenge' === ( $args['page'] ?? '' )
-							&& 'https://example.com/wp-admin/plugins.php' === ( $args['return_url'] ?? '' );
+							&& rawurlencode( 'https://example.com/wp-admin/plugins.php' ) === ( $args['return_url'] ?? '' );
 					}
 				),
 				'https://example.com/wp-admin/admin.php'
@@ -255,6 +255,76 @@ class PublicApiTest extends TestCase {
 		$this->expectExceptionMessage( 'redirected' );
 
 		Public_API::require( array( 'rule_id' => 'cron.run' ) );
+	}
+
+	/**
+	 * Bug: settings-tab-lost-on-reauth-replay (7th affected site — Public_API::
+	 * build_challenge_url(), missed by the first pass of the fix).
+	 *
+	 * build_challenge_url() nests a full URL (which already contains its own
+	 * query string, e.g. "...options-general.php?page=wp-sudo-settings&tab=access")
+	 * as a raw VALUE inside the array given to add_query_arg(). Real WP core's
+	 * add_query_arg()/build_query() do NOT urlencode newly-added array values,
+	 * so the nested "&tab=access" becomes a new sibling top-level query
+	 * parameter, truncating return_url at the first "&" once the browser
+	 * round-trips the link through $_GET. This test uses FAITHFUL
+	 * add_query_arg() semantics (TestCase::stub_faithful_add_query_arg())
+	 * rather than the Mockery::on()/andReturn() stub used above, which
+	 * cannot detect this defect.
+	 */
+	public function test_require_redirect_preserves_nested_query_string_in_return_url(): void {
+		$user_id = 34;
+
+		Functions\when( 'get_current_user_id' )->justReturn( $user_id );
+		Functions\when( 'get_user_meta' )->justReturn( '' );
+		Functions\when( 'headers_sent' )->justReturn( false );
+		Functions\when( 'wp_doing_ajax' )->justReturn( false );
+		Functions\when( 'is_network_admin' )->justReturn( false );
+		Functions\when( 'admin_url' )->alias(
+			static function ( string $path = '' ): string {
+				return 'https://example.com/wp-admin/' . ltrim( $path, '/' );
+			}
+		);
+		$this->stub_faithful_add_query_arg();
+
+		$_SERVER['HTTP_REFERER'] = 'https://example.com/wp-admin/options-general.php?page=wp-sudo-settings&tab=access';
+
+		Actions\expectDone( 'wp_sudo_action_gated' )
+			->once()
+			->with( $user_id, 'cron.run', 'public_api' );
+
+		$captured_url = null;
+		Functions\expect( 'wp_safe_redirect' )
+			->once()
+			->andReturnUsing(
+				function ( $url ) use ( &$captured_url ) {
+					$captured_url = $url;
+					throw new \RuntimeException( 'redirected' );
+				}
+			);
+
+		try {
+			Public_API::require( array( 'rule_id' => 'cron.run' ) );
+			$this->fail( 'Expected RuntimeException from wp_safe_redirect stub.' );
+		} catch ( \RuntimeException $e ) {
+			$this->assertSame( 'redirected', $e->getMessage() );
+		}
+
+		$this->assertIsString( $captured_url );
+
+		// Simulate the browser navigating to $captured_url and PHP parsing its
+		// query string into $_GET, exactly as Challenge::enqueue_assets() would see it.
+		$parts = parse_url( $captured_url );
+		parse_str( $parts['query'] ?? '', $get );
+
+		$this->assertArrayHasKey( 'return_url', $get );
+		$this->assertStringContainsString(
+			'tab=access',
+			$get['return_url'],
+			'The Public_API::require() challenge_url must carry a return_url that survives the browser\'s query-string round trip with &tab=access intact.'
+		);
+
+		unset( $_SERVER['HTTP_REFERER'] );
 	}
 
 	public function test_require_calls_wp_die_when_redirect_fails(): void {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -373,3 +373,6 @@ unset( $_patchwork, $_patchwork_candidates, $active_vendor_autoload );
 // Loaded AFTER Patchwork so Brain\Monkey can stub wp_sudo_is_recovery_mode()
 // and any other governance functions in unit tests.
 require_once dirname( __DIR__ ) . '/includes/functions-governance.php';
+
+// ── Challenge URL helpers ────────────────────────────────────────────
+require_once dirname( __DIR__ ) . '/includes/functions-challenge-url.php';

--- a/wp-sudo.php
+++ b/wp-sudo.php
@@ -23,6 +23,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 require_once __DIR__ . '/includes/class-bootstrap.php';
 require_once __DIR__ . '/includes/functions-governance.php';
+require_once __DIR__ . '/includes/functions-challenge-url.php';
 
 add_filter( 'map_meta_cap', 'wp_sudo_map_governance_meta_cap', 10, 4 );
 


### PR DESCRIPTION
## Summary

Fixes the **single-site** tab-loss you reproduced in Playground: after passing a sudo reauth from `…?page=wp-sudo-settings&tab=access`, you landed on the bare settings page. Confirmed via `window.wpSudoChallenge.cancelUrl` being tab-less — a real plugin bug, not a Playground artifact.

**Root cause:** WordPress's `add_query_arg( array $args, $url )` does **not** URL-encode values in the `$args` array. WP Sudo nested a full URL (with its own `&`-separated query) as a `return_url` array value, so the nested `&` leaked out as a sibling param and `$_GET['return_url']` got truncated at the first `&` — dropping `&tab=` (and any nested query). One shared mechanism across **7 call sites**.

**Fix:** a shared `wp_sudo_build_challenge_url()` helper that `rawurlencode()`s the nested `return_url` exactly once, routed through by all 6 challenge-URL builders; the admin-bar deactivate link (a `wp_nonce_url`-wrapped, different contract) fixed as its own case. Read side is unchanged — `wp_validate_redirect()` still gates the decoded target, so open-redirect protection is intact.

Sites fixed: `Plugin::enqueue_shortcut`, `Gate::{build_session_challenge_url,challenge_admin,render_gate_notice,render_blocked_notice}`, `Public_API::build_challenge_url` (missed by the first audit pass), and `Admin_Bar::admin_bar_node`.

## Why prior passes missed it
Every existing test stub emulated `add_query_arg()` with `http_build_query()` (which encodes by default), silently curing the bug under test. This PR adds a **faithful** `add_query_arg` stub (byte-for-byte port of WP core) and uses it for all encoding-sensitive assertions.

## Tests
- New helper tests incl. `+` / `%XX` / multibyte single-encode round-trips.
- Per-site tests (shortcut, gated bounce, notice links, public API, admin-bar) asserting the decoded `return_url` preserves the tab.
- `composer test` 956/2888 · `composer analyse` (PHPStan L6 + Psalm) · `composer lint` — all green.

## Notes
- Design-reviewed before implementation (must-fixes folded in: the 7th/public-API site, admin-bar as a distinct contract, and the shared helper for DRY).
- Split into 3 code commits to stay within the pre-commit size gate; each reviewer-approved.
- **No product version/tag bump.**
- Follow-up (tracked, separate PR): migrate the remaining `http_build_query`-based test stubs to the faithful stub so this class of bug can't be re-masked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)