### PR TITLE
fix: Playground demos — PR-preview commit-zip + release badges

### DIFF
--- a/.github/workflows/playground-preview.yml
+++ b/.github/workflows/playground-preview.yml
@@ -45,11 +45,14 @@ jobs:
             }
 
             delete pluginStep.pluginZipFile;
+            // Pin the install to the PR commit via a plain GitHub archive .zip
+            // (resource: 'url'), NOT git:directory. Playground's git-clone path
+            // currently fails with "createHash is not a function", while plain
+            // .zip downloads are unaffected; a commit archive installs the exact
+            // SHA and dodges that regression.
             pluginStep.pluginData = {
-              resource: 'git:directory',
-              url: repoUrl,
-              ref: sha,
-              refType: 'commit',
+              resource: 'url',
+              url: `${repoUrl}/archive/${sha}.zip`,
             };
 
             const encoded = encodeURIComponent(JSON.stringify(blueprint));
@@ -62,7 +65,7 @@ jobs:
               '',
               'Preview is pinned to WordPress `7.0`.',
               '',
-              `Uses the checked-in \`blueprint.json\` from this PR, with the plugin install pinned to commit \`${sha}\` through Playground's CORS-safe \`git:directory\` resource.`,
+              `Uses the checked-in \`blueprint.json\` from this PR, with the plugin install pinned to commit \`${sha}\` via a GitHub archive \`.zip\` (\`resource: url\`).`,
               '',
               'Logs in as `admin` / `password`; use `password` again for the WP Sudo reauthentication challenge.',
               '',

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,6 +198,12 @@ changed since the last release. Use the project size commands above.
 
 And update `Stable tag` in `readme.txt`.
 
+Also bump the Playground stable-demo install target in `blueprint.json` — the
+`archive/refs/tags/vX.Y.Z.zip` URL in its `installPlugin` step — to the new tag.
+The release badges point at `main/blueprint.json` (not a frozen tag), so this one
+edit keeps "Try the latest release in Playground" installing the current release.
+(`blueprint-main.json` tracks `archive/refs/heads/main.zip` and needs no bump.)
+
 ## Test-Driven Development
 
 All new code must follow TDD:

--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,7 @@ Require password confirmation before high-risk changes go through on your WordPr
 [![CodeQL](https://github.com/dknauss/Sudo/actions/workflows/codeql.yml/badge.svg)](https://github.com/dknauss/Sudo/actions/workflows/codeql.yml)
 [![Codecov](https://codecov.io/gh/dknauss/Sudo/graph/badge.svg?branch=main)](https://codecov.io/gh/dknauss/Sudo)
 [![Type Coverage](https://shepherd.dev/github/dknauss/Sudo/coverage.svg)](https://shepherd.dev/github/dknauss/Sudo)
-[![Try latest release in Playground](https://img.shields.io/badge/Try%20release-Playground-3858e9?logo=wordpress&logoColor=white)](https://playground.wordpress.net/?blueprint-url=https%3A%2F%2Fraw.githubusercontent.com%2Fdknauss%2FSudo%2Fv4.1.0%2Fblueprint.json)
+[![Try latest release in Playground](https://img.shields.io/badge/Try%20release-Playground-3858e9?logo=wordpress&logoColor=white)](https://playground.wordpress.net/?blueprint-url=https%3A%2F%2Fraw.githubusercontent.com%2Fdknauss%2FSudo%2Fmain%2Fblueprint.json)
 [![Try main in Playground](https://img.shields.io/badge/Try%20main-Playground-23282d?logo=wordpress&logoColor=white)](https://playground.wordpress.net/?blueprint-url=https%3A%2F%2Fraw.githubusercontent.com%2Fdknauss%2FSudo%2Fmain%2Fblueprint-main.json)
 
 Playground demo credentials are `admin` / `password`. When Sudo asks for reauthentication, enter the same password: `password`.

--- a/readme.txt
+++ b/readme.txt
@@ -19,7 +19,7 @@ This is not role-based escalation. Every logged-in user is treated the same: att
 
 = Playground demo =
 
-* [Try the latest release in WordPress Playground](https://playground.wordpress.net/?blueprint-url=https%3A%2F%2Fraw.githubusercontent.com%2Fdknauss%2FSudo%2Fv4.2.2%2Fblueprint.json)
+* [Try the latest release in WordPress Playground](https://playground.wordpress.net/?blueprint-url=https%3A%2F%2Fraw.githubusercontent.com%2Fdknauss%2FSudo%2Fmain%2Fblueprint.json)
 * [Try current main in WordPress Playground](https://playground.wordpress.net/?blueprint-url=https%3A%2F%2Fraw.githubusercontent.com%2Fdknauss%2FSudo%2Fmain%2Fblueprint-main.json)
 
 Playground demo credentials are `admin` / `password`. When WP Sudo asks for reauthentication, enter the same password: `password`.


### PR DESCRIPTION
Fixes the WP Sudo Playground demos, broken by Playground's current `git:directory` `createHash` regression **and** by stale badge pinning.

## 1. PR-preview workflow (`playground-preview.yml`)
Injected a `git:directory` resource (broken). Now emits `resource: 'url'` → `github.com/OWNER/REPO/archive/<sha>.zip` (commit-archive zip), which installs the exact PR commit and works. **Verified in Playground**; this PR's own preview comment now uses the fixed URL.

## 2. Release badges (README.md + readme.txt)
Pointed at frozen tag refs of `blueprint.json` (`v4.1.0` / `v4.2.2`) whose install step still hardcodes `archive/refs/tags/v3.2.0.zip` — so "Try the latest release" booted **ancient v3.2.0**. Repointed both at `main/blueprint.json` (already installs the current release), so they're instantly correct and can't drift. Added one line to the version-sync checklist to bump `blueprint.json`'s install tag on release. **No GitHub Action needed.**

Root cause (Playground side): `git:directory` / git-detected URLs fail `createHash`; plain `.zip` downloads and `wordpress.org/plugins` are unaffected — matches the recent `#3840`/`#3841` git-storage refactors. Docs + CI-glue only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)