### PR TITLE
fix(playground): fetch plugin archives via CORS proxy, not direct github.com

### DIFF
--- a/.github/workflows/playground-preview.yml
+++ b/.github/workflows/playground-preview.yml
@@ -45,14 +45,20 @@ jobs:
             }
 
             delete pluginStep.pluginZipFile;
-            // Pin the install to the PR commit via a plain GitHub archive .zip
-            // (resource: 'url'), NOT git:directory. Playground's git-clone path
-            // currently fails with "createHash is not a function", while plain
-            // .zip downloads are unaffected; a commit archive installs the exact
-            // SHA and dodges that regression.
+            // Pin the install to the PR commit via a GitHub archive .zip
+            // (resource: 'url'), NOT git:directory. Two reasons the URL is
+            // wrapped in the official CORS proxy:
+            //   1. Playground's git-clone path currently fails with
+            //      "createHash is not a function", so git:directory is out.
+            //   2. A *direct* github.com/.../archive/<sha>.zip is CORS-blocked
+            //      when Playground fetches it client-side: GitHub serves it
+            //      with Access-Control-Allow-Origin: render.githubusercontent.com,
+            //      not playground.wordpress.net. Routing through
+            //      wordpress-playground-cors-proxy.net returns a permissive
+            //      ACAO so the fetch succeeds. Installs the exact SHA.
             pluginStep.pluginData = {
               resource: 'url',
-              url: `${repoUrl}/archive/${sha}.zip`,
+              url: `https://wordpress-playground-cors-proxy.net/?${repoUrl}/archive/${sha}.zip`,
             };
 
             const encoded = encodeURIComponent(JSON.stringify(blueprint));
@@ -65,7 +71,7 @@ jobs:
               '',
               'Preview is pinned to WordPress `7.0`.',
               '',
-              `Uses the checked-in \`blueprint.json\` from this PR, with the plugin install pinned to commit \`${sha}\` via a GitHub archive \`.zip\` (\`resource: url\`).`,
+              `Uses the checked-in \`blueprint.json\` from this PR, with the plugin install pinned to commit \`${sha}\` via a GitHub archive \`.zip\` (\`resource: url\`, fetched through the WordPress Playground CORS proxy).`,
               '',
               'Logs in as `admin` / `password`; use `password` again for the WP Sudo reauthentication challenge.',
               '',

--- a/blueprint-main.json
+++ b/blueprint-main.json
@@ -19,7 +19,7 @@
       "step": "installPlugin",
       "pluginData": {
         "resource": "url",
-        "url": "https://github.com/dknauss/Sudo/archive/refs/heads/main.zip"
+        "url": "https://wordpress-playground-cors-proxy.net/?https://github.com/dknauss/Sudo/archive/refs/heads/main.zip"
       },
       "options": {
         "activate": true

--- a/blueprint-recovery-mode.json
+++ b/blueprint-recovery-mode.json
@@ -23,7 +23,7 @@
       "step": "installPlugin",
       "pluginData": {
         "resource": "url",
-        "url": "https://github.com/dknauss/Sudo/archive/refs/heads/main.zip"
+        "url": "https://wordpress-playground-cors-proxy.net/?https://github.com/dknauss/Sudo/archive/refs/heads/main.zip"
       },
       "options": {
         "activate": true

--- a/blueprint-user-switching.json
+++ b/blueprint-user-switching.json
@@ -19,7 +19,7 @@
       "step": "installPlugin",
       "pluginData": {
         "resource": "url",
-        "url": "https://github.com/dknauss/Sudo/archive/refs/heads/main.zip"
+        "url": "https://wordpress-playground-cors-proxy.net/?https://github.com/dknauss/Sudo/archive/refs/heads/main.zip"
       },
       "options": {
         "activate": true

--- a/blueprint.json
+++ b/blueprint.json
@@ -19,7 +19,7 @@
       "step": "installPlugin",
       "pluginData": {
         "resource": "url",
-        "url": "https://github.com/dknauss/Sudo/archive/refs/tags/v4.2.2.zip"
+        "url": "https://wordpress-playground-cors-proxy.net/?https://github.com/dknauss/Sudo/archive/refs/tags/v4.2.2.zip"
       },
       "options": {
         "activate": true


### PR DESCRIPTION
## Problem

All four Playground blueprints (`blueprint.json`, `blueprint-main.json`, `blueprint-recovery-mode.json`, `blueprint-user-switching.json`) and the PR-preview workflow installed the plugin from a **direct** `github.com/dknauss/Sudo/archive/<ref>.zip`. The current Playground build **CORS-blocks** that fetch: GitHub serves archive zips with `Access-Control-Allow-Origin: https://render.githubusercontent.com` (a fixed origin), so Playground's client-side fetch from `playground.wordpress.net` is rejected and the install step fails. Result: the release-badge demo, the feature-demo blueprints, and every PR-preview link were broken.

This is distinct from — but was masked by — the `git:directory` `createHash` regression these blueprints had already moved off of.

## Fix

Wrap each archive URL in the official `https://wordpress-playground-cors-proxy.net/?<url>` proxy, which returns a permissive ACAO so the fetch succeeds. Same code installed, just fetched through a CORS-friendly path. The workflow's injected `pluginData.url` is wrapped identically, with the explanatory comment and PR-comment body updated to match.

## Verification

Booted the release `blueprint.json` in real Playground (headless Chromium, 2026-07-02): **WP Sudo and Two-Factor both activate**, zero console errors — no `createHash`, no CORS, no step-execution failure. The proxy+archive mechanism was independently confirmed on a sibling repo (theme activated).

## Notes

- Config/CI only — no PHP changed.
- Header evidence: direct `github.com/.../archive/*.zip` → `ACAO: render.githubusercontent.com` (blocked); `raw.githubusercontent.com` / `downloads.wordpress.org` → `ACAO: *` (fine); official proxy → verified working in-browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)