### PR TITLE
docs(release): record 4.5.0 env matrix status + local smoke evidence

### DIFF
--- a/docs/release-environment-log.md
+++ b/docs/release-environment-log.md
@@ -11,6 +11,7 @@ Keep the executable smoke-test procedure in [`tests/MANUAL-TESTING.md`](../tests
 | Package/version | Date | Overall status | Summary | WordPress.org posture |
 |-----------------|------|----------------|---------|-----------------------|
 | `v4.2.2` | 2026-06-29 | Deferred | Release environment matrix was documented for future execution; lanes were not rerun in Phase 17. | Submission/upload remains delayed/on hold. |
+| `4.5.0` (staged, no tag yet) | 2026-07-05 | Deferred (lanes) + supporting local smoke recorded | The three release-grade lanes (Apache, managed host, minimum WordPress) remain maintainer-owned and are **not** completed. A non-lane supporting smoke run of the full core smoke set passed on a local PHP-built-in-server + SQLite + WordPress 7.0 replica against the merged 4.5.0 code. | Submission/upload remains delayed/on hold. |
 
 ## `v4.2.2` environment matrix
 
@@ -21,6 +22,41 @@ The `v4.2.2` package already exists, but Phase 17 did not rerun release-grade ma
 | Apache stack | Deferred | Maintainer | Before next public tag/publication decision | Yes unless explicitly waived | Run the core smoke set from the manual guide on DDEV, MAMP, Local, or an Apache staging host and record evidence here. |
 | Managed WordPress host | Deferred | Maintainer | Before next public tag/publication decision | Yes unless explicitly waived | Provision or use an approved staging/trial managed WordPress host only when the maintainer chooses to execute the release-grade lane. |
 | Minimum supported WordPress version | Deferred | Maintainer | Before next public tag/publication decision | Yes unless explicitly waived | Confirm the current floor in `docs/release-status.md`, run the manual smoke set there, and record exact WordPress/PHP/site-mode evidence here. |
+
+## `4.5.0` environment matrix
+
+The `4.5.0` package is staged on `main` (version-synced; no `v4.5.0` tag cut yet).
+The three release-grade lanes below are **not** completed — each is an explicit
+deferral owned by the maintainer, because they require real environments that the
+build/CI sandbox cannot provide (a real Apache stack, a real managed WordPress host).
+
+| Environment lane | Status | Owner | Timing | Blocks next public tag/publication decision? | Notes |
+|------------------|--------|-------|--------|---------------------------------------------|-------|
+| Apache stack | Deferred | Maintainer | Before next public tag/publication decision | Yes unless explicitly waived | Recommended runner: **Local (by Flywheel)** with the site's web server set to **Apache**, or DDEV/MAMP/an Apache staging host. The distinctive check this lane protects is `mod_rewrite` passing the `Authorization` header to REST/Application-Password auth (§4.1, §5.2), which the non-Apache smoke below does not exercise. Run core smoke sections 1.1, 2.1, 2.9, 4.1, 5.2, 9.1 and record host/tool, PHP, database, browser, and rewrite/auth-header notes. |
+| Managed WordPress host | Deferred | Maintainer | Before next public tag/publication decision | Yes unless explicitly waived | Run core smoke sections 1.1, 2.1, 2.9, 9.1, 10.1 on an approved staging/trial managed host; record plan/trial type, caching or security features enabled, and any blocked filesystem or mu-plugin operations. |
+| Minimum supported WordPress version (6.4) | Deferred (manual) — partially covered by CI | Maintainer | Before next public tag/publication decision | Yes unless explicitly waived | The automated Integration matrix already runs the full suite on the **6.4 floor** (PHP 8.2/8.3, single-site and multisite), so the functional dimension is covered. The manual browser smoke (sections 1.1, 2.1, 2.9, 4.1, 5.2, 9.1) on a 6.4 site is still outstanding; record the exact WordPress/PHP version and single-site vs multisite. |
+
+### Supporting evidence (non-lane): local smoke run
+
+This run is **supporting evidence only** — it does **not** satisfy any of the three
+lanes above (it is neither Apache, nor a managed host, nor the minimum WordPress
+version). It is recorded here because it exercises the merged 4.5.0 code end-to-end.
+
+- Package/version: `4.5.0` (merged to `main`; plugin reports `WP_SUDO_VERSION 4.5.0`)
+- Date: 2026-07-05
+- Environment: local replica — PHP 8.4 built-in server (`php -S`, not Apache/nginx), SQLite drop-in, WordPress 7.0, single-site
+- Browser: Chromium (Playwright)
+- Two Factor and Patchstack Security (Pro 2.3.6) both active alongside; no interference observed
+- Core smoke sections run and result:
+  - §1.1 Activate via challenge page — PASS (challenge renders, password activates session, returns to originating page, admin-bar timer appears)
+  - §2.1 Activate plugin — PASS (no-session: gate notice + disabled `<span>` action links; with session: operable nonced link, "Plugin activated." with no further challenge)
+  - §2.9 Change critical site setting — PASS (Save redirects to challenge with `stash_key` and label "Change critical site setting"; after auth the POST is replayed — "Settings saved." with pending admin-email change)
+  - §4.1 Create Application Password (cookie-auth REST gate) — PASS (no session: "This action (Create application password) requires reauthentication…" notice, no password created; with session: password created)
+  - §5.1 Non-gated App-Password endpoint (`GET users/me`) — PASS (HTTP 200)
+  - §5.2 Gated App-Password endpoint under Limited (default) — PASS (`{"code":"sudo_blocked",…}` HTTP 403)
+  - §9.1 Three-option policy dropdowns — PASS (four surface dropdowns Disabled/Limited (default)/Unrestricted; WPGraphQL row absent when inactive; session duration 15; presets Normal/Incident Lockdown/Headless Friendly; renders correctly under WP 7.0 chrome)
+  - §10.1 Site Health all Limited — PASS ("All Sudo entry point policies are secure" under the Good/Passed section)
+- Runner: automated browser + curl session (Claude Code, remote build sandbox)
 
 ## Required evidence for completed lanes
 


### PR DESCRIPTION
## Summary

- **What changed?** Records the release-environment-matrix status for the staged **4.5.0** package in `docs/release-environment-log.md`. Docs-only; one file, +36 lines.
- **Why was this change needed?** The `v4.5.0` tag is gated on the release-grade environment matrix. This captures where that matrix actually stands so the deferral is explicit and the maintainer can decide go/no-go (run the remaining lanes, or waive) from a durable record.

### What it records

- **The three release-grade lanes remain maintainer-owned and NOT completed** — each is an explicit deferral with owner/timing/blocker posture, because they require real environments this build sandbox cannot provide:
  - **Apache** — recommended runner noted as **Local (by Flywheel) with the web server set to Apache** (or DDEV/MAMP/Apache staging). This lane protects the `mod_rewrite` → `Authorization`-header passthrough for REST/App-Password auth (§4.1, §5.2), which a non-Apache smoke cannot exercise.
  - **Managed WordPress host** — needs a real staging/trial managed host.
  - **Minimum WordPress (6.4)** — noted as partially covered: CI's Integration matrix already runs the full suite on the 6.4 floor (PHP 8.2/8.3, single + multisite); the manual 6.4 browser smoke is still outstanding.
- **A non-lane supporting smoke run**, recorded honestly as supporting evidence only (it satisfies none of the three lanes): the full core smoke set passed on a local PHP-built-in-server + SQLite + WordPress 7.0 replica against the merged 4.5.0 code (`WP_SUDO_VERSION 4.5.0`), driven via Chromium + curl — §1.1, §2.1, §2.9, §4.1, §5.1/§5.2, §9.1, §10.1 all PASS.

## Validation

- [x] `composer test` — unchanged; this PR is docs-only (no code touched)
- [x] Manual checks described — the recorded smoke run and its per-section results are in the log entry itself

## Checklist

- [x] Linked issue or explained why none was needed — release-readiness bookkeeping for the staged 4.5.0 tag; no code issue applies
- [x] Updated docs, tests, or manual testing guidance if behavior changed — no behavior change; documentation only
- [x] No sensitive details disclosed publicly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017TCJoA72EDAmLviMKDB5zx)_