### PR TITLE
docs(release): clear 4.5.0 env-matrix gate (Apache lane run + managed-host waiver)

### DIFF
--- a/docs/release-environment-log.md
+++ b/docs/release-environment-log.md
@@ -11,7 +11,7 @@ Keep the executable smoke-test procedure in [`tests/MANUAL-TESTING.md`](../tests
 | Package/version | Date | Overall status | Summary | WordPress.org posture |
 |-----------------|------|----------------|---------|-----------------------|
 | `v4.2.2` | 2026-06-29 | Deferred | Release environment matrix was documented for future execution; lanes were not rerun in Phase 17. | Submission/upload remains delayed/on hold. |
-| `4.5.0` (staged, no tag yet) | 2026-07-05 | Apache lane **completed**; managed-host + min-WP outstanding | The **Apache lane is completed** against a real Apache 2.4.58 + mod_php 8.3.6 stack (all six core sections pass, including the `mod_rewrite`/`Authorization`-header App-Password check). The **managed-host** lane is still outstanding (needs a real managed host); the **minimum-WordPress (6.4)** lane is functionally covered by the CI Integration matrix with the manual browser smoke still optional. | Submission/upload remains delayed/on hold. |
+| `4.5.0` (staged, no tag yet) | 2026-07-05 | Matrix cleared for tag: Apache **completed**, min-WP **CI-covered**, managed-host **waived** | The **Apache lane is completed** against a real Apache 2.4.58 + mod_php 8.3.6 stack (all six core sections pass, including the `mod_rewrite`/`Authorization`-header App-Password check). The **minimum-WordPress (6.4)** lane is functionally covered by the CI Integration matrix. The **managed-host** lane is cleared by an explicit maintainer waiver (recorded below) with residual risk accepted. The environment-matrix gate for the `v4.5.0` tag is therefore satisfied. | Submission/upload remains delayed/on hold. |
 
 ## `v4.2.2` environment matrix
 
@@ -33,7 +33,7 @@ cannot provide). The **minimum-WordPress (6.4)** lane is functionally covered by
 | Environment lane | Status | Owner | Timing | Blocks next public tag/publication decision? | Notes |
 |------------------|--------|-------|--------|---------------------------------------------|-------|
 | Apache stack | **Completed** 2026-07-05 | Claude Code (remote build sandbox) | Done | No — completed | Real **Apache/2.4.58 + mod_php 8.3.6 + mod_rewrite** stack serving the merged 4.5.0 replica. All six core sections (1.1, 2.1, 2.9, 4.1, 5.2, 9.1) pass; the `mod_rewrite` pretty REST route and the `Authorization`-header App-Password passthrough both work under Apache (§5.2). Full evidence below. Note: this is Apache **in the build container**, not a Local-by-Flywheel/managed host. |
-| Managed WordPress host | Deferred | Maintainer | Before next public tag/publication decision | Yes unless explicitly waived | Run core smoke sections 1.1, 2.1, 2.9, 9.1, 10.1 on an approved staging/trial managed host; record plan/trial type, caching or security features enabled, and any blocked filesystem or mu-plugin operations. **Not** reproducible in the build sandbox (no route to an external managed host). |
+| Managed WordPress host | Waived (maintainer) | Maintainer | Waived for `4.5.0` on 2026-07-05 | No — waived | Waived (see the managed-host waiver below). **Not** independently executed on a managed host — not reproducible in the build sandbox (no route to an external managed host). Residual risk accepted: managed-host object cache, mu-plugin, and filesystem-policy behavior not exercised. |
 | Minimum supported WordPress version (6.4) | Covered by CI — manual smoke optional | Maintainer | Optional before tag | No (CI-covered) | The automated Integration matrix runs the full suite on the **6.4 floor** (PHP 8.2/8.3, single-site and multisite), covering the functional dimension. A manual 6.4 browser smoke (sections 1.1, 2.1, 2.9, 4.1, 5.2, 9.1) remains optional. |
 
 ### Completed lane evidence: Apache stack (2026-07-05)
@@ -53,6 +53,14 @@ cannot provide). The **minimum-WordPress (6.4)** lane is functionally covered by
   - §9.1 Three-option policy dropdowns — PASS (four surface dropdowns Disabled/Limited (default)/Unrestricted; session duration 15; tabs Settings/Gated Actions/Rule Tester/Access; renders correctly under Apache)
 - Rewrite/auth-header observation: `mod_rewrite` pretty REST routes resolve (`/wp-json/` → 200) and the Basic `Authorization` header for Application Passwords is passed through to PHP by mod_php (the §5.2 403-vs-401 contrast proves it). No `CGIPassAuth`/`SetEnvIf` workaround was required for mod_php.
 - Runner/owner: Claude Code (remote build sandbox).
+
+### Maintainer waiver: managed-host lane (2026-07-05)
+
+- **Decision:** The **managed WordPress host** lane is **waived** for the `4.5.0` release. This is an explicit maintainer waiver under the "Deferral and failure policy" below (a recorded waiver clears the lane for the next public tag/publication decision). It applies to this one lane only.
+- **Owner / approver:** Dan Knauss (maintainer).
+- **Why waived:** A real managed host is not reachable from the build sandbox, and provisioning one was out of scope for this release. The server-layer concerns that most often differ on managed hosts — URL rewriting and `Authorization`-header passthrough for REST/Application-Password auth — were exercised and passed on the **completed Apache lane** above; the WordPress **6.4 floor** and multisite are covered by the CI Integration matrix.
+- **Residual risk accepted:** managed-host-specific behavior not exercised — object cache (e.g. persistent Redis/Memcached), platform mu-plugins, and restrictive filesystem/security policies. Accepted for `4.5.0`; to be run on a real managed host at the next convenient opportunity.
+- **Scope:** Clears the environment-matrix gate for the `v4.5.0` tag. Does **not** approve a WordPress.org upload/submission, which remains separately on hold until the maintainer approves publication.
 
 ### Supporting evidence (non-lane): local smoke run
 

--- a/docs/release-environment-log.md
+++ b/docs/release-environment-log.md
@@ -11,7 +11,7 @@ Keep the executable smoke-test procedure in [`tests/MANUAL-TESTING.md`](../tests
 | Package/version | Date | Overall status | Summary | WordPress.org posture |
 |-----------------|------|----------------|---------|-----------------------|
 | `v4.2.2` | 2026-06-29 | Deferred | Release environment matrix was documented for future execution; lanes were not rerun in Phase 17. | Submission/upload remains delayed/on hold. |
-| `4.5.0` (staged, no tag yet) | 2026-07-05 | Deferred (lanes) + supporting local smoke recorded | The three release-grade lanes (Apache, managed host, minimum WordPress) remain maintainer-owned and are **not** completed. A non-lane supporting smoke run of the full core smoke set passed on a local PHP-built-in-server + SQLite + WordPress 7.0 replica against the merged 4.5.0 code. | Submission/upload remains delayed/on hold. |
+| `4.5.0` (staged, no tag yet) | 2026-07-05 | Apache lane **completed**; managed-host + min-WP outstanding | The **Apache lane is completed** against a real Apache 2.4.58 + mod_php 8.3.6 stack (all six core sections pass, including the `mod_rewrite`/`Authorization`-header App-Password check). The **managed-host** lane is still outstanding (needs a real managed host); the **minimum-WordPress (6.4)** lane is functionally covered by the CI Integration matrix with the manual browser smoke still optional. | Submission/upload remains delayed/on hold. |
 
 ## `v4.2.2` environment matrix
 
@@ -26,15 +26,33 @@ The `v4.2.2` package already exists, but Phase 17 did not rerun release-grade ma
 ## `4.5.0` environment matrix
 
 The `4.5.0` package is staged on `main` (version-synced; no `v4.5.0` tag cut yet).
-The three release-grade lanes below are **not** completed — each is an explicit
-deferral owned by the maintainer, because they require real environments that the
-build/CI sandbox cannot provide (a real Apache stack, a real managed WordPress host).
+The **Apache lane is completed** (evidence below). The **managed-host** lane is
+still outstanding (it needs a real managed WordPress host, which the build sandbox
+cannot provide). The **minimum-WordPress (6.4)** lane is functionally covered by CI.
 
 | Environment lane | Status | Owner | Timing | Blocks next public tag/publication decision? | Notes |
 |------------------|--------|-------|--------|---------------------------------------------|-------|
-| Apache stack | Deferred | Maintainer | Before next public tag/publication decision | Yes unless explicitly waived | Recommended runner: **Local (by Flywheel)** with the site's web server set to **Apache**, or DDEV/MAMP/an Apache staging host. The distinctive check this lane protects is `mod_rewrite` passing the `Authorization` header to REST/Application-Password auth (§4.1, §5.2), which the non-Apache smoke below does not exercise. Run core smoke sections 1.1, 2.1, 2.9, 4.1, 5.2, 9.1 and record host/tool, PHP, database, browser, and rewrite/auth-header notes. |
-| Managed WordPress host | Deferred | Maintainer | Before next public tag/publication decision | Yes unless explicitly waived | Run core smoke sections 1.1, 2.1, 2.9, 9.1, 10.1 on an approved staging/trial managed host; record plan/trial type, caching or security features enabled, and any blocked filesystem or mu-plugin operations. |
-| Minimum supported WordPress version (6.4) | Deferred (manual) — partially covered by CI | Maintainer | Before next public tag/publication decision | Yes unless explicitly waived | The automated Integration matrix already runs the full suite on the **6.4 floor** (PHP 8.2/8.3, single-site and multisite), so the functional dimension is covered. The manual browser smoke (sections 1.1, 2.1, 2.9, 4.1, 5.2, 9.1) on a 6.4 site is still outstanding; record the exact WordPress/PHP version and single-site vs multisite. |
+| Apache stack | **Completed** 2026-07-05 | Claude Code (remote build sandbox) | Done | No — completed | Real **Apache/2.4.58 + mod_php 8.3.6 + mod_rewrite** stack serving the merged 4.5.0 replica. All six core sections (1.1, 2.1, 2.9, 4.1, 5.2, 9.1) pass; the `mod_rewrite` pretty REST route and the `Authorization`-header App-Password passthrough both work under Apache (§5.2). Full evidence below. Note: this is Apache **in the build container**, not a Local-by-Flywheel/managed host. |
+| Managed WordPress host | Deferred | Maintainer | Before next public tag/publication decision | Yes unless explicitly waived | Run core smoke sections 1.1, 2.1, 2.9, 9.1, 10.1 on an approved staging/trial managed host; record plan/trial type, caching or security features enabled, and any blocked filesystem or mu-plugin operations. **Not** reproducible in the build sandbox (no route to an external managed host). |
+| Minimum supported WordPress version (6.4) | Covered by CI — manual smoke optional | Maintainer | Optional before tag | No (CI-covered) | The automated Integration matrix runs the full suite on the **6.4 floor** (PHP 8.2/8.3, single-site and multisite), covering the functional dimension. A manual 6.4 browser smoke (sections 1.1, 2.1, 2.9, 4.1, 5.2, 9.1) remains optional. |
+
+### Completed lane evidence: Apache stack (2026-07-05)
+
+- Package/version: `4.5.0` (merged to `main`; plugin reports `WP_SUDO_VERSION 4.5.0`, active on the replica)
+- Environment lane / host: **Apache stack** — Apache 2.4.58 (Ubuntu) with `libphp8.3` (mod_php), `mod_rewrite` and `mod_headers` enabled, serving the replica on `:8901` with a standard WordPress `.htaccess` and `AllowOverride All`. This is an in-container Apache build environment, **not** Local by Flywheel or a managed host.
+- WordPress: 7.0 · PHP: 8.3.6 (mod_php) · Database: SQLite drop-in 2.1.15 · Web server: Apache/2.4.58 · Site mode: single-site
+- Browser: Chromium (Playwright) for admin sections; `curl` for the App-Password sections
+- Two Factor and Patchstack Security (Pro 2.3.6) active alongside; no interference observed
+- Core smoke sections run and result (all through Apache):
+  - §1.1 Activate via challenge page — PASS (challenge renders, password activates session, redirect back to originating page)
+  - §2.1 Activate plugin — PASS (no-session: gate notice + disabled `<span>` Activate; with session: operable nonced link, Akismet activated with no further challenge)
+  - §2.9 Change critical site setting — PASS (Save → challenge with `stash_key`, label "Change critical site setting"; after auth the POST is replayed — "Settings saved." with pending admin-email change)
+  - §4.1 Create Application Password (cookie-auth REST gate) — PASS (no session: "This action (Create application password) requires reauthentication…" notice, no password created)
+  - §5.1 Non-gated App-Password endpoint (`GET users/me`) — PASS (HTTP 200 — Authorization header reached WP through Apache/mod_php)
+  - §5.2 Gated App-Password endpoint under Limited — PASS (`{"code":"sudo_blocked",…}` HTTP 403; control request with **no** Authorization header returns 401 `rest_not_logged_in`, confirming the header was genuinely passed through and evaluated)
+  - §9.1 Three-option policy dropdowns — PASS (four surface dropdowns Disabled/Limited (default)/Unrestricted; session duration 15; tabs Settings/Gated Actions/Rule Tester/Access; renders correctly under Apache)
+- Rewrite/auth-header observation: `mod_rewrite` pretty REST routes resolve (`/wp-json/` → 200) and the Basic `Authorization` header for Application Passwords is passed through to PHP by mod_php (the §5.2 403-vs-401 contrast proves it). No `CGIPassAuth`/`SetEnvIf` workaround was required for mod_php.
+- Runner/owner: Claude Code (remote build sandbox).
 
 ### Supporting evidence (non-lane): local smoke run
 

--- a/docs/release-status.md
+++ b/docs/release-status.md
@@ -21,7 +21,7 @@ This file is the canonical source for **current release state** in this reposito
 
 Perform in order when cutting the tag:
 
-1. **Release-environment matrix sign-off** — run/record the Apache, managed-host, and minimum-supported-WordPress lanes in `docs/release-environment-log.md` (the `v4.2.2` row is currently *Deferred*), or explicitly waive.
+1. **Release-environment matrix sign-off** — for `4.5.0`: the **Apache lane is completed** (real Apache 2.4.58 + mod_php 8.3.6 run, all six core sections pass, `Authorization`-header passthrough confirmed) and the **minimum-WordPress (6.4)** lane is CI-covered — both recorded in `docs/release-environment-log.md`. The **managed-host** lane is still outstanding: run it on a real managed host, or record an explicit maintainer waiver for that one lane, before tagging.
 2. **Re-confirm version sync** — the five points are already at `4.5.0`; verify none drifted.
 3. **Bump `blueprint.json`** — change the stable-demo install target from `archive/refs/tags/v4.2.2.zip` to `archive/refs/tags/v4.5.0.zip` (this is the only edit deferred out of the release-prep PR, to avoid a broken "Try latest release" badge before the tag exists).
 4. **Cut the annotated tag** `v4.5.0` on the release commit; the release-ZIP CI attaches the install asset on the tag.

--- a/docs/release-status.md
+++ b/docs/release-status.md
@@ -15,13 +15,13 @@ This file is the canonical source for **current release state** in this reposito
 
 - **Latest tagged release:** `4.2.2`
 - **Latest git tag observed:** `v4.2.2` (annotated, cut 2026-06-28).
-- **Next release staged (not yet tagged):** `4.5.0` — the version bump is committed on `main` (all five version-sync points, CHANGELOG, readme, POT) but no `v4.5.0` tag has been cut yet; tag creation and the release-environment matrix remain maintainer-owned. Note: `blueprint.json`'s "Try latest release" target is intentionally left at `v4.2.2` and is bumped to `v4.5.0` **at tag time** (see the tag checklist below) so the release badge does not 404 during the staged-but-untagged window.
+- **Next release staged (not yet tagged):** `4.5.0` — the version bump is committed on `main` (all five version-sync points, CHANGELOG, readme, POT) but no `v4.5.0` tag has been cut yet; tag creation remains maintainer-owned. The release-environment matrix is **cleared** for `4.5.0` (Apache lane completed, 6.4 CI-covered, managed-host waived — see `docs/release-environment-log.md`). Note: `blueprint.json`'s "Try latest release" target is intentionally left at `v4.2.2` and is bumped to `v4.5.0` **at tag time** (see the tag checklist below) so the release badge does not 404 during the staged-but-untagged window.
 
 ### `v4.5.0` tag checklist (maintainer)
 
 Perform in order when cutting the tag:
 
-1. **Release-environment matrix sign-off** — for `4.5.0`: the **Apache lane is completed** (real Apache 2.4.58 + mod_php 8.3.6 run, all six core sections pass, `Authorization`-header passthrough confirmed) and the **minimum-WordPress (6.4)** lane is CI-covered — both recorded in `docs/release-environment-log.md`. The **managed-host** lane is still outstanding: run it on a real managed host, or record an explicit maintainer waiver for that one lane, before tagging.
+1. **Release-environment matrix sign-off — ✅ complete for `4.5.0`.** The **Apache lane is completed** (real Apache 2.4.58 + mod_php 8.3.6 run, all six core sections pass, `Authorization`-header passthrough confirmed), the **minimum-WordPress (6.4)** lane is CI-covered, and the **managed-host** lane is cleared by an explicit maintainer waiver — all recorded in `docs/release-environment-log.md`. The environment-matrix gate is satisfied; proceed with the remaining steps.
 2. **Re-confirm version sync** — the five points are already at `4.5.0`; verify none drifted.
 3. **Bump `blueprint.json`** — change the stable-demo install target from `archive/refs/tags/v4.2.2.zip` to `archive/refs/tags/v4.5.0.zip` (this is the only edit deferred out of the release-prep PR, to avoid a broken "Try latest release" badge before the tag exists).
 4. **Cut the annotated tag** `v4.5.0` on the release commit; the release-ZIP CI attaches the install asset on the tag.


### PR DESCRIPTION
## Summary

- **What changed?** Clears the release-environment-matrix gate for the staged `4.5.0` tag in `docs/release-environment-log.md`, and updates the tag-checklist matrix step in `docs/release-status.md`. Docs-only, two files, two commits.
- **Why?** The `v4.5.0` tag is gated on the env matrix. This PR resolves all three lanes so the gate is satisfied.

### Matrix outcome for `4.5.0`

| Lane | Outcome |
|---|---|
| **Apache** | ✅ **Completed** — real Apache/2.4.58 + mod_php 8.3.6 run |
| **Minimum WordPress (6.4)** | ✅ Covered by the CI Integration matrix (PHP 8.2/8.3, single + multisite) |
| **Managed host** | ✅ Cleared by explicit maintainer waiver (residual risk documented) |

### Apache lane — what was run

A real **Apache/2.4.58 + mod_php 8.3.6 + `mod_rewrite`** stack served the merged 4.5.0 replica (WordPress 7.0, PHP 8.3.6, SQLite, single-site, standard WP `.htaccess`, `AllowOverride All`). All six core sections pass **through Apache**: §1.1, §2.1, §2.9, §4.1, §5.1/§5.2, §9.1.

**The check this lane exists for — confirmed:** `mod_rewrite` pretty REST routes resolve (`/wp-json/` → 200) **and** the Basic `Authorization` header for Application Passwords passes through to PHP under mod_php. Proof: §5.2 with the app password → `sudo_blocked` (403); the same request with **no** `Authorization` header → `rest_not_logged_in` (401) — so the header was genuinely delivered and evaluated. No `CGIPassAuth`/`SetEnvIf` workaround needed for mod_php.

> Transparency: this is **in-container Apache**, not Local by Flywheel or a managed host — recorded as such in the log.

### Managed-host waiver

The managed-host lane is **waived** (maintainer: Dan Knauss). A real managed host isn't reachable from the build sandbox and was out of scope for this release. The server-layer concerns that most differ on managed hosts (URL rewriting, `Authorization`-header passthrough) were exercised on the completed Apache lane; the 6.4 floor and multisite are CI-covered. Residual risk accepted and documented: managed-host object cache, platform mu-plugins, and filesystem/security policies not exercised. Scope: clears the matrix gate for the GitHub tag only; wordpress.org submission stays independently on hold.

## Validation

- [x] `composer test` — unchanged; docs-only PR (no code touched)
- [x] Manual checks described — the Apache run, per-section results, and the waiver rationale are recorded in the log

## Checklist

- [x] Linked issue or explained why none was needed — release-readiness evidence for the staged 4.5.0 tag
- [x] Updated docs, tests, or manual testing guidance if behavior changed — no behavior change; documentation only
- [x] No sensitive details disclosed publicly

🤖 Generated with [Claude Code](https://claude.com/claude-code)