### PR TITLE
test(e2e): use WP_BASE_URL in CHAL-04 return_url instead of hardcoded port

### DIFF
--- a/tests/e2e/specs/challenge.spec.ts
+++ b/tests/e2e/specs/challenge.spec.ts
@@ -734,7 +734,7 @@ test.describe( 'Challenge flow', () => {
 
         await page.goto(
             '/wp-admin/admin.php?page=wp-sudo-challenge&stash_key=expired-key&return_url=' +
-            encodeURIComponent( 'http://localhost:8889/wp-admin/plugins.php' )
+            encodeURIComponent( `${ WP_BASE_URL }/wp-admin/plugins.php` )
         );
 
         await page.waitForURL( /plugins\.php/, { timeout: 15_000 } );


### PR DESCRIPTION
## Summary

- **What changed?** `tests/e2e/specs/challenge.spec.ts` — CHAL-04's stale-challenge `return_url` now uses `` `${ WP_BASE_URL }/wp-admin/plugins.php` `` instead of a hardcoded `http://localhost:8889/wp-admin/plugins.php`. One-line test fix.
- **Why?** CHAL-04 hardcoded the default wp-env port, so the E2E matrix failed with a `page.waitForURL` timeout whenever it ran against a non-default port (e.g. a clean stack on `:8891`). WP Sudo correctly redirected to the supplied `return_url`, but that URL pointed at a different environment. The fix matches the pattern **already used by CHAL-05** (`WP_BASE_URL` is defined at the top of the spec).

Discovered and validated during a local Playwright E2E matrix run on the maintainer's machine (clean wp-env on `:8891`/`:8892`, after the default `:8889` was found unusable due to a stale/redirecting listener). The root cause was the test's hardcoded port, not product behavior.

## Validation

- [x] CHAL-04 passes locally (chromium) against `WP_BASE_URL=http://localhost:8891` — `✓ CHAL-04: active session escapes stale challenge URL`
- [x] `composer test` (unit) unaffected — this is an E2E spec only; no product code touched
- [ ] Full E2E matrix rerun from a clean wp-env state is recommended (maintainer-side; requires Docker/wp-env, not available in the CI/build sandbox)

## Checklist

- [x] Linked issue or explained why none was needed — test-robustness fix surfaced by the E2E matrix run
- [x] Updated docs, tests, or manual testing guidance if behavior changed — test-only; no behavior change
- [x] No sensitive details disclosed publicly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017TCJoA72EDAmLviMKDB5zx)_