### PR TITLE
chore(release): bump blueprint.json stable-demo target to v4.5.0 [MERGE AT TAG TIME]

### DIFF
--- a/blueprint.json
+++ b/blueprint.json
@@ -19,7 +19,7 @@
       "step": "installPlugin",
       "pluginData": {
         "resource": "url",
-        "url": "https://wordpress-playground-cors-proxy.net/?https://github.com/dknauss/Sudo/archive/refs/tags/v4.2.2.zip"
+        "url": "https://wordpress-playground-cors-proxy.net/?https://github.com/dknauss/Sudo/archive/refs/tags/v4.5.0.zip"
       },
       "options": {
         "activate": true


### PR DESCRIPTION
## Summary

- **What changed?** `blueprint.json` — the Playground "Try latest release" install step now targets `archive/refs/tags/v4.5.0.zip` (was `v4.2.2.zip`). One-line change. This is **step 3** of the `v4.5.0` tag checklist in `docs/release-status.md`.
- **Why staged separately?** The release badge (in `readme.md`) points at **`main/blueprint.json`**, so this must **not** reach `main` until the `v4.5.0` tag exists — otherwise the badge resolves to a not-yet-existent tag zip and 404s.

## ⚠️ Merge ordering

**Do not merge this until the `v4.5.0` git tag has been cut.** Recommended sequence:

1. Merge any final release content to `main`.
2. Cut the annotated `v4.5.0` tag (GitHub then generates `archive/refs/tags/v4.5.0.zip`).
3. **Merge this PR** → the "Try latest release" badge immediately points at the real v4.5.0 zip.

`blueprint-main.json` (which tracks `archive/refs/heads/main.zip`) is intentionally unchanged.

## Validation

- [x] `blueprint.json` is valid JSON; only the one install-target URL changed
- [x] `blueprint-main.json` untouched
- [ ] Post-merge (after tag): confirm the "Try latest release in Playground" badge loads `v4.5.0.zip`

## Checklist

- [x] Linked issue or explained why none was needed — mechanical release step (tag-checklist step 3)
- [x] Updated docs, tests, or manual testing guidance if behavior changed — no behavior change; Playground demo target only
- [x] No sensitive details disclosed publicly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017TCJoA72EDAmLviMKDB5zx)_