### PR TITLE
docs(planning): re-land reauth PR #157 review fixes (merged before they landed)

### DIFF
--- a/.planning/RETROSPECTIVE.md
+++ b/.planning/RETROSPECTIVE.md
@@ -74,6 +74,32 @@
 
 ---
 
+## Process Note: 2026-07-05 — Model-tier / delegation discipline
+
+*Non-milestone session (block-editor reauth design-phase scaffolding).*
+
+### What Was Inefficient
+- Spawned a security-docs **survey** subagent (read-and-extract across five repos) on
+  the inherited **Opus** tier instead of downshifting to **Sonnet** — mechanical work
+  that the global CLAUDE.md Model-Downshifting rules and GSD agent profiles already say
+  belongs on Sonnet/Haiku. The user caught the waste, not the agent.
+- Compounded it by writing a project memory that duplicated the CLAUDE.md rule (churn,
+  the "don't save what the repo already records" anti-pattern). Reverted.
+- Full cost/accountability record in `docs/llm-lies-log.md` → "Cost / Process Cheats"
+  (entries C1–C2).
+
+### Key Lesson
+- **Always delegate for model efficiency and pass an explicit right-sized `model` on
+  every spawn.** Reserve Opus for genuine judgment (design/security review, hard
+  debugging, architecture); mechanical read/extract/search/map/boilerplate work goes to
+  Sonnet, or Haiku when trivial. The rule already exists — the failure was not applying
+  it. This is an execution discipline, not a documentation gap.
+- The two Opus **reviews** this session (design + security, on auth/session code) were
+  correctly tiered; the mistiered item was the read-only docs survey. The tell:
+  "extract and summarize" → Sonnet; "adversarially judge this security code" → Opus.
+
+---
+
 ## Cross-Milestone Trends
 
 ### Process Evolution

--- a/.planning/gutenberg-editor-reauth-design-brief.md
+++ b/.planning/gutenberg-editor-reauth-design-brief.md
@@ -238,7 +238,7 @@ Key refutations (all code-grounded):
   **wrong** for the editor. The editor is a long-lived SPA and the short sudo session
   expires while it stays open, so the recovery handler must be loaded even if a session
   is active at page load, or a later gated action reopens the opaque 403. Safe to always
-  load because this nonce is a CSRF token, not authz (this Part 3.6), trivially mintable
+  load because this nonce is a CSRF token, not authz (see Part 3.6), trivially mintable
   by any same-origin script.
 - **C3 — first-party re-dispatch.** The re-fired request must carry the user's own
   `wp_rest` nonce so `is_rest_cookie_auth()` (`class-gate.php:451-466`) classifies it as

--- a/.planning/gutenberg-editor-reauth-design-brief.md
+++ b/.planning/gutenberg-editor-reauth-design-brief.md
@@ -316,8 +316,9 @@ a `build/` artifact, and version-pinning maintenance — cost a snackbar does no
    Specs: block-plugin install/activate happy path; re-dispatch after grant; AJAX 2FA
    grant path; **batched gated write** (per the Q2 decision); headless-branch-stays-
    `challenge_url`-free regression (**security C4**); grace-window no-duplicate-snackbar;
-   grant-nonce localized only on editor screens and skipped when session active
-   (**security C2**); re-dispatch carries a first-party `wp_rest` nonce (**security C3**).
+   grant-nonce localized only on editor screens **but loaded even when a session is
+   active** (**revised security C2** — do NOT skip when active); re-dispatch carries a
+   first-party `wp_rest` nonce (**security C3**).
 
 ---
 

--- a/.planning/gutenberg-editor-reauth-design-brief.md
+++ b/.planning/gutenberg-editor-reauth-design-brief.md
@@ -231,10 +231,15 @@ Key refutations (all code-grounded):
 - **C1 — grant-nonce blast radius.** Keeping the single `wp_sudo_challenge` nonce action
   is acceptable (it is a CSRF token); a distinct editor-grant nonce action is optional
   defense-in-depth. Decide, don't drift.
-- **C2 — tight localization.** Enqueue/localize the grant nonce **only on actual
-  block/site-editor screens** (mirror `class-challenge.php:179`), and skip it when
-  `Sudo_Session::is_active()` (as the existing shortcut enqueue does,
-  `class-plugin.php:200-202`). Do not spray the nonce onto non-editor pages.
+- **C2 — tight localization (revised after PR #157 review).** Enqueue/localize the grant
+  nonce **only on actual block/site-editor screens** (mirror `class-challenge.php:179`);
+  do not spray it onto non-editor pages. **Correction:** the original C2 said to also skip
+  when `Sudo_Session::is_active()` (mirroring `class-plugin.php:200-202`) — that is
+  **wrong** for the editor. The editor is a long-lived SPA and the short sudo session
+  expires while it stays open, so the recovery handler must be loaded even if a session
+  is active at page load, or a later gated action reopens the opaque 403. Safe to always
+  load because this nonce is a CSRF token, not authz (this Part 3.6), trivially mintable
+  by any same-origin script.
 - **C3 — first-party re-dispatch.** The re-fired request must carry the user's own
   `wp_rest` nonce so `is_rest_cookie_auth()` (`class-gate.php:451-466`) classifies it as
   cookie-auth and re-evaluates the now-active session at `:1829`. Never rebuild it

--- a/.planning/gutenberg-editor-reauth-phase2-plan.md
+++ b/.planning/gutenberg-editor-reauth-phase2-plan.md
@@ -109,19 +109,21 @@ gated; the REST path never touches `Request_Stash`.
 - **GREEN:** `wp.element.createElement( wp.components.Modal, … )` — build-free. Snackbar
   (`core/notices`) is the trigger surface that opens the modal; it degrades to a plain
   message when `challenge_url` is absent (headless).
-- **⚠ 2FA rendering caveat (Codex PR #157 review — corrects an overstated SEV-1).**
-  `handle_ajax_2fa()` only *validates*; the provider *fields* are emitted server-side by
-  `Challenge::render_page()` via the `wp_sudo_render_two_factor_fields` render hook, which
-  the modal never runs. So AJAX 2FA is **not** universally reusable:
-  - **TOTP-style factors** (a plain code input) — the modal renders its own field with
-    `autocomplete="one-time-code"` + `inputmode="numeric"` (2FA bridge-guide rules, Part 7)
-    and posts to `handle_ajax_2fa`. Works in-modal.
-  - **Provider-ceremony factors** (WebAuthn/passkey, or any custom
-    `wp_sudo_render_two_factor_fields` output) — the modal **cannot** render these. Either
-    add a small server-rendered 2FA-partial endpoint the modal fetches and injects, **or**
-    route these users to the link-out fallback (full-page challenge). Decide per-factor at
-    task-design time; **default to link-out** if the partial endpoint is not built. Do not
-    ship the modal claiming universal 2FA support.
+- **⚠ 2FA rendering caveat (Codex PR #157/#158 review — corrects an overstated SEV-1).**
+  `handle_ajax_2fa()` only *validates*, and it delegates to `$provider->validate_authentication($user)`
+  (`class-challenge.php:607`) plus the `wp_sudo_validate_two_factor` filter (`:619`) — **both
+  read provider-specific `$_POST` field names** emitted by the provider's own render step
+  (`Challenge::render_page()` via the `wp_sudo_render_two_factor_fields` hook), which the
+  modal never runs. So AJAX 2FA is **not** reusable with a generic input — even for TOTP:
+  - A **generic** modal TOTP field (`one-time-code`) will **not** be read, because the
+    provider's `validate_authentication()` looks for its own field name (e.g. Two Factor's
+    `authcode`). Rendering a plain input and posting to `handle_ajax_2fa` **does not work**.
+  - The modal must therefore either (a) fetch a **server-rendered 2FA partial** (the exact
+    provider markup) and inject it, or (b) render **provider-exact field names** per factor.
+    For WebAuthn/passkey ceremonies (b) is infeasible → **link-out fallback**.
+  - **Default to the server-rendered partial or link-out**; do not claim any in-modal 2FA
+    works until the partial endpoint exists. Field-markup rules (Part 7) still apply to
+    whatever the partial renders (`autocomplete="one-time-code"`, `inputmode="numeric"`).
 
 ### Task 4 — Re-dispatch the original request on grant (C3)
 - **RED:** test that on `authenticated`, the exact original request is re-fired once,
@@ -151,12 +153,17 @@ green does **not** imply multisite green.
   session expiry) and absent on non-editor screens; batched `sudo_required` surfaces the
   snackbar (no silent no-op); headless branch stays `challenge_url`-free (C4).
 - **Multisite (network admin + a subsite editor):** the same grant→re-dispatch flow
-  succeeds; the `challenge_url` routes to the correct (network vs. site) admin context;
-  a network-only gated action (e.g. a super-admin-scoped operation) gates and grants
-  correctly; per-site session isolation holds (a grant on one site does not silently
-  satisfy a gated action on another beyond documented behavior). Run the integration
-  suite with the multisite bootstrap (`WP_TESTS_MULTISITE`/`WP_MULTISITE`) as well as
-  single-site.
+  succeeds on a subsite editor using the **existing editor-reachable REST route**
+  (`/wp/v2/plugins` install/activate — the only realistic surface per the inventory);
+  the `challenge_url` routes to the correct (network vs. site) admin context via the
+  referrer logic in `build_session_challenge_url()`; per-site session isolation holds
+  (a grant on one site does not silently satisfy a gated action on another beyond
+  documented behavior). **Do not** scope a `network.*` action into this lane — those
+  rules are `rest => null` (admin-only) and are not editor-reachable (surface inventory);
+  testing them here would drag in unrelated classic-network-admin coverage. Run the
+  integration suite with **`WP_MULTISITE=1 composer test:integration`** (the flag
+  `bin/run-integration-tests.sh` actually forwards — `WP_TESTS_MULTISITE` alone silently
+  runs single-site) as well as the single-site run.
 - Reuse the harness admin auth pattern per the repo's E2E convention; unit tests that
   branch on `is_multisite()` must cover **both** return values.
 

--- a/.planning/gutenberg-editor-reauth-phase2-plan.md
+++ b/.planning/gutenberg-editor-reauth-phase2-plan.md
@@ -146,9 +146,10 @@ green does **not** imply multisite green.
 
 - **Single-site:** Block Directory install/activate happy path (gated → modal → grant →
   auto re-dispatch → plugin active, editor state intact); AJAX 2FA grant path;
-  grace-window no-duplicate-snackbar; grant nonce present only on editor screens and
-  absent when session active; batched `sudo_required` surfaces the snackbar (no silent
-  no-op); headless branch stays `challenge_url`-free (C4).
+  grace-window no-duplicate-snackbar; grant nonce present on editor screens **including
+  when a session is active at page load** (revised C2 — the recovery path must survive
+  session expiry) and absent on non-editor screens; batched `sudo_required` surfaces the
+  snackbar (no silent no-op); headless branch stays `challenge_url`-free (C4).
 - **Multisite (network admin + a subsite editor):** the same grant→re-dispatch flow
   succeeds; the `challenge_url` routes to the correct (network vs. site) admin context;
   a network-only gated action (e.g. a super-admin-scoped operation) gates and grants

--- a/.planning/gutenberg-editor-reauth-phase2-plan.md
+++ b/.planning/gutenberg-editor-reauth-phase2-plan.md
@@ -15,16 +15,19 @@ Pre-Implementation Design Review is already satisfied by the brief + two reviews
 ## ⛔ Required gates — READ BEFORE WRITING ANY CODE
 
 This feature is **security-sensitive** (new REST + editor surface, sudo-session grant,
-CSRF-nonce exposure, capability-gated actions). Per `CLAUDE.md` and the global
-"size review to risk" rule it gets a **mandatory deep review**, not a light touch.
-These gates are non-negotiable; do not merge past their findings.
+CSRF-nonce exposure, capability-gated actions), so it warrants a **mandatory deep
+review**, not a light touch — high-risk diffs (auth, capabilities, sessions, new
+endpoints) always do. These gates are non-negotiable; do not merge past their findings.
 
 **Deterministic gates that WILL fire automatically (do not bypass):**
 - **Pre-commit reviewer-agent approval** on every code commit. The text-only skip is
   `\.(md|txt|rst)$` — the editor `.js` and any `.php` here do **not** qualify, so each
   code commit needs a fresh `reviewer-approved` flag written by the reviewer agent
   (not the main agent). Do **not** use `USER_COMMIT=1` on AI-generated code.
-- **`composer test` + `composer analyse` (PHPStan L6) + Psalm + PHPCS** via the hook.
+- The pre-commit hook runs **`composer test:unit`**, **`composer lint`** (PHPCS), and
+  **`composer analyse:phpstan`** (`.reviewer-config.sh`) — it does **not** run Psalm or
+  the full `composer analyse`/integration suite locally. Run `composer analyse` (PHPStan
+  + Psalm) and the integration suite yourself before pushing; CI is the backstop.
 - **CODEOWNERS** `* @dknauss` → GitHub review + "require conversation resolution".
 - **`docs/current-metrics.md`** must be updated in the same commit that changes any
   counted quantity (new E2E specs, unit tests) — `composer verify:metrics` gates it.
@@ -39,7 +42,7 @@ These gates are non-negotiable; do not merge past their findings.
    generic and will **not** know about these unless the review brief names them. Every
    review request for this feature MUST ask the reviewer to verify:
    - **C1** — grant nonce stays the single `wp_sudo_challenge` CSRF action; not broadened to authz use.
-   - **C2** — grant nonce localized **only** on block/site-editor screens, skipped when `Sudo_Session::is_active()`; never sprayed onto non-editor pages.
+   - **C2** — grant nonce localized **only** on block/site-editor screens (never sprayed onto non-editor pages), but **loaded even when a session is active** so the recovery path survives session expiry in a long-open editor (revised per Codex PR #157 review).
    - **C3** — re-dispatch carries the user's own first-party `wp_rest` nonce; the request is never rebuilt server-side.
    - **C4** — `challenge_url` stays absent on the headless/app-password branch (regression test present and passing).
    - Plus: REST path never touches `Request_Stash`; no content/design save is gated; no `@wordpress/scripts` build step introduced.
@@ -69,7 +72,7 @@ gated; the REST path never touches `Request_Stash`.
 ## Security conditions carried from the review (C1–C4) → tasks
 
 - **C1** grant-nonce blast radius → keep the single `wp_sudo_challenge` nonce action (it is a CSRF token, not authz); do **not** broaden it. (Task 2)
-- **C2** localize the grant nonce **only** on block/site-editor screens, skipped when `Sudo_Session::is_active()` — mirror `class-plugin.php:200-202`. (Task 2)
+- **C2 (revised)** localize the grant nonce **only** on block/site-editor screens — but **do NOT** skip when `Sudo_Session::is_active()`; the editor is a long-lived SPA and the short sudo session expires while it stays open, so the recovery handler must already be loaded. Acceptable because the nonce is a CSRF token, not authz (see brief Part 3.6). (Task 2)
 - **C3** re-dispatch carries the user's own `wp_rest` nonce (first-party; never server-rebuilt). (Task 4)
 - **C4** regression: `challenge_url` stays absent on the headless/app-password branch. (Task 5)
 
@@ -87,23 +90,38 @@ gated; the REST path never touches `Request_Stash`.
   an internal event/state the snackbar layer consumes. No password UI yet.
 - **Notes:** build-free vanilla JS in `admin/js/`, deps declared on `wp-api-fetch`.
 
-### Task 2 — Editor enqueue + grant-nonce localization (C1, C2)
-- **RED:** PHP unit: the editor enqueue registers only on editor screens; the localized
-  data carries the grant nonce and challenge-AJAX action; nothing is enqueued when
-  `Sudo_Session::is_active()`; the nonce is **not** emitted on non-editor screens.
+### Task 2 — Editor enqueue + grant-nonce localization (C1, C2 revised)
+- **RED:** PHP unit: the editor handler + grant nonce are enqueued on block/site-editor
+  screens **regardless of whether a sudo session is active at page load**; the nonce is
+  **not** emitted on non-editor screens; `NONCE_ACTION` is reused (C1 — no new action).
 - **GREEN:** hook `enqueue_block_editor_assets` (or equivalent), mirroring the tight
-  gating of `class-challenge.php:179` and the active-session skip at
-  `class-plugin.php:200-202`. Reuse `NONCE_ACTION` (C1 — no new action).
+  *screen* gating of `class-challenge.php:179` — but **NOT** the active-session skip at
+  `class-plugin.php:200-202`. That skip is a proactive shortcut for a single page load;
+  the editor is a long-lived SPA where the short session expires while it stays open, so
+  a later gated action would return `sudo_required` with no handler/modal/nonce loaded,
+  reopening the opaque 403 this feature fixes (Codex PR #157 review). The nonce is a CSRF
+  token (brief Part 3.6), so always-loading it in the editor adds negligible risk.
 
-### Task 3 — In-editor modal: password + AJAX 2FA via existing grant endpoints
-- **RED:** test that the modal calls `wp_ajax_` `handle_ajax_auth` with the password and
-  **no** `stash_key` (session-only grant), handles `{code:'authenticated'}`,
-  `{code:'2fa_pending'}` → 2FA step via `handle_ajax_2fa`, `locked_out`, and
-  `invalid_password`; closing the modal cancels cleanly.
-- **GREEN:** `wp.element.createElement( wp.components.Modal, … )` — build-free. Collects
-  the password, posts to the grant endpoint with the localized nonce, drives the 2FA
-  sub-step. Snackbar (`core/notices`) is the trigger surface that opens the modal;
-  it also degrades to a plain message when `challenge_url` is absent (headless).
+### Task 3 — In-editor modal: password + 2FA (with a per-factor 2FA rendering split)
+- **RED:** test that the modal calls `handle_ajax_auth` with the password and **no**
+  `stash_key` (session-only grant), handles `{code:'authenticated'}`,
+  `{code:'2fa_pending'}`, `locked_out`, and `invalid_password`; closing cancels cleanly.
+- **GREEN:** `wp.element.createElement( wp.components.Modal, … )` — build-free. Snackbar
+  (`core/notices`) is the trigger surface that opens the modal; it degrades to a plain
+  message when `challenge_url` is absent (headless).
+- **⚠ 2FA rendering caveat (Codex PR #157 review — corrects an overstated SEV-1).**
+  `handle_ajax_2fa()` only *validates*; the provider *fields* are emitted server-side by
+  `Challenge::render_page()` via the `wp_sudo_render_two_factor_fields` render hook, which
+  the modal never runs. So AJAX 2FA is **not** universally reusable:
+  - **TOTP-style factors** (a plain code input) — the modal renders its own field with
+    `autocomplete="one-time-code"` + `inputmode="numeric"` (2FA bridge-guide rules, Part 7)
+    and posts to `handle_ajax_2fa`. Works in-modal.
+  - **Provider-ceremony factors** (WebAuthn/passkey, or any custom
+    `wp_sudo_render_two_factor_fields` output) — the modal **cannot** render these. Either
+    add a small server-rendered 2FA-partial endpoint the modal fetches and injects, **or**
+    route these users to the link-out fallback (full-page challenge). Decide per-factor at
+    task-design time; **default to link-out** if the partial endpoint is not built. Do not
+    ship the modal claiming universal 2FA support.
 
 ### Task 4 — Re-dispatch the original request on grant (C3)
 - **RED:** test that on `authenticated`, the exact original request is re-fired once,
@@ -119,12 +137,32 @@ gated; the REST path never touches `Request_Stash`.
   echoes the rule label (Q4).
 - **GREEN:** already-true server invariant + client guards; this task locks them with tests.
 
-### Task 6 — Playwright E2E (first challenge-transport E2E)
-- Specs: Block Directory install/activate happy path (gated → modal → grant → auto
-  re-dispatch → plugin active, editor state intact); AJAX 2FA grant path; grace-window
-  no-duplicate-snackbar; grant nonce present only on editor screens and absent when
-  session active; batched `sudo_required` surfaces the snackbar (does not silently
-  no-op). Reuse the harness admin auth pattern per the repo's E2E convention.
+### Task 6 — E2E + integration on BOTH single-site and multisite (required)
+**Both topologies must pass — this is a hard requirement, not a nicety.** The
+challenge-URL construction is multisite-specific (`build_session_challenge_url()`
+infers network-admin routing from the referrer, `class-gate.php:2646-2664`) and the
+capability model differs (single-site admin vs. network super-admin), so single-site
+green does **not** imply multisite green.
+
+- **Single-site:** Block Directory install/activate happy path (gated → modal → grant →
+  auto re-dispatch → plugin active, editor state intact); AJAX 2FA grant path;
+  grace-window no-duplicate-snackbar; grant nonce present only on editor screens and
+  absent when session active; batched `sudo_required` surfaces the snackbar (no silent
+  no-op); headless branch stays `challenge_url`-free (C4).
+- **Multisite (network admin + a subsite editor):** the same grant→re-dispatch flow
+  succeeds; the `challenge_url` routes to the correct (network vs. site) admin context;
+  a network-only gated action (e.g. a super-admin-scoped operation) gates and grants
+  correctly; per-site session isolation holds (a grant on one site does not silently
+  satisfy a gated action on another beyond documented behavior). Run the integration
+  suite with the multisite bootstrap (`WP_TESTS_MULTISITE`/`WP_MULTISITE`) as well as
+  single-site.
+- Reuse the harness admin auth pattern per the repo's E2E convention; unit tests that
+  branch on `is_multisite()` must cover **both** return values.
+
+### Task 7 — Security-config alignment check (see Part 7)
+Before the final security-scoped review, confirm the implementation matches the
+config best-practices in Part 7 (nonce/cookie/REST/capability/enqueue/multisite). This
+is a checklist pass, not new code; failures here feed back into Tasks 1–6.
 
 ---
 
@@ -148,3 +186,65 @@ gated; the REST path never touches `Request_Stash`.
   `2026-07-05-password-manager-2fa-interaction.md`. Verify autofill during Task 3.
 - **Metrics.** Adding E2E specs changes counts in `docs/current-metrics.md` — update it
   in the same commit per the repo rule.
+
+---
+
+## Part 7 — Security-config alignment (from the security-docs survey)
+
+Grounded against the user's security-doc repos (`wp-security-benchmark`,
+`wp-security-hardening-guide`, `wp-security-style-guide`, `wordpress-2fa-ecosystem`;
+`Security-White-Paper` had no citable config content). Items below are the ones that
+bear on this feature. **Gaps are stated explicitly — do not treat this as full coverage.**
+
+**Reauth concept is endorsed by the corpus.** `wp-security-benchmark` §5.5 "Ensure
+reauthentication is required for privileged actions" (Level 2) names **wp-sudo** and lists
+exactly the gated-action categories this plugin covers; `wp-security-hardening-guide` §8.2
+"Privileged Action Gating" frames it as "sudo mode" and cites VIP step-up auth's bounded
+unlock window as precedent for a time-boxed grant. The feature is aligned with documented
+best practice, not inventing a pattern.
+
+**Nonce / CSRF (supports C1, C3).** Style-guide glossary "Nonce": WP nonces are **not**
+single-use — valid up to ~24h (two 12h ticks) — so a nonce is request-intent/origin proof,
+**not** authorization; keep `current_user_can()` gating the destructive action itself
+(A01 passage, hardening-guide §4 pairs nonce + capability as *both-required* layers). This
+directly backs C1 (nonce is CSRF, not authz) and the design's insistence that the sudo
+session never becomes a substitute for capability checks.
+
+**Sessions / cookies (supports C4 + session-binding).** Benchmark §2.5 / hardening §6.3
+require `HttpOnly + Secure + SameSite` on session cookies (framed as defense-in-depth for
+`session_start()` plugins — cite carefully, it is not stated for WP's own auth cookie).
+Style-guide "Session hijacking": **2FA does not protect an already-authenticated session**
+→ bind the sudo grant to the login session and keep it short (benchmark §5.3 / hardening
+§8.4: 8–24h max, purge on permission change). Reinforces the short-lived, login-bound token.
+
+**REST (supports C4).** Hardening §7.5 / benchmark §5.6: every custom REST endpoint **must**
+have a `permission_callback` (if a 2FA-partial endpoint is added in Task 3, this is
+mandatory). Application passwords **bypass 2FA by design** and are a separate trust tier
+(style-guide "Application password") — this is the doctrinal basis for **C4** (the
+headless/app-password branch must not receive `challenge_url` or a reauth affordance).
+Keep soft-block/challenge responses **generic** (no user-enumeration / capability-name
+leakage) — benchmark §5.4, style-guide "Information disclosure".
+
+**Capabilities / multisite (supports the Task 6 multisite requirement).** Hardening §7.4:
+"apply reauthentication requirements at the **network level** for Super Admin actions
+(adding sites, network-wide plugins, network settings)" — the single most on-point citation
+for why Task 6's multisite lane is mandatory. Super Admin is all-or-nothing/unscopable
+(benchmark §13.1); single-site **Administrator** ↔ **Super Admin** is the terminology to use
+per context (style-guide "Admin (role)").
+
+**2FA rendering (backs the Task 3 caveat).** `wordpress-2fa-ecosystem/docs/bridge-guide.md`
+"Three-Hook Pattern" — Detection / **Rendering** / Validation are *separate*; the host
+renders fields, and **WebAuthn/passkey ceremonies require enqueued scripts + a hidden
+result field, not a pure PHP/AJAX bridge** ("Constraints and Unsupported Patterns"). This
+independently confirms Codex's provider-2FA finding. Field-markup rules for the modal's own
+TOTP input: **no `<form>`/submit/`_wpnonce`**, unique `name`, `autocomplete="one-time-code"`,
+`inputmode="numeric"`; **debounce email-OTP sends** (a retry can invalidate the code);
+render **backup-code** fallback; **never decrypt secrets yourself** — always call the
+provider's own validation. Push/cloud-validated methods (miniOrange) and no-stable-API
+plugins (Shield) are unsuitable for synchronous in-modal 2FA → link-out.
+
+**Explicit gaps in the corpus (source elsewhere — do NOT cite these repos for them):**
+script-enqueue/`wp_localize_script` secret-leakage & screen-scoping guidance (use core
+handbook / `wp-secure-code`); `map_meta_cap` cautions (absent everywhere); cookie-flag
+guidance for a *plugin-issued* cookie specifically; session-fixation mitigation for a
+custom token; REST soft-block info-disclosure specifics.

--- a/.planning/gutenberg-editor-reauth-phase2-plan.md
+++ b/.planning/gutenberg-editor-reauth-phase2-plan.md
@@ -101,6 +101,15 @@ gated; the REST path never touches `Request_Stash`.
   a later gated action would return `sudo_required` with no handler/modal/nonce loaded,
   reopening the opaque 403 this feature fixes (Codex PR #157 review). The nonce is a CSRF
   token (brief Part 3.6), so always-loading it in the editor adds negligible risk.
+- **⚠ Grant-nonce staleness (Codex #158 review).** Localizing the nonce at page load is
+  not sufficient on its own: `handle_ajax_auth()`/`handle_ajax_2fa()` reject on
+  `check_ajax_referer()` once the `wp_sudo_challenge` nonce ages out (WP nonces ~24 h). An
+  editor tab left open overnight has a valid login cookie, an expired sudo session, and the
+  loaded handler — but the AJAX grant then fails on the **stale grant nonce**, recreating
+  the dead-end. Require a **nonce refresh**: re-mint the grant nonce on demand (a tiny
+  authenticated endpoint keyed on the still-valid login/`wp_rest` cookie) before the grant
+  call, or retry once with a fresh nonce on a `check_ajax_referer` failure. Long-open
+  recovery tests (Task 6) must exercise a **stale-nonce** tab, not only a nonce-valid one.
 
 ### Task 3 — In-editor modal: password + 2FA (with a per-factor 2FA rendering split)
 - **RED:** test that the modal calls `handle_ajax_auth` with the password and **no**
@@ -156,9 +165,14 @@ green does **not** imply multisite green.
   succeeds on a subsite editor using the **existing editor-reachable REST route**
   (`/wp/v2/plugins` install/activate — the only realistic surface per the inventory);
   the `challenge_url` routes to the correct (network vs. site) admin context via the
-  referrer logic in `build_session_challenge_url()`; per-site session isolation holds
-  (a grant on one site does not silently satisfy a gated action on another beyond
-  documented behavior). **Do not** scope a `network.*` action into this lane — those
+  referrer logic in `build_session_challenge_url()`. **Assert the documented network-wide
+  session contract, NOT per-site isolation** (Codex #158 review): sudo sessions live in
+  global user meta (`_wp_sudo_expires`/`_wp_sudo_token` via `update_user_meta()`,
+  `class-sudo-session.php:294,854`), so per `docs/FAQ.md` "authenticating on one site
+  covers all sites" — a grant in one subsite editor satisfies the same user's gated
+  action on another site (bounded by the cookie domain / login-session binding). A test
+  asserting isolation would contradict the product contract. **Do not** scope a
+  `network.*` action into this lane — those
   rules are `rest => null` (admin-only) and are not editor-reachable (surface inventory);
   testing them here would drag in unrelated classic-network-admin coverage. Run the
   integration suite with **`WP_MULTISITE=1 composer test:integration`** (the flag

--- a/.planning/todos/pending/2026-07-05-password-manager-2fa-interaction.md
+++ b/.planning/todos/pending/2026-07-05-password-manager-2fa-interaction.md
@@ -14,7 +14,8 @@ files:
 WP Sudo's reauthentication surfaces (the full-page `wp-sudo-challenge` screen and,
 if the Tier 2 block-editor feature ships, an in-editor modal) present a password
 field and, on 2FA sites, a second-factor step. How password managers interact with
-these surfaces is unverified, and at least one manager is known to be getting harder:
+these surfaces is unverified, and at least one manager is *reportedly* getting harder
+(unverified — see below):
 
 - **1Password is reportedly/anecdotally harder with two-factor lately — UNVERIFIED.**
   This is a hypothesis to reproduce, not a settled fact. Recent 1Password behavior

--- a/.planning/todos/pending/2026-07-05-password-manager-2fa-interaction.md
+++ b/.planning/todos/pending/2026-07-05-password-manager-2fa-interaction.md
@@ -16,10 +16,12 @@ if the Tier 2 block-editor feature ships, an in-editor modal) present a password
 field and, on 2FA sites, a second-factor step. How password managers interact with
 these surfaces is unverified, and at least one manager is known to be getting harder:
 
-- **1Password is particularly tough with two-factor now.** Recent 1Password behavior
-  around TOTP autofill / passkeys / the in-app 2FA flow makes it awkward on
-  second-factor prompts. Worth pinning down what actually breaks (autofill not
-  offered, TOTP not surfaced, passkey prompt intercepted, etc.) rather than assuming.
+- **1Password is reportedly/anecdotally harder with two-factor lately — UNVERIFIED.**
+  This is a hypothesis to reproduce, not a settled fact. Recent 1Password behavior
+  around TOTP autofill / passkeys / the in-app 2FA flow *may* make it awkward on
+  second-factor prompts. Pin down what actually breaks (autofill not offered, TOTP not
+  surfaced, passkey prompt intercepted, etc.) with a **concrete 1Password version +
+  repro** before recording any of it as fact (per the repo verification rules).
 
 The reauth flow is deliberately *not* the WordPress login form — it is a custom
 challenge handler (`includes/class-challenge.php`). Password managers key heavily off

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1068,10 +1068,11 @@ Sudo's reauth surfaces — the full-page `wp-sudo-challenge` form and, if the Ti
 block-editor feature ships, an in-editor modal — is unverified. Managers key off
 login-form heuristics (`autocomplete` tokens, field semantics, a real `<form>`), and
 our custom challenge handler is deliberately not `wp-login.php`; a `wp.components.Modal`
-field is the most autofill-hostile surface. **1Password is notably tough with two-factor
-now** and needs a concrete repro. Also covers how WordPress/two-factor renders each
-provider (TOTP, WebAuthn/passkey, backup codes) at our challenge time. Deliverable: a
-per-manager × per-surface autofill matrix plus any cheap markup fixes. Tracked in
+field is the most autofill-hostile surface. **1Password is reportedly/anecdotally harder
+with two-factor lately** (unverified — needs a concrete version + repro before it is
+treated as fact). Also covers how WordPress/two-factor renders each provider (TOTP,
+WebAuthn/passkey, backup codes) at our challenge time. Deliverable: a per-manager ×
+per-surface autofill matrix plus any cheap markup fixes. Tracked in
 `.planning/todos/pending/2026-07-05-password-manager-2fa-interaction.md`; feeds the
 Tier 2 modal autofill check in `.planning/gutenberg-editor-reauth-phase2-plan.md`.
 

--- a/docs/llm-lies-log.md
+++ b/docs/llm-lies-log.md
@@ -538,3 +538,38 @@ The fabricated method and meta key names are the worst category — these
 are not stale facts but invented strings that sound plausible. A human
 reading the documentation would have no reason to doubt them, and code
 using them would fail silently or throw errors.
+
+
+================================================================
+COST / PROCESS CHEATS (non-confabulation)
+================================================================
+A separate class from the fabrications above: these are not false claims,
+they are ways the agent wasted the user's tokens/money or added no-value
+churn. Logged here at the user's request for accountability, kept distinct
+from the confabulation entries so the numbered list stays confabulation-only.
+
+C1. WRONG MODEL TIER FOR MECHANICAL WORK — Opus on a read/extract survey
+    Date:   2026-07-05 (block-editor reauth design-phase session)
+    Cheat:  Spawned a security-docs *survey* subagent (read five repos,
+            extract citable best-practices) on the inherited Opus tier
+            instead of downshifting to Sonnet. Pure read-and-extract work —
+            textbook Sonnet/Haiku per the global CLAUDE.md "Model
+            Downshifting" and "Reasoning / Effort Tuning" rules and the GSD
+            agent model-profiles.
+    Cost:   A full Opus subagent run's tokens for work Sonnet does at a
+            fraction of the price; the user caught it, not the agent.
+    Rule:   The guidance already existed (global CLAUDE.md + agent profiles).
+            This was a failure to APPLY a known rule, not a missing rule.
+    Fix:    Killed the Opus run, relaunched identical survey on Sonnet.
+            Standing correction: pass an explicit right-sized `model` on
+            every Agent/Workflow spawn; never let a mechanical subagent
+            silently inherit Opus.
+
+C2. REDUNDANT MEMORY DUPLICATING CLAUDE.md
+    Date:   2026-07-05 (same session)
+    Cheat:  After C1, wrote a project "memory" restating the model-tier
+            rule that already lives in global CLAUDE.md and the agent
+            profiles — the exact "don't save what the repo already records"
+            anti-pattern. Added churn, not value.
+    Fix:    Reverted the memory addition. Rule stays where it belongs
+            (CLAUDE.md + profiles); the job is to execute it, not re-log it.


### PR DESCRIPTION
## Why this exists

PR #157 was merged at an earlier branch tip (`dff61d7`), **before** two follow-up commits were pushed. Those commits — the automated-review fixes and the cost-cheat log entries — never made it into `main`. This PR re-lands them (clean cherry-picks, no conflicts). Docs/planning only.

## What's re-landed

**Automated review fixes (were `c4eda20`, addressing Codex P2 ×3 + Copilot ×4 on #157):**
- Session-expiry recovery: C2 revised — editor reauth handler/nonce load **even when a session is active** (a long-open editor's short session expires; skipping would reopen the opaque 403).
- Provider 2FA rendering: corrected an overstated SEV-1 — `handle_ajax_2fa()` only validates; Task 3 now splits TOTP-style (in-modal) from provider-ceremony factors (WebAuthn/custom → server-rendered partial or link-out).
- 1Password wording (todo + ROADMAP): reworded from a settled claim to an explicitly **unverified** hypothesis needing a version + repro.
- Corrected the non-verifiable "size review to risk" citation and the overstated pre-commit-hook description (`.reviewer-config.sh` runs `test:unit` + `lint` + `analyse:phpstan`, not Psalm).
- Added Part 7 (security-config alignment from the security-docs survey, with citations + explicit gaps).

**Cost-cheat accountability (were `158616d`):**
- `docs/llm-lies-log.md` "Cost / Process Cheats" section (wrong model tier; redundant memory), kept distinct from the confabulation entries.
- `.planning/RETROSPECTIVE.md` model-tier/delegation process note.

## Risk

Low — docs only. The `docs/gutenberg-reauth-design-brief.md` change here is the C2 revision folded consistently into the merged brief.

🤖 Generated with [Claude Code](https://claude.com/claude-code)