### PR TITLE
docs: close missed review findings (5 merged PRs) + enable conversation-resolution gate

### DIFF
--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -127,7 +127,7 @@ Recommended next multisite browser sequence:
 - **Local multisite drift**: Symlinked Local/Studio plugin installs can execute the plugin from the repo target path, not the public `wp-content/plugins/<slug>` path. Bootstrap URL logic must recover the public plugin basename from active plugin state, and browser regressions for that behavior remain local-only.
 - **Multisite browser scope**: Hosted Playwright CI still cannot prove network-admin-only stash/replay behavior. Local multisite regressions should target multisite-specific routing seams in priority order instead of adding broad duplicate coverage.
 - **Two Factor source discipline**: Third-party technical claims about upstream WordPress/two-factor internals must be refreshed from live source before implementation and cited in code/docs.
-- **Patchstack fixture boundary**: Patchstack Security 2FA compatibility remains manual/fixture-blocked until a paid Patchstack-enabled test environment exists; do not ship Patchstack bridge code or runtime support claims from source inspection alone.
+- **Patchstack boundary**: Patchstack Security 2FA core bridge path was runtime-validated offline against a licensed Pro 2.3.6 fixture (PR #145) — the fixture blocker is resolved. The remaining Patchstack work is the live login-form / profile-save / WooCommerce lifecycle runs and the bridge-vs-upstream decision; do not ship Patchstack bridge code or a runtime support claim until those lifecycle runs land.
 
 ## Key Decisions
 

--- a/.planning/todos/pending/2026-06-28-add-patchstack-2fa-compatibility-target.md
+++ b/.planning/todos/pending/2026-06-28-add-patchstack-2fa-compatibility-target.md
@@ -11,7 +11,7 @@ files:
 
 Patchstack Security includes a paid-feature TOTP 2FA flow outside WP Sudo's automatic WordPress/two-factor integration. The Phase 19 ecosystem matrix now tracks it conservatively as a second-tier/manual-test target so source-inspection findings do not become runtime support claims.
 
-Refreshed evidence in `docs/two-factor-ecosystem.md` points to WordPress.org SVN [`includes/login.php`](https://plugins.svn.wordpress.org/patchstack/trunk/includes/login.php), repository revision `3590474`, file revision `3433693` dated 2026-01-06, checked 2026-06-29. The source still shows `patchstack_login_2fa`, `webarx_2fa_enabled`, `webarx_2fa_secretkey`, `webarx_2fa_secretkey_nonce`, `patchstack_2fa`, and `TokenAuth6238::verify()`. Free-license mode returns before meaningful 2FA hook registration, so runtime behavior remains unverified without a paid Patchstack-enabled fixture.
+Refreshed evidence in `docs/two-factor-ecosystem.md` points to WordPress.org SVN [`includes/login.php`](https://plugins.svn.wordpress.org/patchstack/trunk/includes/login.php), repository revision `3590474`, file revision `3433693` dated 2026-01-06, checked 2026-06-29. The source still shows `patchstack_login_2fa`, `webarx_2fa_enabled`, `webarx_2fa_secretkey`, `webarx_2fa_secretkey_nonce`, `patchstack_2fa`, and `TokenAuth6238::verify()`. Free-license mode returns before meaningful 2FA hook registration; runtime behavior has since been verified offline against a licensed Pro 2.3.6 fixture (see Remaining Work / Status below), resolving the earlier fixture blocker. The remaining gap is the live login-form / profile-save / WooCommerce lifecycle runs.
 
 ## Remaining Work
 

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -105,7 +105,10 @@ Rule of thumb: if you cannot point to a new entry this change adds to
 - Releases are annotated tags `vX.Y.Z` cut from the release commit; the GitHub
   Release is published from that tag. Tagging/publishing is **maintainer-owned**.
 - Every release keeps the five version-sync points in agreement (see the
-  `CLAUDE.md` version-sync checklist); the `verify:metrics`/CI gates fail on drift.
+  `CLAUDE.md` version-sync checklist). This is a **manual** release-checklist step —
+  `verify:metrics` checks `docs/current-metrics.md` (test/LOC/registry counts), **not**
+  the version-sync points, so version-sync drift is caught by the checklist, not by an
+  automated CI gate.
 - The public "Try latest release" Playground badge loads `blueprint.json` from
   `main`, so its tag-ZIP target is bumped **after** the tag is cut, never before
   (a pre-tag bump would make the public demo fetch a missing ZIP).

--- a/docs/release-environment-log.md
+++ b/docs/release-environment-log.md
@@ -28,14 +28,16 @@ The `v4.2.2` package already exists, but Phase 17 did not rerun release-grade ma
 
 The `4.5.0` package is staged on `main` (version-synced; no `v4.5.0` tag cut yet).
 The **Apache lane is completed** (evidence below). The **managed-host** lane is
-still outstanding (it needs a real managed WordPress host, which the build sandbox
-cannot provide). The **minimum-WordPress (6.4)** lane is functionally covered by CI.
+**waived** for `4.5.0` by explicit maintainer waiver (see below) — it was not run
+because a real managed WordPress host is not reachable from the build sandbox;
+residual risk accepted. The **minimum-WordPress (6.4)** lane is functionally covered
+by CI (on the PHP 8.2 single-site lane — see the row below for the exact scope).
 
 | Environment lane | Status | Owner | Timing | Blocks next public tag/publication decision? | Notes |
 |------------------|--------|-------|--------|---------------------------------------------|-------|
 | Apache stack | **Completed** 2026-07-05 | Claude Code (remote build sandbox) | Done | No — completed | Real **Apache/2.4.58 + mod_php 8.3.6 + mod_rewrite** stack serving the merged 4.5.0 replica. All six core sections (1.1, 2.1, 2.9, 4.1, 5.2, 9.1) pass; the `mod_rewrite` pretty REST route and the `Authorization`-header App-Password passthrough both work under Apache (§5.2). Full evidence below. Note: this is Apache **in the build container**, not a Local-by-Flywheel/managed host. |
 | Managed WordPress host | Waived (maintainer) | Maintainer | Waived for `4.5.0` on 2026-07-05 | No — waived | Waived (see the managed-host waiver below). **Not** independently executed on a managed host — not reproducible in the build sandbox (no route to an external managed host). Residual risk accepted: managed-host object cache, mu-plugin, and filesystem-policy behavior not exercised. |
-| Minimum supported WordPress version (6.4) | Covered by CI — manual smoke optional | Maintainer | Optional before tag | No (CI-covered) | The automated Integration matrix runs the full suite on the **6.4 floor** (PHP 8.2/8.3, single-site and multisite), covering the functional dimension. A manual 6.4 browser smoke (sections 1.1, 2.1, 2.9, 4.1, 5.2, 9.1) remains optional. |
+| Minimum supported WordPress version (6.4) | Covered by CI — manual smoke optional | Maintainer | Optional before tag | No (CI-covered) | The automated Integration matrix runs the full suite on the **6.4 floor** on **PHP 8.2, single-site** (the only 6.4 lane in `.github/workflows/phpunit.yml`); multisite is exercised on the PHP 8.3 / WP 7.0 lane, **not** on 6.4. This covers the functional dimension on the floor; a manual 6.4 browser smoke (sections 1.1, 2.1, 2.9, 4.1, 5.2, 9.1) — and specifically 6.4 multisite — remains optional. |
 
 ### Completed lane evidence: Apache stack (2026-07-05)
 
@@ -91,7 +93,7 @@ The `4.5.1` package is staged on `main` (version-synced; no `v4.5.1` tag cut yet
 
 - **Decision:** The `4.5.0` environment matrix above is **reused** for `4.5.1`; no lane is re-run.
 - **What actually changed since the `v4.5.0` tag:** `git diff v4.5.0..<release-commit> -- includes/ bridges/ mu-plugin/ admin/ wp-sudo.php` shows PR #154 only — `includes/class-admin.php`, `includes/class-dashboard-widget.php`, new `includes/class-user-identity.php`, `admin/css/wp-sudo-admin.css`, and the version constant/header in `wp-sudo.php`. This is **admin-UI presentation code** (how a user is rendered on the dashboard widget and the Access tab) plus the `get_avatar()` `force`→`force_display` fix. It is *not* a version-only bump — there is a real code delta from the tagged `4.5.0` tree.
-- **Why the matrix still applies (not re-run):** the manual environment matrix exists to catch **server- and host-layer** differences — Apache URL-rewrite and `Authorization`-header passthrough for REST/App-Password auth, managed-host object cache / platform mu-plugins / filesystem policy, and the WordPress 6.4 floor. PR #154's changes are admin-side rendering with no new REST/rewrite/auth surface and no API newer than the 6.4 floor (`get_avatar`, `translate_user_role`, `wp_roles` all long predate 6.4). Those functional changes are exercised by the CI Integration matrix on the 6.4 floor (single-site and multisite). No environmental dimension the manual lanes test is affected by admin-markup changes, so a re-run would exercise nothing new.
+- **Why the matrix still applies (not re-run):** the manual environment matrix exists to catch **server- and host-layer** differences — Apache URL-rewrite and `Authorization`-header passthrough for REST/App-Password auth, managed-host object cache / platform mu-plugins / filesystem policy, and the WordPress 6.4 floor. PR #154's changes are admin-side rendering with no new REST/rewrite/auth surface and no API newer than the 6.4 floor (`get_avatar`, `translate_user_role`, `wp_roles` all long predate 6.4). Those functional changes are exercised by the CI Integration matrix on the 6.4 floor (PHP 8.2 single-site; multisite is covered on the PHP 8.3 / WP 7.0 lane). No environmental dimension the manual lanes test is affected by admin-markup changes, so a re-run would exercise nothing new.
 - **Owner / approver:** Maintainer (reuse rationale authored for review; the tag decision remains maintainer-owned).
 - **Scope:** Clears the environment-matrix gate for the `v4.5.1` tag by inheritance. Does **not** approve a WordPress.org upload/submission, which remains separately on hold.
 

--- a/docs/release-status.md
+++ b/docs/release-status.md
@@ -97,8 +97,9 @@ Canonical source for post-tag drift after `v4.5.0`: `git log v4.5.0..main --onel
 The `v4.5.0` tag (2026-07-05) shipped the **substantial** body of work
 accumulated since `v4.2.2` — two completed GSD milestones (v4.4.0 Two Factor
 Lifecycle Bridge and v4.5 Session Governance & Admin UX) plus security
-hardening. All of it is now released. `main` and the tag are level, so there is
-no unreleased work beyond the tag. Canonical drift source for the release:
+hardening — released as of the `v4.5.0` tag. `main` has since **advanced past**
+`v4.5.0` (the staged `4.5.1` version bump plus post-tag docs/CI work), so there **is**
+unreleased work beyond the tag; see "Unreleased `main` work" below. Drift source:
 `git log v4.2.2..v4.5.0 --oneline`; see the `CHANGELOG.md` `4.5.0` section for
 the curated feature list.
 
@@ -128,7 +129,7 @@ Canonical source for drift after the tag: `git log v4.5.0..main --oneline`.
 
 ### Release environment assurance
 
-Phase 17 added [`docs/release-environment-log.md`](release-environment-log.md) as the record of record for release-grade manual environment matrix outcomes. The current `v4.2.2` package row is explicitly **Deferred**: Apache stack, managed WordPress host, and minimum-supported-WordPress lanes were not rerun in Phase 17 and each is owned by the Maintainer before the next public tag/publication decision, blocking unless explicitly waived.
+Phase 17 added [`docs/release-environment-log.md`](release-environment-log.md) as the record of record for release-grade manual environment matrix outcomes. For the current `4.5.0`/`4.5.1` package the environment-matrix gate is **cleared for tag**: the Apache lane is completed, the minimum-supported-WordPress (6.4) floor is CI-covered, and the managed-host lane is cleared by an explicit maintainer waiver (see the log). The historical `v4.2.2` row remains **Deferred**.
 
 Release readiness now distinguishes **Pre-tag/core** gates from **WordPress.org-only** gates. Pre-tag/core gates cover version sync, Composer validation commands, external-claim audit, changelog/readme/release-status sanity, package metadata, and the release environment matrix/log gate. WordPress.org-only gates cover the readme validator, clean-package Plugin Check, SVN layout/upload, listing assets, screenshot/caption parity, slug-lock decision, and final publication approval. WordPress.org submission/upload remains delayed/on hold.
 


### PR DESCRIPTION
## Why

Auditing the last 48h found **five merged PRs whose Codex/Copilot review threads were never addressed or resolved** — merged straight past, because `main` did **not** have "Require conversation resolution" enabled (despite CLAUDE.md claiming it was active). This PR:

1. **Fixes the still-live findings** (verified against current `main`, not assumed).
2. Comes with the gate now **enabled** on `main` so this can't recur.

## Findings fixed

| Source PR | Finding | Fix |
|---|---|---|
| #147 / #148 | WP 6.4 CI coverage overstated as "PHP 8.2/8.3, single-site **and multisite**" | Verified `phpunit.yml`: 6.4 is **PHP 8.2 single-site only**; multisite is 8.3/7.0. Corrected 3 spots. |
| #148 | Managed-host lane "still outstanding" vs "waived" contradiction | Reconciled to waived (maintainer). |
| #148 / #152 | Assurance section still cited `v4.2.2` Deferred as current | Updated to 4.5.0/4.5.1 cleared-for-tag. |
| #152 | "main and tag are level" — stale | main is **36 commits past v4.5.0**; corrected. |
| #156 | `verify:metrics` claimed to gate version-sync | It only checks `current-metrics.md`; reworded to a manual checklist step. |
| #145 | Patchstack "fixture-blocked" — stale | PR #145 runtime-validated the core bridge path (licensed Pro 2.3.6); updated, lifecycle runs still pending. |

## Recurrence prevention

`required_conversation_resolution` is now **enabled** on the `main` branch protection (all 5 required status checks preserved). Unresolved review threads now block the merge button.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)