### PR TITLE
docs: footprint & performance stats for READMEs

### DIFF
--- a/docs/current-metrics.md
+++ b/docs/current-metrics.md
@@ -25,6 +25,45 @@ Verification environment: local workspace, PHP 8.x
 | Test-to-production ratio | 2.11:1 | `36231 / 17183` |
 | Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`) | 54,349 | `find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/vendor_test/*" ! -path "*/.tmp/*" ! -path "*/.git/*" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
 
+## Footprint & Performance
+
+Persistent storage is near-static; the only growing table self-prunes. Per-request
+DB cost is characterized from a full static hook sweep (2026-07-05), not runtime
+profiling — a precise Query Monitor figure would confirm but not change the shape.
+
+### Persistent storage
+
+| Item | Value | Verification |
+|---|---:|---|
+| Persistent options | 3 | `wp_sudo_settings` (config, `Admin::OPTION_KEY`), `wp_sudo_activated`, `wp_sudo_governance_mode`: `grep -rhoE "wp_sudo_(settings\|activated\|governance_mode)\b" includes/ wp-sudo.php \| sort -u \| wc -l` → 3 |
+| Custom tables | 1 | `{base_prefix}wpsudo_events` (dashboard activity log; one network-wide table on multisite): `grep -oE "wpsudo_events" includes/class-event-store.php \| sort -u \| wc -l` → 1 |
+| Events retention (default) | 14 days, batch-pruned | `grep -c 'function prune( int \$days = 14' includes/class-event-store.php` → 1 |
+
+Per-user meta (`_wp_sudo_*`: session token/expiry/bind + ephemeral rate-limit counters)
+and transients (request stash, rate-limit keys, active-count cache) are written only for
+users who hold a session or trigger gating; they self-expire and are removed on uninstall.
+
+### Per-request cost (front-end)
+
+WP Sudo is an event-gate — no per-page DB work. The only always-on per-request hooks are
+three `init` callbacks (`enforce_editor_unfiltered_html`, `gate_non_interactive`,
+`handle_deactivate`); `map_meta_cap` returns immediately for any non-governance capability.
+
+| Context | Added DB queries | Basis |
+|---|---:|---|
+| Front-end visitor (logged out) | 0 | No admin bar; the `init` hooks do constant/global + cached-role checks only |
+| Front-end, logged-in user | ≤ 1 (cached user-meta) | Admin-bar `Sudo_Session::is_active()` — static per-request cache, else one `get_user_meta` |
+| Non-gated admin page | negligible | In-memory rule matching + the same cached session check |
+| Gated action | bounded (grant/stash/rate-limit) | Only on the specific dangerous action, not on browsing |
+
+Re-derive the hook inventory (confirm the always-on set is only the 3 `init` hooks):
+
+```
+grep -rhoE "add_(action|filter)\(\s*'[^']+'" includes/ wp-sudo.php bridges/ mu-plugin/ | grep -oE "'[^']+'" | sort | uniq -c | sort -rn
+```
+
+No production dependencies, no build step: `jq '.dependencies // {} | length' package.json` → `0`.
+
 ## Architectural Facts
 
 Volatile counts that change when features ship. Every doc referencing these

--- a/readme.txt
+++ b/readme.txt
@@ -17,6 +17,8 @@ WordPress has rich access control — roles, capabilities, policies on who can d
 
 This is not role-based escalation. Every logged-in user is treated the same: attempt a gated action without an active sudo session, get challenged. Sessions are time-bounded and non-extendable, enforcing the zero-trust principle that trust must be continuously earned, never assumed. Sudo verifies that the current user is still the account holder; WordPress still decides whether that user is allowed to perform the action.
 
+Lightweight by design. Sudo is an event-gate, not a query-heavy plugin: it adds no database queries to normal front-end page loads (at most one cached read for the logged-in admin-bar timer), ships zero production dependencies with no build step, and stores only three small options plus self-expiring session data. Its one growing table — the activity log — self-prunes at a 14-day default, and everything is removed on uninstall. Database work happens only when a covered action is actually being confirmed.
+
 = Playground demo =
 
 * [Try the latest release in WordPress Playground](https://playground.wordpress.net/?blueprint-url=https%3A%2F%2Fraw.githubusercontent.com%2Fdknauss%2FSudo%2Fmain%2Fblueprint.json)


### PR DESCRIPTION
## What

Adds README-ready **footprint & performance** stats, grounded in a full static hook sweep (not estimates):

- **`docs/current-metrics.md`** — new canonical "Footprint & Performance" section with re-derivation commands for every figure.
- **`README.md`** — a "Footprint and performance" section linking to the canonical metrics.
- **`readme.txt`** — a short "Lightweight by design" paragraph in the Description.

## The numbers (all re-derivable)

- **Storage:** 3 persistent options; 1 custom table (`{base_prefix}wpsudo_events`, **14-day self-pruning** retention); ephemeral, self-expiring user meta + transients; removed on uninstall.
- **Per-request cost:** WP Sudo is an event-gate — **0 added DB queries** on front-end loads for visitors, **≤1 cached** user-meta read for a logged-in user (admin-bar session check). The only always-on hooks are 3 `init` callbacks; `map_meta_cap` returns immediately for non-governance caps. DB activity is confined to the specific gated action.
- **0 production dependencies, no build step.**

## Verification (for the record)

Static sweep of every `add_action`/`add_filter`; the always-on front-end set is only the 3 `init` hooks, all confirmed query-free (cached role check / constant checks / early-return). All four new metric commands re-derive to their stated values (options→3, tables→1, retention→14d, deps→0). One draft error caught and fixed: the table is `wpsudo_events`, not `wp_sudo_events`.

A precise Query Monitor per-page figure would confirm but not change the shape; deliberately not run (needs a live runtime, and 0→0 adds no README value).

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)