### PR TITLE
docs(readme): add Footprint and performance section (missed in #160)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -162,6 +162,16 @@ Sudo exposes a small, stable API. Custom gated rules are plain associative array
 
 For current release posture, supported lanes, and forward `main` notes, see [docs/release-status.md](docs/release-status.md).
 
+## Footprint and performance
+
+Sudo is an event-gate, not a query-heavy plugin — it does no per-page database work.
+
+- **No production dependencies and no build step** — hand-written PHP (~17k lines) and vanilla JS.
+- **Front-end page loads:** zero added database queries for visitors, and at most one cached user-meta read for a logged-in user (the admin-bar session check). Database activity is confined to the specific gated action being confirmed, not to normal browsing.
+- **Storage:** three small options, per-user session and rate-limit meta plus transients that self-expire, and one activity-log table that self-prunes at a 14-day default retention. Everything is removed on uninstall.
+
+These are verified against the plugin's always-on hooks; the exact counts, retention, and re-derivation commands live in [docs/current-metrics.md](docs/current-metrics.md#footprint--performance).
+
 ## Documentation
 
 ### Start here


### PR DESCRIPTION
## What

Adds the **Footprint and performance** section to `readme.md` — the GitHub-displayed README.

## Why a follow-up

In PR #160 the section landed correctly in `readme.txt` and `docs/current-metrics.md`, but **not** in `readme.md`: I edited the wrong-case path `README.md` on a case-insensitive filesystem, so `git add README.md` didn't stage the tracked lowercase `readme.md`. The content is identical to what's already in the canonical metrics doc; this just puts it where GitHub renders it.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)