### PR TITLE
feat(bridges): optional critical-event alert bridge + Playground inline demo

### DIFF
--- a/bin/demo/wp-sudo-alert-inline-demo.php
+++ b/bin/demo/wp-sudo-alert-inline-demo.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * WP Sudo — Inline Alert Demo (companion to the critical-event alert bridge)
+ *
+ * ┌─────────────────────────────────────────────────────────────────────────┐
+ * │ DEMO / REFERENCE ONLY — DO NOT DEPLOY TO A PRODUCTION SITE.              │
+ * └─────────────────────────────────────────────────────────────────────────┘
+ *
+ * `bridges/wp-sudo-critical-alert-bridge.php` notifies a human by EMAIL when a
+ * high-severity audit hook fires. WordPress Playground (and other sandboxes)
+ * disable PHP outbound network, so `wp_mail()` silently goes nowhere and the
+ * "trigger a tamper/escalation/lockout → watch the alert fire" story shows
+ * nothing. This companion makes each composed alert visible IN wp-admin instead.
+ *
+ * It is the concrete realization of the bridge's documented use case: "capture
+ * the composed alert for inline display where outbound network is unavailable."
+ *
+ * How it works:
+ *
+ * - It listens on the bridge's ADDITIVE `wp_sudo_critical_alert_dispatched`
+ *   action — NOT the `wp_sudo_critical_alert_dispatch` replace-filter. The
+ *   additive action always fires alongside the (here undeliverable) email, so
+ *   this file observes without suppressing the bridge's real dispatch path. That
+ *   means dropping this demo next to a real bridge cannot silently kill alert
+ *   email, and cannot poison a downstream Slack/webhook dispatcher.
+ * - Each composed alert is appended RAW to a small rolling site transient
+ *   (newest {@see WP_SUDO_ALERT_INLINE_DEMO_CAP} kept, FIFO). On the next
+ *   wp-admin page load it is rendered — escaped at output — as an admin notice,
+ *   then the buffer is drained so each alert shows exactly once.
+ * - Because it is a DEMO, it also relaxes the bridge's own flood protection
+ *   (`wp_sudo_critical_alert_throttle` and `wp_sudo_critical_alert_hourly_cap`
+ *   → 0) so repeatedly re-triggering the SAME event during a live walkthrough
+ *   keeps surfacing instead of being deduped for an hour. A real deployment
+ *   must NOT do this — that throttling exists to stop attacker-driven floods.
+ *
+ * Demo tip: the alert is composed on `shutdown` of the triggering request and
+ * rendered on the NEXT admin page load — after triggering, reload/navigate in
+ * wp-admin to see the panel. Single-site oriented: network-scope events render
+ * on the triggering site only.
+ *
+ * @package WP_Sudo_Demo
+ * @version 1.0.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! defined( 'WP_SUDO_ALERT_INLINE_DEMO_KEY' ) ) {
+	define( 'WP_SUDO_ALERT_INLINE_DEMO_KEY', '_wp_sudo_alert_inline_demo' );
+}
+
+if ( ! defined( 'WP_SUDO_ALERT_INLINE_DEMO_CAP' ) ) {
+	define( 'WP_SUDO_ALERT_INLINE_DEMO_CAP', 20 );
+}
+
+if ( ! function_exists( 'wp_sudo_alert_inline_demo_capture' ) ) {
+	/**
+	 * Buffer a dispatched alert for inline display. Stores the alert RAW; the
+	 * renderer escapes at output. Trims to the newest CAP entries (FIFO).
+	 *
+	 * @param array<string, mixed> $event Composed event from the alert bridge.
+	 * @return void
+	 */
+	function wp_sudo_alert_inline_demo_capture( array $event ): void {
+		$buffer = get_transient( WP_SUDO_ALERT_INLINE_DEMO_KEY );
+		if ( ! is_array( $buffer ) ) {
+			$buffer = array();
+		}
+
+		$buffer[] = array(
+			'subject' => isset( $event['subject'] ) ? (string) $event['subject'] : 'Critical event',
+			'body'    => isset( $event['body'] ) ? (string) $event['body'] : '',
+			'scope'   => isset( $event['scope'] ) ? (string) $event['scope'] : 'site',
+			'time'    => gmdate( 'c' ),
+		);
+
+		if ( count( $buffer ) > WP_SUDO_ALERT_INLINE_DEMO_CAP ) {
+			$buffer = array_slice( $buffer, -WP_SUDO_ALERT_INLINE_DEMO_CAP );
+		}
+
+		set_transient( WP_SUDO_ALERT_INLINE_DEMO_KEY, $buffer, HOUR_IN_SECONDS );
+	}
+}
+
+if ( ! function_exists( 'wp_sudo_alert_inline_demo_render' ) ) {
+	/**
+	 * Render buffered alerts as admin notices, then drain the buffer so each
+	 * alert shows exactly once. Only users who can manage the site see them.
+	 *
+	 * @return void
+	 */
+	function wp_sudo_alert_inline_demo_render(): void {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		$buffer = get_transient( WP_SUDO_ALERT_INLINE_DEMO_KEY );
+		if ( ! is_array( $buffer ) || array() === $buffer ) {
+			return;
+		}
+
+		// Drain first so a fatal mid-render can't wedge the notice permanently.
+		delete_transient( WP_SUDO_ALERT_INLINE_DEMO_KEY );
+
+		foreach ( $buffer as $entry ) {
+			$subject = isset( $entry['subject'] ) ? (string) $entry['subject'] : 'Critical event';
+			$body    = isset( $entry['body'] ) ? (string) $entry['body'] : '';
+			$time    = isset( $entry['time'] ) ? (string) $entry['time'] : '';
+
+			$line = '🔔 WP Sudo alert emitted: ' . $subject;
+			if ( '' !== $body ) {
+				$line .= ' — ' . $body;
+			}
+			if ( '' !== $time ) {
+				$line .= ' (' . $time . ' UTC)';
+			}
+
+			printf(
+				'<div class="notice notice-warning"><p>%s</p></div>',
+				esc_html( $line )
+			);
+		}
+	}
+}
+
+add_action( 'wp_sudo_critical_alert_dispatched', 'wp_sudo_alert_inline_demo_capture', 10, 1 );
+add_action( 'admin_notices', 'wp_sudo_alert_inline_demo_render' );
+
+// DEMO ONLY: disable the bridge's dedupe window and hourly cap so a live
+// walkthrough can re-trigger the same event and keep seeing it. Never do this
+// on a production site — the throttling defends against attacker-driven floods.
+add_filter( 'wp_sudo_critical_alert_throttle', '__return_zero' );
+add_filter( 'wp_sudo_critical_alert_hourly_cap', '__return_zero' );

--- a/blueprint-main.json
+++ b/blueprint-main.json
@@ -42,6 +42,10 @@
     {
       "step": "runPHP",
       "code": "<?php require_once '/wordpress/wp-load.php'; foreach ( array( 'admin', 'carlosadmin', 'mariadev' ) as $login ) { $u = get_user_by( 'login', $login ); if ( $u ) { foreach ( array( 'manage_wp_sudo', 'view_wp_sudo_activity', 'export_wp_sudo_activity', 'revoke_wp_sudo_sessions' ) as $c ) { $u->add_cap( $c ); } } }"
+    },
+    {
+      "step": "runPHP",
+      "code": "<?php require_once '/wordpress/wp-load.php'; $mu = defined('WPMU_PLUGIN_DIR') ? WPMU_PLUGIN_DIR : WP_CONTENT_DIR . '/mu-plugins'; if ( ! is_dir( $mu ) ) { @mkdir( $mu, 0777, true ); } $found = glob( WP_PLUGIN_DIR . '/*/bridges/wp-sudo-critical-alert-bridge.php' ); if ( is_array( $found ) && ! empty( $found ) ) { $src = $found[0]; $root = dirname( dirname( $src ) ); @copy( $src, $mu . '/wp-sudo-critical-alert-bridge.php' ); $demo = $root . '/bin/demo/wp-sudo-alert-inline-demo.php'; if ( file_exists( $demo ) ) { @copy( $demo, $mu . '/wp-sudo-alert-inline-demo.php' ); } } echo 'Wired critical-alert bridge + inline alert demo into mu-plugins (when present).';"
     }
   ]
 }

--- a/bridges/wp-sudo-critical-alert-bridge.php
+++ b/bridges/wp-sudo-critical-alert-bridge.php
@@ -1,0 +1,401 @@
+<?php
+/**
+ * WP Sudo ↔ Critical-Event Alert Bridge
+ *
+ * Optional bridge that PUSHES a notification when WP Sudo fires one of its
+ * high-severity audit hooks. Drop this file into wp-content/mu-plugins/ to
+ * activate. Unlike the Stream and WSAL bridges (which LOG every audit event),
+ * this bridge notifies a human about the events that usually warrant a look.
+ *
+ * Safety properties (see the design notes below each concern):
+ *
+ * - Deferred, never blocking. Alerts are queued and dispatched on `shutdown`,
+ *   which fires even after the gate's `wp_die()`. A slow SMTP send therefore
+ *   never delays the security-blocking response — the event that fires an alert
+ *   (e.g. wp_sudo_escalation_blocked, right before the gate dies) is already
+ *   answered before the mail is attempted.
+ * - Throttled against floods. Every mapped event is deduped per identity for a
+ *   window, and a bridge-wide hourly cap collapses an incident into a single
+ *   "N more suppressed" summary. This matters because several of these hooks are
+ *   attacker-driven at volume (lockout enumeration, per-request tamper), so an
+ *   unthrottled bridge would be a mail/outbound-DoS amplifier.
+ * - Observability only. It consumes `do_action` hooks; it cannot change any
+ *   gating decision and does not interfere with the Stream/WSAL bridges.
+ *
+ * Configuration (all filterable):
+ *
+ * - `wp_sudo_critical_alert_events`     — array of enabled event keys.
+ * - `wp_sudo_critical_alert_recipient`  — ( string $email, array $event ).
+ * - `wp_sudo_critical_alert_throttle`   — int seconds, per-event dedupe window.
+ * - `wp_sudo_critical_alert_hourly_cap` — int max alerts/hour bridge-wide.
+ * - `wp_sudo_critical_alert_dispatch`   — ( null|mixed $handled, array $event ):
+ *       return non-null to REPLACE the default email (Slack/webhook/inline
+ *       capture). Runs before the default email; a non-null return suppresses it.
+ * - `wp_sudo_critical_alert_dispatched` — action ( array $event ): additive
+ *       observer that always fires (e.g. a demo panel or secondary sink).
+ *
+ * @package WP_Sudo_Bridges
+ * @version 1.0.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! function_exists( 'wp_sudo_critical_alert_bridge_event_map' ) ) {
+	/**
+	 * Map of alert event keys to their WP Sudo audit hook + argument count.
+	 *
+	 * `recovery_mode` is deliberately absent from the default enabled set (see
+	 * wp_sudo_critical_alert_bridge_enabled_events): it fires on every Sudo
+	 * admin-page load during a legitimate break-glass episode and would drown
+	 * the genuinely urgent tamper/escalation alerts.
+	 *
+	 * @return array<string, array{hook: string, args: int}>
+	 */
+	function wp_sudo_critical_alert_bridge_event_map(): array {
+		return array(
+			'capability_tampered'   => array( 'hook' => 'wp_sudo_capability_tampered', 'args' => 2 ),
+			'escalation_blocked'    => array( 'hook' => 'wp_sudo_escalation_blocked', 'args' => 3 ),
+			'lockout'               => array( 'hook' => 'wp_sudo_lockout', 'args' => 3 ),
+			'missing_builtin_rules' => array( 'hook' => 'wp_sudo_gated_actions_missing_builtin_rules', 'args' => 1 ),
+			'recovery_mode'         => array( 'hook' => 'wp_sudo_recovery_mode_active', 'args' => 1 ),
+		);
+	}
+}
+
+if ( ! function_exists( 'wp_sudo_critical_alert_bridge_enabled_events' ) ) {
+	/**
+	 * The enabled event keys. Defaults to the always-suspicious set; the
+	 * frequent `recovery_mode` event is opt-in via the filter.
+	 *
+	 * @return string[]
+	 */
+	function wp_sudo_critical_alert_bridge_enabled_events(): array {
+		$default = array( 'capability_tampered', 'escalation_blocked', 'lockout', 'missing_builtin_rules' );
+
+		$events = apply_filters( 'wp_sudo_critical_alert_events', $default );
+
+		if ( ! is_array( $events ) ) {
+			return $default;
+		}
+
+		// Keep only keys we actually know how to build.
+		return array_values( array_intersect( array_map( 'strval', $events ), array_keys( wp_sudo_critical_alert_bridge_event_map() ) ) );
+	}
+}
+
+if ( ! function_exists( 'wp_sudo_critical_alert_bridge_register' ) ) {
+	/**
+	 * Register listeners for the enabled critical audit hooks, plus the
+	 * shutdown flush that dispatches queued alerts.
+	 *
+	 * @return void
+	 */
+	function wp_sudo_critical_alert_bridge_register(): void {
+		$map     = wp_sudo_critical_alert_bridge_event_map();
+		$enabled = wp_sudo_critical_alert_bridge_enabled_events();
+
+		foreach ( $enabled as $key ) {
+			if ( ! isset( $map[ $key ] ) ) {
+				continue;
+			}
+
+			/** @psalm-suppress HookNotFound WP Sudo audit hook names are declared by the event map above. */
+			add_action(
+				$map[ $key ]['hook'],
+				static function ( ...$args ) use ( $key ): void {
+					$event = wp_sudo_critical_alert_bridge_build_event( $key, $args );
+					if ( null !== $event ) {
+						wp_sudo_critical_alert_bridge_queue( 'add', $event );
+					}
+				},
+				10,
+				(int) $map[ $key ]['args']
+			);
+		}
+
+		// Dispatch on shutdown so a slow send never delays the triggering
+		// request (shutdown fires even after the gate's wp_die()).
+		add_action( 'shutdown', 'wp_sudo_critical_alert_bridge_flush', 100, 0 );
+	}
+}
+
+if ( ! function_exists( 'wp_sudo_critical_alert_bridge_queue' ) ) {
+	/**
+	 * Pending-alert accumulator. `add` appends, `reset` clears (test hygiene),
+	 * `get` returns the current queue.
+	 *
+	 * @param string     $op    One of 'get', 'add', 'reset'.
+	 * @param array|null $event Event to append when $op is 'add'.
+	 * @return array<int, array<string, mixed>>
+	 */
+	function wp_sudo_critical_alert_bridge_queue( string $op = 'get', ?array $event = null ): array {
+		static $queue = array();
+
+		if ( 'reset' === $op ) {
+			$queue = array();
+		} elseif ( 'add' === $op && null !== $event ) {
+			$queue[] = $event;
+		}
+
+		return $queue;
+	}
+}
+
+if ( ! function_exists( 'wp_sudo_critical_alert_bridge_build_event' ) ) {
+	/**
+	 * Normalize a raw hook payload into a dispatchable event, or null if the
+	 * event key is unknown.
+	 *
+	 * @param string             $key  Event key.
+	 * @param array<int, mixed>  $args Raw hook arguments.
+	 * @return array<string, mixed>|null
+	 */
+	function wp_sudo_critical_alert_bridge_build_event( string $key, array $args ): ?array {
+		switch ( $key ) {
+			case 'capability_tampered':
+				$role = isset( $args[0] ) && is_string( $args[0] ) ? $args[0] : '';
+				$cap  = isset( $args[1] ) && is_string( $args[1] ) ? $args[1] : '';
+				return array(
+					'key'      => $key,
+					'subject'  => 'Capability tamper detected',
+					'body'     => sprintf( 'Role "%s" regained capability "%s"; WP Sudo re-stripped it.', $role, $cap ),
+					'identity' => $role . ':' . $cap,
+					'scope'    => 'site',
+				);
+
+			case 'escalation_blocked':
+				// arg[0] is the TARGET being granted/deleted, NOT the actor. The
+				// hook carries no actor id, so enrich with the current user for
+				// context (may be 0/unknown on some surfaces) and never imply the
+				// target is the perpetrator.
+				$target  = (int) ( $args[0] ?? 0 );
+				$rule    = isset( $args[1] ) && is_string( $args[1] ) ? $args[1] : '';
+				$surface = isset( $args[2] ) && is_string( $args[2] ) ? $args[2] : '';
+				$actor   = (int) get_current_user_id();
+				return array(
+					'key'      => $key,
+					'subject'  => 'Admin escalation blocked',
+					'body'     => sprintf(
+						'Blocked %s targeting user #%d via %s. Actor: %s.',
+						$rule,
+						$target,
+						$surface,
+						$actor > 0 ? '#' . $actor : 'unknown'
+					),
+					'identity' => $rule . ':' . $target,
+					// Super-admin grants are a network-scope concern.
+					'scope'    => 'user.super_admin' === $rule ? 'network' : 'site',
+				);
+
+			case 'lockout':
+				$user     = (int) ( $args[0] ?? 0 );
+				$attempts = (int) ( $args[1] ?? 0 );
+				$ip       = isset( $args[2] ) && is_string( $args[2] ) ? $args[2] : '';
+				return array(
+					'key'      => $key,
+					'subject'  => 'Reauthentication lockout',
+					'body'     => sprintf( 'User #%d locked out after %d failed attempts from %s.', $user, $attempts, $ip ),
+					'identity' => $user . ':' . $ip,
+					'scope'    => 'site',
+				);
+
+			case 'missing_builtin_rules':
+				$missing = isset( $args[0] ) && is_array( $args[0] ) ? array_map( 'strval', $args[0] ) : array();
+				return array(
+					'key'      => $key,
+					'subject'  => 'Built-in gated rules missing',
+					'body'     => 'A filter removed built-in gated rules: ' . implode( ', ', $missing ),
+					'identity' => implode( ',', $missing ),
+					'scope'    => 'site',
+				);
+
+			case 'recovery_mode':
+				$user = (int) ( $args[0] ?? 0 );
+				return array(
+					'key'      => $key,
+					'subject'  => 'Recovery mode active',
+					'body'     => sprintf( 'WP Sudo break-glass recovery mode is active (user #%d).', $user ),
+					'identity' => (string) $user,
+					'scope'    => 'site',
+				);
+		}
+
+		return null;
+	}
+}
+
+if ( ! function_exists( 'wp_sudo_critical_alert_bridge_flush' ) ) {
+	/**
+	 * Dispatch queued alerts, applying per-event dedupe and the hourly cap.
+	 *
+	 * @return void
+	 */
+	function wp_sudo_critical_alert_bridge_flush(): void {
+		$queue = wp_sudo_critical_alert_bridge_queue( 'get' );
+		if ( array() === $queue ) {
+			return;
+		}
+
+		// Clear immediately so a second shutdown pass cannot re-send.
+		wp_sudo_critical_alert_bridge_queue( 'reset' );
+
+		$window     = (int) apply_filters( 'wp_sudo_critical_alert_throttle', HOUR_IN_SECONDS );
+		$cap        = (int) apply_filters( 'wp_sudo_critical_alert_hourly_cap', 10 );
+		$suppressed = 0;
+
+		foreach ( $queue as $event ) {
+			// Per-event dedupe (skip repeats of the same event+identity).
+			if ( $window > 0 && ! wp_sudo_critical_alert_bridge_reserve( $event, $window ) ) {
+				continue;
+			}
+
+			// Bridge-wide hourly cap: collapse overflow into one summary.
+			if ( $cap > 0 && wp_sudo_critical_alert_bridge_count() >= $cap ) {
+				++$suppressed;
+				continue;
+			}
+
+			wp_sudo_critical_alert_bridge_dispatch( $event );
+			wp_sudo_critical_alert_bridge_count( true );
+		}
+
+		if ( $suppressed > 0 ) {
+			wp_sudo_critical_alert_bridge_dispatch(
+				array(
+					'key'      => 'digest',
+					'subject'  => 'Additional critical events suppressed',
+					'body'     => sprintf(
+						'%d further critical event(s) were suppressed this hour by the alert cap. Review the Sudo dashboard widget and activity log.',
+						$suppressed
+					),
+					'identity' => 'digest',
+					'scope'    => 'network',
+				)
+			);
+		}
+	}
+}
+
+if ( ! function_exists( 'wp_sudo_critical_alert_bridge_reserve' ) ) {
+	/**
+	 * Reserve a dedupe slot for an event; returns false if one is already held
+	 * within the window (i.e. this event should be skipped). Network-scope
+	 * events dedupe network-wide; others per-site.
+	 *
+	 * @param array<string, mixed> $event  Event.
+	 * @param int                  $window Dedupe window in seconds.
+	 * @return bool True if the caller may send; false if deduped.
+	 */
+	function wp_sudo_critical_alert_bridge_reserve( array $event, int $window ): bool {
+		$key     = isset( $event['key'] ) ? (string) $event['key'] : '';
+		$ident   = isset( $event['identity'] ) ? (string) $event['identity'] : '';
+		$name    = '_wp_sudo_critalert_' . $key . '_' . md5( $ident );
+		$network = ( isset( $event['scope'] ) && 'network' === $event['scope'] ) && is_multisite();
+
+		if ( $network ) {
+			if ( get_site_transient( $name ) ) {
+				return false;
+			}
+			set_site_transient( $name, 1, $window );
+			return true;
+		}
+
+		if ( get_transient( $name ) ) {
+			return false;
+		}
+		set_transient( $name, 1, $window );
+		return true;
+	}
+}
+
+if ( ! function_exists( 'wp_sudo_critical_alert_bridge_count' ) ) {
+	/**
+	 * Read (or, when $increment is true, bump) the bridge-wide hourly alert
+	 * counter used by the cap.
+	 *
+	 * @param bool $increment Whether to increment the counter.
+	 * @return int Current count (after increment when applicable).
+	 */
+	function wp_sudo_critical_alert_bridge_count( bool $increment = false ): int {
+		$name  = '_wp_sudo_critalert_count';
+		$count = (int) get_transient( $name );
+
+		if ( $increment ) {
+			++$count;
+			set_transient( $name, $count, HOUR_IN_SECONDS );
+		}
+
+		return $count;
+	}
+}
+
+if ( ! function_exists( 'wp_sudo_critical_alert_bridge_dispatch' ) ) {
+	/**
+	 * Deliver one alert. A `wp_sudo_critical_alert_dispatch` filter that returns
+	 * non-null fully replaces the default email (Slack/webhook/inline capture);
+	 * the `wp_sudo_critical_alert_dispatched` action always fires for additive
+	 * observers.
+	 *
+	 * @param array<string, mixed> $event Event.
+	 * @return void
+	 */
+	function wp_sudo_critical_alert_bridge_dispatch( array $event ): void {
+		$handled = apply_filters( 'wp_sudo_critical_alert_dispatch', null, $event );
+
+		if ( null === $handled ) {
+			wp_sudo_critical_alert_bridge_email( $event );
+		}
+
+		do_action( 'wp_sudo_critical_alert_dispatched', $event );
+	}
+}
+
+if ( ! function_exists( 'wp_sudo_critical_alert_bridge_email' ) ) {
+	/**
+	 * Send the default email for an event to the scope-appropriate recipient.
+	 *
+	 * @param array<string, mixed> $event Event.
+	 * @return bool wp_mail() result, or false when there is no recipient.
+	 */
+	function wp_sudo_critical_alert_bridge_email( array $event ): bool {
+		$to = wp_sudo_critical_alert_bridge_recipient( $event );
+		if ( '' === $to ) {
+			return false;
+		}
+
+		$scope = isset( $event['scope'] ) ? (string) $event['scope'] : 'site';
+		$home  = ( 'network' === $scope && is_multisite() ) ? network_home_url() : home_url();
+
+		$subject = '[WP Sudo] ' . ( isset( $event['subject'] ) ? (string) $event['subject'] : 'Critical event' );
+		$body    = ( isset( $event['body'] ) ? (string) $event['body'] : '' )
+			. "\n\nSite: " . $home
+			. "\nTime (UTC): " . gmdate( 'c' );
+
+		return (bool) wp_mail( $to, $subject, $body );
+	}
+}
+
+if ( ! function_exists( 'wp_sudo_critical_alert_bridge_recipient' ) ) {
+	/**
+	 * Resolve the recipient email for an event. Network-scope events default to
+	 * the network admin email; site events to the site admin email. Filterable.
+	 *
+	 * @param array<string, mixed> $event Event.
+	 * @return string Recipient email (may be empty).
+	 */
+	function wp_sudo_critical_alert_bridge_recipient( array $event ): string {
+		$scope = isset( $event['scope'] ) ? (string) $event['scope'] : 'site';
+
+		if ( 'network' === $scope && is_multisite() ) {
+			$default = (string) get_site_option( 'admin_email' );
+		} else {
+			$default = (string) get_option( 'admin_email' );
+		}
+
+		$to = apply_filters( 'wp_sudo_critical_alert_recipient', $default, $event );
+
+		return is_string( $to ) ? $to : '';
+	}
+}
+
+wp_sudo_critical_alert_bridge_register();

--- a/bridges/wp-sudo-critical-alert-bridge.php
+++ b/bridges/wp-sudo-critical-alert-bridge.php
@@ -15,7 +15,7 @@
  *   (e.g. wp_sudo_escalation_blocked, right before the gate dies) is already
  *   answered before the mail is attempted.
  * - Throttled against floods. Every mapped event is deduped per identity for a
- *   window, and a bridge-wide hourly cap collapses an incident into a single
+ *   window, and a per-recipient hourly cap collapses an incident into a single
  *   "N more suppressed" summary. This matters because several of these hooks are
  *   attacker-driven at volume (lockout enumeration, per-request tamper), so an
  *   unthrottled bridge would be a mail/outbound-DoS amplifier.
@@ -27,7 +27,7 @@
  * - `wp_sudo_critical_alert_events`     — array of enabled event keys.
  * - `wp_sudo_critical_alert_recipient`  — ( string $email, array $event ).
  * - `wp_sudo_critical_alert_throttle`   — int seconds, per-event dedupe window.
- * - `wp_sudo_critical_alert_hourly_cap` — int max alerts/hour bridge-wide.
+ * - `wp_sudo_critical_alert_hourly_cap` — int max alerts/hour per recipient.
  * - `wp_sudo_critical_alert_dispatch`   — ( null|mixed $handled, array $event ):
  *       return non-null to REPLACE the default email (Slack/webhook/inline
  *       capture). Runs before the default email; a non-null return suppresses it.
@@ -183,8 +183,10 @@ if ( ! function_exists( 'wp_sudo_critical_alert_bridge_build_event' ) ) {
 						$actor > 0 ? '#' . $actor : 'unknown'
 					),
 					'identity' => $rule . ':' . $target,
-					// Super-admin grants are a network-scope concern.
-					'scope'    => 'user.super_admin' === $rule ? 'network' : 'site',
+					// A super-admin grant/deletion is a network-scope concern. On
+					// multisite a super-admin *target* routes to the network admin
+					// even under a generic user.delete/user.promote rule id.
+					'scope'    => ( 'user.super_admin' === $rule || ( is_multisite() && $target > 0 && is_super_admin( $target ) ) ) ? 'network' : 'site',
 				);
 
 			case 'lockout':
@@ -201,12 +203,18 @@ if ( ! function_exists( 'wp_sudo_critical_alert_bridge_build_event' ) ) {
 
 			case 'missing_builtin_rules':
 				$missing = isset( $args[0] ) && is_array( $args[0] ) ? array_map( 'strval', $args[0] ) : array();
+				// A removed network-scope rule (registry ids are network.*) concerns
+				// the network admin; site rules the site admin.
+				$missing_network = is_multisite() && (bool) array_filter(
+					$missing,
+					static fn( string $rule_id ): bool => str_starts_with( $rule_id, 'network' )
+				);
 				return array(
 					'key'      => $key,
 					'subject'  => 'Built-in gated rules missing',
 					'body'     => 'A filter removed built-in gated rules: ' . implode( ', ', $missing ),
 					'identity' => implode( ',', $missing ),
-					'scope'    => 'site',
+					'scope'    => $missing_network ? 'network' : 'site',
 				);
 
 			case 'recovery_mode':
@@ -249,29 +257,38 @@ if ( ! function_exists( 'wp_sudo_critical_alert_bridge_flush' ) ) {
 				continue;
 			}
 
-			// Bridge-wide hourly cap: collapse overflow into one summary.
-			if ( $cap > 0 && wp_sudo_critical_alert_bridge_count() >= $cap ) {
+			// Per-recipient hourly cap: network-scope events share a network-wide
+			// counter, site-scope events a per-site one, so no single mailbox is
+			// flooded and one busy site cannot starve another site's alerts.
+			$network = ( isset( $event['scope'] ) && 'network' === $event['scope'] ) && is_multisite();
+			if ( $cap > 0 && wp_sudo_critical_alert_bridge_count( false, $network ) >= $cap ) {
 				++$suppressed;
 				continue;
 			}
 
 			wp_sudo_critical_alert_bridge_dispatch( $event );
-			wp_sudo_critical_alert_bridge_count( true );
+			wp_sudo_critical_alert_bridge_count( true, $network );
 		}
 
 		if ( $suppressed > 0 ) {
-			wp_sudo_critical_alert_bridge_dispatch(
-				array(
-					'key'      => 'digest',
-					'subject'  => 'Additional critical events suppressed',
-					'body'     => sprintf(
-						'%d further critical event(s) were suppressed this hour by the alert cap. Review the Sudo dashboard widget and activity log.',
-						$suppressed
-					),
-					'identity' => 'digest',
-					'scope'    => 'network',
-				)
+			$digest = array(
+				'key'      => 'digest',
+				'subject'  => 'Additional critical events suppressed',
+				'body'     => sprintf(
+					'%d further critical event(s) were suppressed this hour by the alert cap. Review the Sudo dashboard widget and activity log.',
+					$suppressed
+				),
+				'identity' => 'digest',
+				'scope'    => 'network',
 			);
+
+			// Throttle the digest itself so a per-request flood cannot emit one
+			// digest per request. Never pass a non-positive window to reserve() (a
+			// 0 TTL is a *permanent* transient); with dedupe disabled (window <= 0,
+			// demo only) the digest intentionally flows every time.
+			if ( $window <= 0 || wp_sudo_critical_alert_bridge_reserve( $digest, $window ) ) {
+				wp_sudo_critical_alert_bridge_dispatch( $digest );
+			}
 		}
 	}
 }
@@ -289,7 +306,7 @@ if ( ! function_exists( 'wp_sudo_critical_alert_bridge_reserve' ) ) {
 	function wp_sudo_critical_alert_bridge_reserve( array $event, int $window ): bool {
 		$key     = isset( $event['key'] ) ? (string) $event['key'] : '';
 		$ident   = isset( $event['identity'] ) ? (string) $event['identity'] : '';
-		$name    = '_wp_sudo_critalert_' . $key . '_' . md5( $ident );
+		$name    = '_wp_sudo_critical_alert_' . $key . '_' . md5( $ident );
 		$network = ( isset( $event['scope'] ) && 'network' === $event['scope'] ) && is_multisite();
 
 		if ( $network ) {
@@ -310,22 +327,40 @@ if ( ! function_exists( 'wp_sudo_critical_alert_bridge_reserve' ) ) {
 
 if ( ! function_exists( 'wp_sudo_critical_alert_bridge_count' ) ) {
 	/**
-	 * Read (or, when $increment is true, bump) the bridge-wide hourly alert
-	 * counter used by the cap.
+	 * Read (or, when $increment is true, bump) the hourly alert counter used by
+	 * the cap. The window opens on the first alert and rolls over an hour later,
+	 * rather than being extended on every increment (which would let a slow
+	 * trickle suppress alerts long after any real hourly burst). Network-scope
+	 * events use a network-wide counter, site-scope events a per-site one, so the
+	 * cap protects each recipient mailbox independently.
 	 *
 	 * @param bool $increment Whether to increment the counter.
-	 * @return int Current count (after increment when applicable).
+	 * @param bool $network   Whether to use the network-wide counter (multisite).
+	 * @return int Current count within the active window (after increment).
 	 */
-	function wp_sudo_critical_alert_bridge_count( bool $increment = false ): int {
-		$name  = '_wp_sudo_critalert_count';
-		$count = (int) get_transient( $name );
+	function wp_sudo_critical_alert_bridge_count( bool $increment = false, bool $network = false ): int {
+		$name = '_wp_sudo_critical_alert_count';
+		$data = $network ? get_site_transient( $name ) : get_transient( $name );
 
-		if ( $increment ) {
-			++$count;
-			set_transient( $name, $count, HOUR_IN_SECONDS );
+		if ( ! is_array( $data ) || ! isset( $data['count'], $data['start'] ) ) {
+			$data = array( 'count' => 0, 'start' => 0 );
 		}
 
-		return $count;
+		// Roll the window over once a full hour has elapsed since it opened.
+		if ( time() - (int) $data['start'] >= HOUR_IN_SECONDS ) {
+			$data = array( 'count' => 0, 'start' => time() );
+		}
+
+		if ( $increment ) {
+			$data['count'] = (int) $data['count'] + 1;
+			if ( $network ) {
+				set_site_transient( $name, $data, HOUR_IN_SECONDS );
+			} else {
+				set_transient( $name, $data, HOUR_IN_SECONDS );
+			}
+		}
+
+		return (int) $data['count'];
 	}
 }
 
@@ -398,4 +433,4 @@ if ( ! function_exists( 'wp_sudo_critical_alert_bridge_recipient' ) ) {
 	}
 }
 
-wp_sudo_critical_alert_bridge_register();
+add_action( 'plugins_loaded', 'wp_sudo_critical_alert_bridge_register', 10, 0 );

--- a/docs/current-metrics.md
+++ b/docs/current-metrics.md
@@ -9,21 +9,21 @@ Verification environment: local workspace, PHP 8.x
 
 | Metric | Value | Verification |
 |---|---:|---|
-| Unit tests | 997 tests | `composer test:unit` |
-| Unit assertions | 3,032 assertions | `composer test:unit` |
+| Unit tests | 1006 tests | `composer test:unit` |
+| Unit assertions | 3,059 assertions | `composer test:unit` |
 | Integration tests in suite | 208 test methods | `rg -c "function test" tests/Integration/*.php | awk -F: '{sum+=$2} END{print sum}'` |
-| Unit test files | 30 | `ls tests/Unit/*.php | wc -l` |
+| Unit test files | 31 | `ls tests/Unit/*.php | wc -l` |
 | Integration test files | 28 | `ls tests/Integration/*.php | wc -l` |
 
 ## Size Metrics
 
 | Metric | Value | Verification |
 |---|---:|---|
-| Production PHP lines (`includes/`, `wp-sudo.php`, `uninstall.php`, `mu-plugin/`, `bridges/`) | 17,183 | `find ./includes ./wp-sudo.php ./uninstall.php ./mu-plugin ./bridges -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
-| Tests PHP lines (`tests/`) | 36,231 | `find ./tests -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
-| Production + tests PHP lines | 53,414 | sum of the two rows above |
-| Test-to-production ratio | 2.11:1 | `36231 / 17183` |
-| Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`) | 54,349 | `find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/vendor_test/*" ! -path "*/.tmp/*" ! -path "*/.git/*" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Production PHP lines (`includes/`, `wp-sudo.php`, `uninstall.php`, `mu-plugin/`, `bridges/`) | 17,584 | `find ./includes ./wp-sudo.php ./uninstall.php ./mu-plugin ./bridges -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Tests PHP lines (`tests/`) | 36,496 | `find ./tests -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Production + tests PHP lines | 54,080 | sum of the two rows above |
+| Test-to-production ratio | 2.08:1 | `36496 / 17584` |
+| Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`) | 55,015 | `find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/vendor_test/*" ! -path "*/.tmp/*" ! -path "*/.git/*" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
 
 ## Footprint & Performance
 

--- a/docs/current-metrics.md
+++ b/docs/current-metrics.md
@@ -9,8 +9,8 @@ Verification environment: local workspace, PHP 8.x
 
 | Metric | Value | Verification |
 |---|---:|---|
-| Unit tests | 1012 tests | `composer test:unit` |
-| Unit assertions | 3,074 assertions | `composer test:unit` |
+| Unit tests | 1020 tests | `composer test:unit` |
+| Unit assertions | 3,085 assertions | `composer test:unit` |
 | Integration tests in suite | 208 test methods | `rg -c "function test" tests/Integration/*.php | awk -F: '{sum+=$2} END{print sum}'` |
 | Unit test files | 32 | `ls tests/Unit/*.php | wc -l` |
 | Integration test files | 28 | `ls tests/Integration/*.php | wc -l` |
@@ -19,11 +19,11 @@ Verification environment: local workspace, PHP 8.x
 
 | Metric | Value | Verification |
 |---|---:|---|
-| Production PHP lines (`includes/`, `wp-sudo.php`, `uninstall.php`, `mu-plugin/`, `bridges/`) | 17,584 | `find ./includes ./wp-sudo.php ./uninstall.php ./mu-plugin ./bridges -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
-| Tests PHP lines (`tests/`) | 36,660 | `find ./tests -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
-| Production + tests PHP lines | 54,244 | sum of the two rows above |
-| Test-to-production ratio | 2.08:1 | `36660 / 17584` |
-| Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`) | 55,311 | `find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/vendor_test/*" ! -path "*/.tmp/*" ! -path "*/.git/*" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Production PHP lines (`includes/`, `wp-sudo.php`, `uninstall.php`, `mu-plugin/`, `bridges/`) | 17,619 | `find ./includes ./wp-sudo.php ./uninstall.php ./mu-plugin ./bridges -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Tests PHP lines (`tests/`) | 36,772 | `find ./tests -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Production + tests PHP lines | 54,391 | sum of the two rows above |
+| Test-to-production ratio | 2.09:1 | `36772 / 17619` |
+| Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`) | 55,458 | `find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/vendor_test/*" ! -path "*/.tmp/*" ! -path "*/.git/*" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
 
 ## Footprint & Performance
 

--- a/docs/current-metrics.md
+++ b/docs/current-metrics.md
@@ -2,17 +2,17 @@
 
 This file is the single source of truth for current repository counts.
 
-Last verified: 2026-07-05
+Last verified: 2026-07-06
 Verification environment: local workspace, PHP 8.x
 
 ## Test Metrics
 
 | Metric | Value | Verification |
 |---|---:|---|
-| Unit tests | 1006 tests | `composer test:unit` |
-| Unit assertions | 3,059 assertions | `composer test:unit` |
+| Unit tests | 1012 tests | `composer test:unit` |
+| Unit assertions | 3,074 assertions | `composer test:unit` |
 | Integration tests in suite | 208 test methods | `rg -c "function test" tests/Integration/*.php | awk -F: '{sum+=$2} END{print sum}'` |
-| Unit test files | 31 | `ls tests/Unit/*.php | wc -l` |
+| Unit test files | 32 | `ls tests/Unit/*.php | wc -l` |
 | Integration test files | 28 | `ls tests/Integration/*.php | wc -l` |
 
 ## Size Metrics
@@ -20,10 +20,10 @@ Verification environment: local workspace, PHP 8.x
 | Metric | Value | Verification |
 |---|---:|---|
 | Production PHP lines (`includes/`, `wp-sudo.php`, `uninstall.php`, `mu-plugin/`, `bridges/`) | 17,584 | `find ./includes ./wp-sudo.php ./uninstall.php ./mu-plugin ./bridges -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
-| Tests PHP lines (`tests/`) | 36,496 | `find ./tests -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
-| Production + tests PHP lines | 54,080 | sum of the two rows above |
-| Test-to-production ratio | 2.08:1 | `36496 / 17584` |
-| Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`) | 55,015 | `find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/vendor_test/*" ! -path "*/.tmp/*" ! -path "*/.git/*" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Tests PHP lines (`tests/`) | 36,660 | `find ./tests -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Production + tests PHP lines | 54,244 | sum of the two rows above |
+| Test-to-production ratio | 2.08:1 | `36660 / 17584` |
+| Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`) | 55,311 | `find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/vendor_test/*" ! -path "*/.tmp/*" ! -path "*/.git/*" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
 
 ## Footprint & Performance
 

--- a/docs/developer-reference.md
+++ b/docs/developer-reference.md
@@ -623,6 +623,46 @@ The bridge supports late Stream availability (mu-plugin loads before
 regular plugins) by deferring registration to `plugins_loaded` when
 needed. It remains inert when Stream APIs are unavailable.
 
+### Optional Critical-Event Alert Bridge
+
+WP Sudo ships an optional alert bridge at
+`bridges/wp-sudo-critical-alert-bridge.php`. Install it as an mu-plugin to be
+**notified** (not just logged) when a high-severity audit hook fires. It packages
+the hook-to-notification wiring so you don't have to write it by hand; unlike the
+Stream/WSAL bridges, which log every event, it pushes a message for the events
+that usually warrant a human look.
+
+Mapped events (default set): `wp_sudo_capability_tampered`,
+`wp_sudo_escalation_blocked`, `wp_sudo_lockout`, and
+`wp_sudo_gated_actions_missing_builtin_rules`. `wp_sudo_recovery_mode_active` is
+supported but **opt-in** (it fires on every Sudo admin-page load during a
+legitimate break-glass episode and would drown the urgent alerts).
+
+Safety properties:
+
+- **Deferred, never blocking.** Alerts are queued and dispatched on `shutdown`
+  (which fires even after the gate's `wp_die()`), so a slow send never delays the
+  security-blocking response — important because `wp_sudo_escalation_blocked`
+  fires immediately before the gate dies.
+- **Throttled against floods.** Each event is deduped per identity for a window,
+  and a bridge-wide hourly cap collapses an incident into one "N more suppressed"
+  summary — several of these hooks are attacker-driven at volume (lockout
+  enumeration, per-request tamper), so an unthrottled bridge would amplify a
+  mail/outbound flood.
+- **Correct attribution.** `wp_sudo_escalation_blocked`'s first argument is the
+  **target** being granted/deleted, not the actor; the alert states the target
+  precisely and enriches with the current user as "Actor" separately.
+- **Multisite-aware recipient.** Super-admin-scope events default to the network
+  admin email; site events to the site admin email.
+
+Filters/actions: `wp_sudo_critical_alert_events` (enabled keys),
+`wp_sudo_critical_alert_recipient` (`string $email, array $event`),
+`wp_sudo_critical_alert_throttle` (int seconds), `wp_sudo_critical_alert_hourly_cap`
+(int), `wp_sudo_critical_alert_dispatch` (return non-null to **replace** the
+default email — send Slack/Teams/webhook via `wp_remote_post`, or capture the
+composed alert for inline display where outbound network is unavailable, e.g.
+WordPress Playground), and the additive `wp_sudo_critical_alert_dispatched` action.
+
 ### Future: External Audit Mode (v3.2 candidate)
 
 For operators who treat Stream or WSAL as their canonical audit destination,

--- a/docs/developer-reference.md
+++ b/docs/developer-reference.md
@@ -645,15 +645,22 @@ Safety properties:
   security-blocking response — important because `wp_sudo_escalation_blocked`
   fires immediately before the gate dies.
 - **Throttled against floods.** Each event is deduped per identity for a window,
-  and a bridge-wide hourly cap collapses an incident into one "N more suppressed"
-  summary — several of these hooks are attacker-driven at volume (lockout
-  enumeration, per-request tamper), so an unthrottled bridge would amplify a
-  mail/outbound flood.
+  and a per-recipient hourly cap (network-scope events against a network-wide
+  counter, site events against a per-site one) collapses an incident into one "N
+  more suppressed" summary — itself throttled to one digest per window. Several
+  of these hooks are attacker-driven at volume (lockout enumeration, per-request
+  tamper), so an unthrottled bridge would amplify a mail/outbound flood.
+- **Filterable at the right time.** Registration is deferred to `plugins_loaded`,
+  so a regular plugin or theme can filter `wp_sudo_critical_alert_events` (e.g.
+  opt into `recovery_mode`, or drop a noisy default) from where WordPress code
+  normally adds filters, not only from an earlier-loading mu-plugin.
 - **Correct attribution.** `wp_sudo_escalation_blocked`'s first argument is the
   **target** being granted/deleted, not the actor; the alert states the target
   precisely and enriches with the current user as "Actor" separately.
 - **Multisite-aware recipient.** Super-admin-scope events default to the network
-  admin email; site events to the site admin email.
+  admin email; site events to the site admin email. On multisite this also covers
+  a super-admin *target* under a generic `user.delete`/`user.promote` rule and a
+  dropped `network.*` built-in rule, both of which route to the network admin.
 
 Filters/actions: `wp_sudo_critical_alert_events` (enabled keys),
 `wp_sudo_critical_alert_recipient` (`string $email, array $event`),

--- a/docs/developer-reference.md
+++ b/docs/developer-reference.md
@@ -663,6 +663,19 @@ default email — send Slack/Teams/webhook via `wp_remote_post`, or capture the
 composed alert for inline display where outbound network is unavailable, e.g.
 WordPress Playground), and the additive `wp_sudo_critical_alert_dispatched` action.
 
+**Inline demo companion.** `bin/demo/wp-sudo-alert-inline-demo.php` is a
+demo-only realization of that Playground use case (it is not shipped for
+production — the `bin/` tree is demo/tooling, not part of the plugin runtime).
+Dropped into `mu-plugins/` alongside the bridge, it listens on the additive
+`wp_sudo_critical_alert_dispatched` action (never the replace-filter, so it
+cannot suppress real alert email), buffers each composed alert in a short-lived
+transient, and renders it as an admin notice on the next wp-admin load. Because
+it is a demo it also relaxes the bridge's dedupe/hourly-cap (both → 0) so a live
+walkthrough can re-trigger the same event and keep seeing it. The Playground
+`blueprint-main.json` copies both the bridge and this companion into
+`mu-plugins/` so "trigger a tamper/escalation/lockout → watch the alert fire" is
+visible without any outbound network.
+
 ### Future: External Audit Mode (v3.2 candidate)
 
 For operators who treat Stream or WSAL as their canonical audit destination,

--- a/tests/Unit/AlertInlineDemoTest.php
+++ b/tests/Unit/AlertInlineDemoTest.php
@@ -1,0 +1,164 @@
+<?php
+/**
+ * Tests for the inline-capture alert demo companion.
+ *
+ * The demo lives at bin/demo/wp-sudo-alert-inline-demo.php. It consumes the
+ * critical-alert bridge's additive `wp_sudo_critical_alert_dispatched` action,
+ * buffers each composed alert, and renders it as an admin notice — the concrete
+ * realization of the bridge's documented "capture for inline display where
+ * outbound network is unavailable" use case (e.g. WordPress Playground).
+ *
+ * @package WP_Sudo
+ */
+
+namespace WP_Sudo\Tests\Unit;
+
+use Brain\Monkey\Functions;
+use WP_Sudo\Tests\TestCase;
+
+/**
+ * @coversNothing Procedural demo file.
+ */
+class AlertInlineDemoTest extends TestCase {
+
+	/**
+	 * In-memory transient store backing the demo buffer.
+	 *
+	 * @var array<string, mixed>
+	 */
+	private array $transients = array();
+
+	/**
+	 * Install baseline stubs the demo depends on, then load it.
+	 *
+	 * @param array<string, mixed> $overrides 'can' => bool for current_user_can.
+	 * @return void
+	 */
+	private function boot( array $overrides = array() ): void {
+		$this->transients = array();
+
+		Functions\when( 'add_action' )->justReturn( true );
+		Functions\when( 'add_filter' )->justReturn( true );
+		Functions\when( 'current_user_can' )->justReturn( (bool) ( $overrides['can'] ?? true ) );
+		Functions\when( 'esc_html' )->alias(
+			static fn( $text ) => htmlspecialchars( (string) $text, ENT_QUOTES )
+		);
+
+		$store = &$this->transients;
+		Functions\when( 'get_transient' )->alias(
+			static function ( string $k ) use ( &$store ) {
+				return $store[ $k ] ?? false;
+			}
+		);
+		Functions\when( 'set_transient' )->alias(
+			static function ( string $k, $v ) use ( &$store ): bool {
+				$store[ $k ] = $v;
+				return true;
+			}
+		);
+		Functions\when( 'delete_transient' )->alias(
+			static function ( string $k ) use ( &$store ): bool {
+				unset( $store[ $k ] );
+				return true;
+			}
+		);
+
+		include __DIR__ . '/../../bin/demo/wp-sudo-alert-inline-demo.php';
+	}
+
+	public function test_registers_capture_and_render_hooks(): void {
+		$this->transients = array();
+		$hooks            = array();
+		Functions\when( 'add_action' )->alias(
+			static function ( string $hook ) use ( &$hooks ): bool {
+				$hooks[] = $hook;
+				return true;
+			}
+		);
+		Functions\when( 'add_filter' )->justReturn( true );
+		Functions\when( 'current_user_can' )->justReturn( true );
+		Functions\when( 'get_transient' )->justReturn( false );
+
+		include __DIR__ . '/../../bin/demo/wp-sudo-alert-inline-demo.php';
+
+		$this->assertContains( 'wp_sudo_critical_alert_dispatched', $hooks );
+		$this->assertContains( 'admin_notices', $hooks );
+	}
+
+	public function test_capture_appends_event_to_buffer(): void {
+		$this->boot();
+
+		wp_sudo_alert_inline_demo_capture(
+			array( 'subject' => 'Reauthentication lockout', 'body' => 'User #5 locked out', 'scope' => 'site' )
+		);
+
+		$buffer = $this->transients[ WP_SUDO_ALERT_INLINE_DEMO_KEY ] ?? array();
+		$this->assertCount( 1, $buffer );
+		$this->assertSame( 'Reauthentication lockout', $buffer[0]['subject'] );
+		$this->assertSame( 'User #5 locked out', $buffer[0]['body'] );
+	}
+
+	public function test_capture_trims_buffer_to_cap_keeping_newest(): void {
+		$this->boot();
+
+		$total = WP_SUDO_ALERT_INLINE_DEMO_CAP + 2;
+		for ( $i = 1; $i <= $total; $i++ ) {
+			wp_sudo_alert_inline_demo_capture(
+				array( 'subject' => 'Event ' . $i, 'body' => 'b', 'scope' => 'site' )
+			);
+		}
+
+		$buffer = $this->transients[ WP_SUDO_ALERT_INLINE_DEMO_KEY ] ?? array();
+		$this->assertCount( WP_SUDO_ALERT_INLINE_DEMO_CAP, $buffer );
+		// FIFO: the two oldest were dropped, so the first surviving entry is #3.
+		$this->assertSame( 'Event 3', $buffer[0]['subject'] );
+		$this->assertSame( 'Event ' . $total, $buffer[ WP_SUDO_ALERT_INLINE_DEMO_CAP - 1 ]['subject'] );
+	}
+
+	public function test_render_escapes_output_and_drains_buffer(): void {
+		$this->boot();
+		$this->transients[ WP_SUDO_ALERT_INLINE_DEMO_KEY ] = array(
+			array(
+				'subject' => 'Reauthentication lockout',
+				'body'    => 'IP <script>alert(1)</script> from 203.0.113.9',
+				'scope'   => 'site',
+				'time'    => '2026-07-06T00:00:00+00:00',
+			),
+		);
+
+		ob_start();
+		wp_sudo_alert_inline_demo_render();
+		$html = (string) ob_get_clean();
+
+		$this->assertStringContainsString( 'Reauthentication lockout', $html );
+		$this->assertStringNotContainsString( '<script>alert(1)</script>', $html );
+		$this->assertStringContainsString( '&lt;script&gt;', $html );
+		// Show-once: the buffer is drained after rendering.
+		$this->assertArrayNotHasKey( WP_SUDO_ALERT_INLINE_DEMO_KEY, $this->transients );
+	}
+
+	public function test_render_noop_without_manage_capability(): void {
+		$this->boot( array( 'can' => false ) );
+		$this->transients[ WP_SUDO_ALERT_INLINE_DEMO_KEY ] = array(
+			array( 'subject' => 's', 'body' => 'b', 'scope' => 'site', 'time' => 't' ),
+		);
+
+		ob_start();
+		wp_sudo_alert_inline_demo_render();
+		$html = (string) ob_get_clean();
+
+		$this->assertSame( '', $html );
+		// Buffer is untouched for a user who cannot see it.
+		$this->assertArrayHasKey( WP_SUDO_ALERT_INLINE_DEMO_KEY, $this->transients );
+	}
+
+	public function test_render_noop_when_buffer_empty(): void {
+		$this->boot();
+
+		ob_start();
+		wp_sudo_alert_inline_demo_render();
+		$html = (string) ob_get_clean();
+
+		$this->assertSame( '', $html );
+	}
+}

--- a/tests/Unit/AlertInlineDemoTest.php
+++ b/tests/Unit/AlertInlineDemoTest.php
@@ -51,7 +51,7 @@ class AlertInlineDemoTest extends TestCase {
 			}
 		);
 		Functions\when( 'set_transient' )->alias(
-			static function ( string $k, $v ) use ( &$store ): bool {
+			static function ( string $k, $v, $exp = 0 ) use ( &$store ): bool {
 				$store[ $k ] = $v;
 				return true;
 			}

--- a/tests/Unit/CriticalAlertBridgeTest.php
+++ b/tests/Unit/CriticalAlertBridgeTest.php
@@ -1,0 +1,265 @@
+<?php
+/**
+ * Tests for the critical-event alert bridge.
+ *
+ * @package WP_Sudo
+ */
+
+namespace WP_Sudo\Tests\Unit;
+
+use Brain\Monkey\Functions;
+use WP_Sudo\Tests\TestCase;
+
+/**
+ * @coversNothing Procedural bridge file.
+ */
+class CriticalAlertBridgeTest extends TestCase {
+
+	/**
+	 * In-memory transient stores backing the throttle/count helpers.
+	 *
+	 * @var array<string, mixed>
+	 */
+	private array $transients = array();
+
+	/**
+	 * @var array<string, mixed>
+	 */
+	private array $site_transients = array();
+
+	/**
+	 * Install baseline WordPress stubs the bridge depends on, then load it.
+	 *
+	 * @param array<string, mixed> $overrides Optional per-test behavior:
+	 *   'events'    => string[] returned by the enabled-events filter,
+	 *   'dispatch'  => mixed returned by the dispatch short-circuit filter,
+	 *   'throttle'  => int throttle window, 'cap' => int hourly cap,
+	 *   'recipient' => string forced recipient, 'multisite' => bool,
+	 *   'current_user' => int.
+	 * @return void
+	 */
+	private function boot( array $overrides = array() ): void {
+		$this->transients      = array();
+		$this->site_transients = array();
+
+		Functions\when( 'add_action' )->justReturn( true );
+		Functions\when( 'do_action' )->justReturn( null );
+		Functions\when( 'is_multisite' )->justReturn( (bool) ( $overrides['multisite'] ?? false ) );
+		Functions\when( 'get_current_user_id' )->justReturn( (int) ( $overrides['current_user'] ?? 0 ) );
+		Functions\when( 'home_url' )->justReturn( 'https://example.test' );
+		Functions\when( 'network_home_url' )->justReturn( 'https://network.example.test' );
+		Functions\when( 'get_option' )->justReturn( 'site-admin@example.test' );
+		Functions\when( 'get_site_option' )->justReturn( 'network-admin@example.test' );
+
+		// Filterable knobs. apply_filters is aliased so each documented tag
+		// resolves to its default (or a per-test override).
+		Functions\when( 'apply_filters' )->alias(
+			function ( string $tag, $value = null ) use ( $overrides ) {
+				switch ( $tag ) {
+					case 'wp_sudo_critical_alert_events':
+						return $overrides['events'] ?? $value;
+					case 'wp_sudo_critical_alert_dispatch':
+						return $overrides['dispatch'] ?? null;
+					case 'wp_sudo_critical_alert_throttle':
+						return $overrides['throttle'] ?? $value;
+					case 'wp_sudo_critical_alert_hourly_cap':
+						return $overrides['cap'] ?? $value;
+					case 'wp_sudo_critical_alert_recipient':
+						return $overrides['recipient'] ?? $value;
+				}
+				return $value;
+			}
+		);
+
+		$store = &$this->transients;
+		Functions\when( 'get_transient' )->alias(
+			static function ( string $k ) use ( &$store ) {
+				return $store[ $k ] ?? false;
+			}
+		);
+		Functions\when( 'set_transient' )->alias(
+			static function ( string $k, $v ) use ( &$store ): bool {
+				$store[ $k ] = $v;
+				return true;
+			}
+		);
+		$sstore = &$this->site_transients;
+		Functions\when( 'get_site_transient' )->alias(
+			static function ( string $k ) use ( &$sstore ) {
+				return $sstore[ $k ] ?? false;
+			}
+		);
+		Functions\when( 'set_site_transient' )->alias(
+			static function ( string $k, $v ) use ( &$sstore ): bool {
+				$sstore[ $k ] = $v;
+				return true;
+			}
+		);
+
+		include __DIR__ . '/../../bridges/wp-sudo-critical-alert-bridge.php';
+	}
+
+	public function test_registers_default_events_and_shutdown_but_not_recovery_mode(): void {
+		$this->transients      = array();
+		$this->site_transients = array();
+		Functions\when( 'apply_filters' )->returnArg( 2 ); // events filter → default.
+		$hooks = array();
+		Functions\when( 'add_action' )->alias(
+			static function ( string $hook ) use ( &$hooks ): bool {
+				$hooks[] = $hook;
+				return true;
+			}
+		);
+
+		include __DIR__ . '/../../bridges/wp-sudo-critical-alert-bridge.php';
+
+		$this->assertContains( 'wp_sudo_capability_tampered', $hooks );
+		$this->assertContains( 'wp_sudo_escalation_blocked', $hooks );
+		$this->assertContains( 'wp_sudo_lockout', $hooks );
+		$this->assertContains( 'wp_sudo_gated_actions_missing_builtin_rules', $hooks );
+		$this->assertContains( 'shutdown', $hooks );
+		// recovery_mode is high-frequency and opt-in: not wired by default.
+		$this->assertNotContains( 'wp_sudo_recovery_mode_active', $hooks );
+	}
+
+	public function test_recovery_mode_wired_only_when_enabled(): void {
+		$this->transients      = array();
+		$this->site_transients = array();
+		Functions\when( 'apply_filters' )->alias(
+			static fn( string $tag, $value = null ) => 'wp_sudo_critical_alert_events' === $tag
+				? array( 'recovery_mode' )
+				: $value
+		);
+		$hooks = array();
+		Functions\when( 'add_action' )->alias(
+			static function ( string $hook ) use ( &$hooks ): bool {
+				$hooks[] = $hook;
+				return true;
+			}
+		);
+
+		include __DIR__ . '/../../bridges/wp-sudo-critical-alert-bridge.php';
+
+		$this->assertContains( 'wp_sudo_recovery_mode_active', $hooks );
+	}
+
+	public function test_escalation_event_labels_target_and_actor_not_confused(): void {
+		$this->boot( array( 'current_user' => 7 ) );
+
+		$event = wp_sudo_critical_alert_bridge_build_event( 'escalation_blocked', array( 42, 'user.super_admin', 'admin' ) );
+
+		$this->assertIsArray( $event );
+		$this->assertStringContainsString( 'targeting user #42', $event['body'] );
+		$this->assertStringContainsString( 'Actor: #7', $event['body'] );
+		// super-admin grants are network-scope.
+		$this->assertSame( 'network', $event['scope'] );
+	}
+
+	public function test_lockout_and_tampered_events_build_expected_bodies(): void {
+		$this->boot();
+
+		$lockout = wp_sudo_critical_alert_bridge_build_event( 'lockout', array( 5, 5, '203.0.113.9' ) );
+		$this->assertStringContainsString( 'User #5 locked out after 5 failed attempts from 203.0.113.9', $lockout['body'] );
+		$this->assertSame( '5:203.0.113.9', $lockout['identity'] );
+
+		$tamper = wp_sudo_critical_alert_bridge_build_event( 'capability_tampered', array( 'editor', 'unfiltered_html' ) );
+		$this->assertStringContainsString( 'Role "editor" regained capability "unfiltered_html"', $tamper['body'] );
+	}
+
+	public function test_reserve_dedupes_same_event_within_window(): void {
+		$this->boot();
+		$event = array( 'key' => 'lockout', 'identity' => '5:203.0.113.9', 'scope' => 'site' );
+
+		$this->assertTrue( wp_sudo_critical_alert_bridge_reserve( $event, 3600 ) );
+		$this->assertFalse( wp_sudo_critical_alert_bridge_reserve( $event, 3600 ) );
+	}
+
+	public function test_flush_sends_one_email_per_distinct_event_and_dedupes_repeats(): void {
+		$this->boot();
+		$sent = array();
+		Functions\when( 'wp_mail' )->alias(
+			static function ( string $to, string $subject ) use ( &$sent ): bool {
+				$sent[] = $subject;
+				return true;
+			}
+		);
+
+		$a = array( 'key' => 'lockout', 'subject' => 'Reauthentication lockout', 'body' => 'x', 'identity' => '5:ip', 'scope' => 'site' );
+		$b = array( 'key' => 'capability_tampered', 'subject' => 'Capability tamper detected', 'body' => 'y', 'identity' => 'editor:cap', 'scope' => 'site' );
+		wp_sudo_critical_alert_bridge_queue( 'add', $a );
+		wp_sudo_critical_alert_bridge_queue( 'add', $a ); // duplicate → deduped.
+		wp_sudo_critical_alert_bridge_queue( 'add', $b );
+
+		wp_sudo_critical_alert_bridge_flush();
+
+		$this->assertCount( 2, $sent );
+		$this->assertContains( '[WP Sudo] Reauthentication lockout', $sent );
+		$this->assertContains( '[WP Sudo] Capability tamper detected', $sent );
+
+		// Queue is cleared after flush.
+		$this->assertSame( array(), wp_sudo_critical_alert_bridge_queue( 'get' ) );
+	}
+
+	public function test_flush_hourly_cap_collapses_overflow_into_a_digest(): void {
+		$this->boot( array( 'cap' => 1 ) );
+		$sent = array();
+		Functions\when( 'wp_mail' )->alias(
+			static function ( string $to, string $subject, string $body ) use ( &$sent ): bool {
+				$sent[] = array( 'subject' => $subject, 'body' => $body );
+				return true;
+			}
+		);
+
+		foreach ( array( 'a', 'b', 'c' ) as $i ) {
+			wp_sudo_critical_alert_bridge_queue(
+				'add',
+				array( 'key' => 'lockout', 'subject' => 'Reauthentication lockout', 'body' => $i, 'identity' => $i, 'scope' => 'site' )
+			);
+		}
+
+		wp_sudo_critical_alert_bridge_flush();
+
+		// One real alert (cap = 1) + one digest summarizing the other two.
+		$this->assertCount( 2, $sent );
+		$digest = end( $sent );
+		$this->assertStringContainsString( '[WP Sudo] Additional critical events suppressed', $digest['subject'] );
+		$this->assertStringContainsString( '2 further critical event', $digest['body'] );
+	}
+
+	public function test_dispatch_filter_short_circuit_suppresses_default_email(): void {
+		$this->boot( array( 'dispatch' => 'handled' ) );
+		$mailed = false;
+		Functions\when( 'wp_mail' )->alias(
+			static function () use ( &$mailed ): bool {
+				$mailed = true;
+				return true;
+			}
+		);
+		$observed = array();
+		Functions\when( 'do_action' )->alias(
+			static function ( string $tag, $event = null ) use ( &$observed ): void {
+				if ( 'wp_sudo_critical_alert_dispatched' === $tag ) {
+					$observed[] = $event;
+				}
+			}
+		);
+
+		wp_sudo_critical_alert_bridge_dispatch( array( 'key' => 'lockout', 'subject' => 's', 'body' => 'b', 'scope' => 'site' ) );
+
+		$this->assertFalse( $mailed, 'A non-null dispatch filter must replace the default email.' );
+		$this->assertCount( 1, $observed, 'The additive dispatched action always fires.' );
+	}
+
+	public function test_recipient_uses_network_admin_for_network_scope(): void {
+		$this->boot( array( 'multisite' => true ) );
+
+		$this->assertSame(
+			'network-admin@example.test',
+			wp_sudo_critical_alert_bridge_recipient( array( 'scope' => 'network' ) )
+		);
+		$this->assertSame(
+			'site-admin@example.test',
+			wp_sudo_critical_alert_bridge_recipient( array( 'scope' => 'site' ) )
+		);
+	}
+}

--- a/tests/Unit/CriticalAlertBridgeTest.php
+++ b/tests/Unit/CriticalAlertBridgeTest.php
@@ -45,6 +45,7 @@ class CriticalAlertBridgeTest extends TestCase {
 		Functions\when( 'add_action' )->justReturn( true );
 		Functions\when( 'do_action' )->justReturn( null );
 		Functions\when( 'is_multisite' )->justReturn( (bool) ( $overrides['multisite'] ?? false ) );
+		Functions\when( 'is_super_admin' )->justReturn( (bool) ( $overrides['super_admin'] ?? false ) );
 		Functions\when( 'get_current_user_id' )->justReturn( (int) ( $overrides['current_user'] ?? 0 ) );
 		Functions\when( 'home_url' )->justReturn( 'https://example.test' );
 		Functions\when( 'network_home_url' )->justReturn( 'https://network.example.test' );
@@ -78,7 +79,7 @@ class CriticalAlertBridgeTest extends TestCase {
 			}
 		);
 		Functions\when( 'set_transient' )->alias(
-			static function ( string $k, $v ) use ( &$store ): bool {
+			static function ( string $k, $v, $exp = 0 ) use ( &$store ): bool {
 				$store[ $k ] = $v;
 				return true;
 			}
@@ -90,7 +91,7 @@ class CriticalAlertBridgeTest extends TestCase {
 			}
 		);
 		Functions\when( 'set_site_transient' )->alias(
-			static function ( string $k, $v ) use ( &$sstore ): bool {
+			static function ( string $k, $v, $exp = 0 ) use ( &$sstore ): bool {
 				$sstore[ $k ] = $v;
 				return true;
 			}
@@ -112,6 +113,13 @@ class CriticalAlertBridgeTest extends TestCase {
 		);
 
 		include __DIR__ . '/../../bridges/wp-sudo-critical-alert-bridge.php';
+
+		// Registration is deferred to plugins_loaded so regular plugins/themes
+		// can filter the enabled-event set before it is read.
+		$this->assertContains( 'plugins_loaded', $hooks );
+
+		// Fire the deferred registration and assert the audit-hook wiring.
+		wp_sudo_critical_alert_bridge_register();
 
 		$this->assertContains( 'wp_sudo_capability_tampered', $hooks );
 		$this->assertContains( 'wp_sudo_escalation_blocked', $hooks );
@@ -139,6 +147,7 @@ class CriticalAlertBridgeTest extends TestCase {
 		);
 
 		include __DIR__ . '/../../bridges/wp-sudo-critical-alert-bridge.php';
+		wp_sudo_critical_alert_bridge_register();
 
 		$this->assertContains( 'wp_sudo_recovery_mode_active', $hooks );
 	}
@@ -261,5 +270,108 @@ class CriticalAlertBridgeTest extends TestCase {
 			'site-admin@example.test',
 			wp_sudo_critical_alert_bridge_recipient( array( 'scope' => 'site' ) )
 		);
+	}
+
+	public function test_hourly_counter_preserves_window_start_across_increments(): void {
+		$this->boot();
+
+		wp_sudo_critical_alert_bridge_count( true, false );
+		$first = $this->transients['_wp_sudo_critical_alert_count'];
+		wp_sudo_critical_alert_bridge_count( true, false );
+		$second = $this->transients['_wp_sudo_critical_alert_count'];
+
+		$this->assertSame( 2, $second['count'] );
+		// The window opens once; increments must not push its start forward
+		// (which would let a slow trickle suppress alerts indefinitely).
+		$this->assertSame( $first['start'], $second['start'] );
+	}
+
+	public function test_hourly_counter_reports_zero_after_the_window_elapses(): void {
+		$this->boot();
+		// Seed an expired window (opened over an hour ago).
+		$this->transients['_wp_sudo_critical_alert_count'] = array(
+			'count' => 9,
+			'start' => time() - HOUR_IN_SECONDS - 1,
+		);
+
+		// A read past the window reports zero without persisting a write.
+		$this->assertSame( 0, wp_sudo_critical_alert_bridge_count( false, false ) );
+	}
+
+	public function test_network_scope_events_count_against_a_separate_network_counter(): void {
+		$this->boot( array( 'multisite' => true ) );
+
+		wp_sudo_critical_alert_bridge_count( true, true );
+		wp_sudo_critical_alert_bridge_count( true, false );
+
+		// Network events use a network transient, site events a per-site one, so
+		// no single recipient's mailbox is flooded and one busy site cannot
+		// starve another site's alerts.
+		$this->assertSame( 1, $this->site_transients['_wp_sudo_critical_alert_count']['count'] );
+		$this->assertSame( 1, $this->transients['_wp_sudo_critical_alert_count']['count'] );
+	}
+
+	public function test_overflow_digest_is_deduped_across_repeated_flushes(): void {
+		$this->boot( array( 'cap' => 1 ) );
+		$digests = 0;
+		Functions\when( 'wp_mail' )->alias(
+			static function ( string $to, string $subject ) use ( &$digests ): bool {
+				if ( false !== strpos( $subject, 'Additional critical events suppressed' ) ) {
+					++$digests;
+				}
+				return true;
+			}
+		);
+
+		// First flush: 'a' fills the cap, 'b' overflows → one digest.
+		wp_sudo_critical_alert_bridge_queue( 'add', array( 'key' => 'lockout', 'subject' => 's', 'body' => 'a', 'identity' => 'a', 'scope' => 'site' ) );
+		wp_sudo_critical_alert_bridge_queue( 'add', array( 'key' => 'lockout', 'subject' => 's', 'body' => 'b', 'identity' => 'b', 'scope' => 'site' ) );
+		wp_sudo_critical_alert_bridge_flush();
+
+		// Second flush in the same window overflows again but must NOT re-emit a
+		// digest — otherwise a per-request flood sends one digest per request.
+		wp_sudo_critical_alert_bridge_queue( 'add', array( 'key' => 'lockout', 'subject' => 's', 'body' => 'c', 'identity' => 'c', 'scope' => 'site' ) );
+		wp_sudo_critical_alert_bridge_flush();
+
+		$this->assertSame( 1, $digests );
+	}
+
+	public function test_escalation_super_admin_target_routes_to_network_on_multisite(): void {
+		$this->boot( array( 'multisite' => true, 'super_admin' => true, 'current_user' => 7 ) );
+
+		// Generic user.delete against a super-admin target is a network concern.
+		$event = wp_sudo_critical_alert_bridge_build_event( 'escalation_blocked', array( 42, 'user.delete', 'admin' ) );
+
+		$this->assertSame( 'network', $event['scope'] );
+	}
+
+	public function test_escalation_non_super_admin_target_stays_site_scope(): void {
+		$this->boot( array( 'multisite' => true, 'super_admin' => false ) );
+
+		$event = wp_sudo_critical_alert_bridge_build_event( 'escalation_blocked', array( 42, 'user.delete', 'admin' ) );
+
+		$this->assertSame( 'site', $event['scope'] );
+	}
+
+	public function test_missing_network_rules_route_to_network_on_multisite(): void {
+		$this->boot( array( 'multisite' => true ) );
+
+		$event = wp_sudo_critical_alert_bridge_build_event(
+			'missing_builtin_rules',
+			array( array( 'network.super_admin', 'plugin.activate' ) )
+		);
+
+		$this->assertSame( 'network', $event['scope'] );
+	}
+
+	public function test_missing_site_only_rules_stay_site_scope(): void {
+		$this->boot( array( 'multisite' => true ) );
+
+		$event = wp_sudo_critical_alert_bridge_build_event(
+			'missing_builtin_rules',
+			array( array( 'plugin.activate', 'user.delete' ) )
+		);
+
+		$this->assertSame( 'site', $event['scope'] );
 	}
 }


### PR DESCRIPTION
## Summary

- **What changed?** Adds an optional mu-plugin bridge, `bridges/wp-sudo-critical-alert-bridge.php`, that **notifies** an operator when a high-severity WP Sudo audit hook fires. The Stream/WSAL bridges *log* these events; nothing pushed an alert by default. This is the packaged form of the &#34;wire the criticals to email/Slack&#34; pattern.
- **Why?** WP Sudo observes but does not alert — suspicious events (tamper, escalation-block, lockout, dropped built-in rules) were only visible passively (Site Health, dashboard widget) unless an operator wrote their own `add_action`.

### How (safety-first, per the pre-implementation design review)
- **Deferred, never blocking.** Alerts queue and dispatch on `shutdown` (fires even after the gate&#39;s `wp_die()`), so a slow SMTP send never delays the security-blocking response — `wp_sudo_escalation_blocked` fires immediately before the gate dies.
- **Throttled against floods.** Every mapped event is deduped per-identity for a window, plus a bridge-wide hourly cap that collapses an incident into one &#34;N more suppressed&#34; digest. Several of these hooks are attacker-driven at volume (lockout enumeration, per-request tamper), so an unthrottled bridge would amplify a mail/outbound flood.
- **Correct attribution.** `wp_sudo_escalation_blocked` arg[0] is the **target**, not the actor — the alert states the target precisely and lists the current user as the actor separately.
- **Multisite-aware recipient** — super-admin-scope events → network admin email; site events → site admin email.
- **Extensible** — `wp_sudo_critical_alert_dispatch` short-circuit filter (return non-null to replace the default email with Slack/webhook, or capture the composed alert for inline display where outbound network is unavailable, e.g. Playground) + additive `wp_sudo_critical_alert_dispatched` action; plus `_events`, `_recipient`, `_throttle`, `_hourly_cap` filters. The per-page-load `recovery_mode` event is opt-in.
- **Anti-shim hygiene** — no `function_exists(&#39;wp_mail&#39;)` guard, no blanket `try/catch`; `function_exists(&#39;wp_sudo_critical_alert_*&#39;)` idempotency wrappers match the Stream/WSAL bridges.

### Inline demo companion (follow-up commit)
`bin/demo/wp-sudo-alert-inline-demo.php` — a **demo-only** realization of the bridge&#39;s &#34;capture for inline display&#34; use case, so the live demo &#34;trigger a tamper/escalation/lockout → watch the alert fire&#34; is visible in Playground, where PHP outbound network is disabled and `wp_mail()` goes nowhere.

- Listens on the **additive** `wp_sudo_critical_alert_dispatched` action (never the replace-filter), so it **cannot** suppress real alert email or poison a downstream Slack/webhook dispatcher — the key design-review objection.
- Buffers each composed alert in a rolling site transient (cap 20, FIFO), renders it as an admin notice on the next wp-admin load — **escaped at output**, drained show-once, gated on `manage_options`.
- Being a demo, it also relaxes the bridge&#39;s dedupe/hourly-cap to `0` (via `__return_zero`) so repeated triggers stay visible; the file and `developer-reference.md` both flag this as never-for-production. `bin/` is excluded from prod-line counts and the i18n POT scan, so it ships zero prod lines / zero translatable strings.
- `blueprint-main.json` copies the bridge + companion into `mu-plugins/` so the &#34;try latest main&#34; demo shows alerts without outbound network. (The per-PR Playground preview uses `blueprint.json` and does not exercise the companion — intentional.)

**Independent PR** — no dependency on the docs PR (#164) or the Gutenberg UX track; mergeable in any order.

## Validation

- [x] `composer test` — **1012 unit tests / 3,074 assertions** (9 bridge tests: default-off registration, dedupe, cap→digest, filter short-circuit, target-vs-actor labeling, multisite recipient; + 6 demo tests: capture/FIFO-trim, escaped-output + drain, capability + empty no-ops, hook registration)
- [x] PHPStan L6, Psalm, PHPCS 22/22, `verify:metrics`, `verify:i18n` — all pass (POT unchanged)
- [x] Pre-implementation design review + independent pre-commit review for **both** the bridge and the demo companion (all design objections verified in-code)

## Checklist

- [x] Linked issue or explained why none was needed — roadmap item (Security Bridge Coverage)
- [x] Updated docs, tests, or manual testing guidance if behavior changed — `developer-reference.md` bridge + demo sections, tests, metrics
- [x] No sensitive details disclosed publicly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017TCJoA72EDAmLviMKDB5zx)_