### PR TITLE
fix: worktree/tooling robustness (merge-aware size gate + verify-metrics .claude exclusion)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -35,6 +35,24 @@ fi
 
 APPROVAL_FILE="$REPO_ROOT/$REVIEWER_APPROVAL_FILE"
 
+# ── Merge detection ──────────────────────────────────────────────────────────
+# During a merge commit, MERGE_HEAD exists (a per-worktree ref). On a merge,
+# `git diff --cached` spans the ENTIRE incoming branch — already-reviewed code —
+# so the AI size gate (Step 2) false-positives on the base branch's insertions.
+# We exempt ONLY the size gate for merges; reviewer approval (Step 1) and the
+# test suite (Step 3) still run, since a merge resolution can contain authored code.
+#
+# Scope: only MERGE_HEAD is exempted. Squash merges (`git merge --squash`) create
+# no MERGE_HEAD and are intentionally still size-gated (a squash is one new
+# authored commit). Cherry-pick/revert/rebase are likewise still size-gated on
+# purpose — they stage a single commit's diff, not a whole base branch.
+# The `if` wrapper keeps `set -e` from aborting when MERGE_HEAD is absent: a
+# non-zero exit inside a condition context is not fatal.
+MERGE_IN_PROGRESS=""
+if git rev-parse -q --verify MERGE_HEAD >/dev/null 2>&1; then
+  MERGE_IN_PROGRESS=1
+fi
+
 # ── Staged file classification ───────────────────────────────────────────────
 # Docs-only = every staged file (lockfiles excluded) matches the text-only
 # pattern. Used to skip both the reviewer-approval check and the test suite.
@@ -80,8 +98,14 @@ else
 fi
 echo ""
 
-# ── Step 2: Commit size (AI commits only) ────────────────────────────────────
-if [ "$USER_COMMIT" != "1" ]; then
+# ── Step 2: Commit size (AI commits only; skipped on merges) ─────────────────
+if [ "$USER_COMMIT" != "1" ] && [ -n "$MERGE_IN_PROGRESS" ]; then
+  echo "2️⃣  Checking commit size..."
+  echo -e "   ${GREEN}ℹ️  Merge commit — skipping AI size gate${NC}"
+  echo "      (git diff --cached spans the whole incoming branch; reviewer"
+  echo "       approval and tests still apply to the merge resolution.)"
+  echo ""
+elif [ "$USER_COMMIT" != "1" ]; then
   echo "2️⃣  Checking commit size..."
 
   STAGED_FILE_COUNT=$(git diff --cached --name-only \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,7 +163,7 @@ curl -s "https://plugins.svn.wordpress.org/all-in-one-wp-security-and-firewall/t
 curl -s "https://raw.githubusercontent.com/WordPress/two-factor/master/class-two-factor-core.php" | grep "function "
 
 # Project size (update readme.md table when line counts change significantly)
-find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/.git/*" -print0 | xargs -0 wc -l | tail -1          # total PHP
+find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/.git/*" ! -path "*/.claude/*" -print0 | xargs -0 wc -l | tail -1  # total PHP (excludes .claude/ worktree checkouts)
 find ./includes ./wp-sudo.php ./uninstall.php ./mu-plugin ./bridges -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1  # production
 find ./tests -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1                                             # tests
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,7 +176,7 @@ curl -s "https://plugins.svn.wordpress.org/all-in-one-wp-security-and-firewall/t
 curl -s "https://raw.githubusercontent.com/WordPress/two-factor/master/class-two-factor-core.php" | grep "function "
 
 # Project size (update readme.md table when line counts change significantly)
-find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/.git/*" -print0 | xargs -0 wc -l | tail -1          # total PHP
+find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/.git/*" ! -path "*/.claude/*" -print0 | xargs -0 wc -l | tail -1  # total PHP (excludes .claude/ worktree checkouts)
 find ./includes ./wp-sudo.php ./uninstall.php ./mu-plugin ./bridges -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1  # production
 find ./tests -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1                                             # tests
 ```

--- a/bin/verify-metrics.sh
+++ b/bin/verify-metrics.sh
@@ -66,7 +66,13 @@ ACTUAL_PROD_LINES="$(find "$REPO_ROOT/includes" "$REPO_ROOT/wp-sudo.php" "$REPO_
 ACTUAL_TEST_LINES="$(find "$REPO_ROOT/tests" -type f -name '*.php' -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}')"
 ACTUAL_TOTAL_LINES="$(( ACTUAL_PROD_LINES + ACTUAL_TEST_LINES ))"
 ACTUAL_RATIO="$(awk -v tests="$ACTUAL_TEST_LINES" -v prod="$ACTUAL_PROD_LINES" 'BEGIN { printf "%.2f", tests / prod }')"
-ACTUAL_REPO_PHP="$(find "$REPO_ROOT" -type f -name '*.php' ! -path '*/vendor/*' ! -path '*/vendor_test/*' ! -path '*/.tmp/*' ! -path '*/.git/*' -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}')"
+# Relative `find .` (not absolute `find "$REPO_ROOT"`) so the `! -path '*/.claude/*'`
+# exclusion anchors to the repo's own .claude/ directory. An absolute path would
+# itself contain `/.claude/` whenever this script runs from a worktree checked out
+# under .claude/worktrees/<name>/, which would exclude the entire tree. Excluding
+# .claude/ prevents double-counting a full worktree checkout (~55k PHP lines) that
+# lives there; CI runs on a clean checkout with no such worktree.
+ACTUAL_REPO_PHP="$(cd "$REPO_ROOT" && find . -type f -name '*.php' ! -path '*/vendor/*' ! -path '*/vendor_test/*' ! -path '*/.tmp/*' ! -path '*/.git/*' ! -path '*/.claude/*' -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}')"
 
 # Architectural facts (security-relevant counts). These use the same commands
 # documented in the metric rows, so the gate and the doc stay self-consistent.
@@ -95,7 +101,7 @@ DOC_PROD_LINES="$(metric_number 'Production PHP lines (`includes/`, `wp-sudo.php
 DOC_TEST_LINES="$(metric_number 'Tests PHP lines (`tests/`)')"
 DOC_TOTAL_LINES="$(metric_number 'Production + tests PHP lines')"
 DOC_RATIO="$(metric_number 'Test-to-production ratio')"
-DOC_REPO_PHP="$(metric_number 'Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`)')"
+DOC_REPO_PHP="$(metric_number 'Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`, `.claude/`)')"
 DOC_GATED_SINGLE="$(metric_number 'Gated rules (single-site)')"
 DOC_GATED_MULTI="$(metric_number 'Gated rules (multisite)')"
 DOC_GATED_TOTAL="$(metric_number 'Gated rules (total)')"

--- a/docs/current-metrics.md
+++ b/docs/current-metrics.md
@@ -23,7 +23,7 @@ Verification environment: local workspace, PHP 8.x
 | Tests PHP lines (`tests/`) | 36,772 | `find ./tests -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
 | Production + tests PHP lines | 54,391 | sum of the two rows above |
 | Test-to-production ratio | 2.09:1 | `36772 / 17619` |
-| Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`) | 55,458 | `find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/vendor_test/*" ! -path "*/.tmp/*" ! -path "*/.git/*" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`, `.claude/`) | 55,458 | `find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/vendor_test/*" ! -path "*/.tmp/*" ! -path "*/.git/*" ! -path "*/.claude/*" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
 
 ## Footprint & Performance
 


### PR DESCRIPTION
Two worktree/tooling robustness fixes for the local dev workflow. Both are shell/docs-only — no production PHP changes.

## 1. `fix(hooks)`: skip the AI size gate on merge commits (`2164c02`)

The pre-commit hook's AI commit-size gate (Step 2) counts `git diff --cached` insertions. On a **merge commit** that diff spans the entire incoming base branch — already-reviewed code — so the gate false-positives and forces a `USER_COMMIT=1` bypass, which *also* skips reviewer approval (Step 1) and the test suite (Step 3). Hit on PR #165's merge commit.

Detect a merge via `git rev-parse -q --verify MERGE_HEAD` (wrapped in `if` so `set -e` doesn't abort when absent). When merging, Step 2 prints an info line and **skips only the file-count/insertion checks**. The original checks are byte-identical in an `elif` branch — **non-merge commits unchanged**. Reviewer approval, tests, and the secrets scan stay armed on merges (a merge resolution can contain authored code). Only `MERGE_HEAD` is exempted; squash/cherry-pick/revert/rebase have none and stay gated.

Verified in an isolated repo: non-merge oversized commit still blocked; merge of a 1201-line branch skips the size gate but still runs approval + tests; merge without approval still blocked at Step 1.

## 2. `fix(tooling)`: exclude `.claude/` from the verify-metrics repo PHP count (`69924e7`)

`bin/verify-metrics.sh` counted total repo PHP lines with an absolute `find "$REPO_ROOT"` that excluded `vendor/`, `vendor_test/`, `.tmp/`, `.git/` but **not** `.claude/`. A spawned-task git worktree at `.claude/worktrees/<name>/` is a full ~55k-line repo checkout, so the total double-counted and `composer verify:metrics` false-failed locally (CI runs on a clean checkout, so it passed).

Switched to a relative `cd "$REPO_ROOT" && find .` with `! -path '*/.claude/*'`. **Relative is required** — an absolute path itself contains `/.claude/` when the script runs from a worktree under `.claude/worktrees/`, which would exclude the entire tree. The `docs/current-metrics.md` row (label + command) and the `metric_number` lookup label were updated in lockstep, plus the `CLAUDE.md` project-size helper. Value stays **55,458** — `.claude/` has no tracked PHP, so the clean-tree count is unchanged.

Verified: with a dummy `.claude/worktrees/test/*.php` present, the old command reported 55,958 and the new one 55,458; `composer verify:metrics` passes.

## Risk

Low — shell + docs only. The hook change relaxes a heuristic line-count gate for merges while keeping reviewer approval, tests, and secret-scanning armed (a clean no-conflict merge still requires a fresh reviewer approval or `USER_COMMIT=1`, by design). The metrics change is a pure count-accuracy fix that keeps the documented value identical on a clean tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)