### PR TITLE
feat(editor): Gutenberg reauth Increment 2, Task 2 — grant plumbing + nonce-refresh endpoint

### DIFF
--- a/docs/current-metrics.md
+++ b/docs/current-metrics.md
@@ -10,7 +10,7 @@ Verification environment: local workspace, PHP 8.x
 | Metric | Value | Verification |
 |---|---:|---|
 | Unit tests | 1,026 tests | `composer test:unit` |
-| Unit assertions | 3,102 assertions | `composer test:unit` |
+| Unit assertions | 3,101 assertions | `composer test:unit` |
 | Integration tests in suite | 208 test methods | `rg -c "function test" tests/Integration/*.php | awk -F: '{sum+=$2} END{print sum}'` |
 | Unit test files | 32 | `ls tests/Unit/*.php | wc -l` |
 | Integration test files | 28 | `ls tests/Integration/*.php | wc -l` |
@@ -19,11 +19,11 @@ Verification environment: local workspace, PHP 8.x
 
 | Metric | Value | Verification |
 |---|---:|---|
-| Production PHP lines (`includes/`, `wp-sudo.php`, `uninstall.php`, `mu-plugin/`, `bridges/`) | 17,720 | `find ./includes ./wp-sudo.php ./uninstall.php ./mu-plugin ./bridges -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
-| Tests PHP lines (`tests/`) | 36,955 | `find ./tests -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
-| Production + tests PHP lines | 54,675 | sum of the two rows above |
-| Test-to-production ratio | 2.09:1 | `36955 / 17720` |
-| Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`, `.claude/`) | 55,742 | `find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/vendor_test/*" ! -path "*/.tmp/*" ! -path "*/.git/*" ! -path "*/.claude/*" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Production PHP lines (`includes/`, `wp-sudo.php`, `uninstall.php`, `mu-plugin/`, `bridges/`) | 17,723 | `find ./includes ./wp-sudo.php ./uninstall.php ./mu-plugin ./bridges -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Tests PHP lines (`tests/`) | 36,942 | `find ./tests -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Production + tests PHP lines | 54,665 | sum of the two rows above |
+| Test-to-production ratio | 2.08:1 | `36942 / 17723` |
+| Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`, `.claude/`) | 55,732 | `find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/vendor_test/*" ! -path "*/.tmp/*" ! -path "*/.git/*" ! -path "*/.claude/*" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
 
 ## Footprint & Performance
 

--- a/docs/current-metrics.md
+++ b/docs/current-metrics.md
@@ -9,8 +9,8 @@ Verification environment: local workspace, PHP 8.x
 
 | Metric | Value | Verification |
 |---|---:|---|
-| Unit tests | 1,023 tests | `composer test:unit` |
-| Unit assertions | 3,090 assertions | `composer test:unit` |
+| Unit tests | 1,026 tests | `composer test:unit` |
+| Unit assertions | 3,102 assertions | `composer test:unit` |
 | Integration tests in suite | 208 test methods | `rg -c "function test" tests/Integration/*.php | awk -F: '{sum+=$2} END{print sum}'` |
 | Unit test files | 32 | `ls tests/Unit/*.php | wc -l` |
 | Integration test files | 28 | `ls tests/Integration/*.php | wc -l` |
@@ -19,11 +19,11 @@ Verification environment: local workspace, PHP 8.x
 
 | Metric | Value | Verification |
 |---|---:|---|
-| Production PHP lines (`includes/`, `wp-sudo.php`, `uninstall.php`, `mu-plugin/`, `bridges/`) | 17,663 | `find ./includes ./wp-sudo.php ./uninstall.php ./mu-plugin ./bridges -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
-| Tests PHP lines (`tests/`) | 36,852 | `find ./tests -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
-| Production + tests PHP lines | 54,515 | sum of the two rows above |
-| Test-to-production ratio | 2.09:1 | `36852 / 17663` |
-| Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`) | 55,582 | `find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/vendor_test/*" ! -path "*/.tmp/*" ! -path "*/.git/*" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Production PHP lines (`includes/`, `wp-sudo.php`, `uninstall.php`, `mu-plugin/`, `bridges/`) | 17,720 | `find ./includes ./wp-sudo.php ./uninstall.php ./mu-plugin ./bridges -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Tests PHP lines (`tests/`) | 36,955 | `find ./tests -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Production + tests PHP lines | 54,675 | sum of the two rows above |
+| Test-to-production ratio | 2.09:1 | `36955 / 17720` |
+| Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`) | 55,742 | `find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/vendor_test/*" ! -path "*/.tmp/*" ! -path "*/.git/*" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
 
 ## Footprint & Performance
 
@@ -105,6 +105,7 @@ Source: `.github/workflows/phpunit.yml`, `.github/workflows/e2e.yml`, `.github/w
 
 ## Verification Notes
 
+- `composer test:unit` passed on 2026-07-06 (unit totals in the Test Metrics table above). Block-editor reauth, **Increment 2, Task 2** (grant plumbing; PHP-only slice — modal/2FA/re-dispatch JS deferred to a wp-env session): `Plugin::enqueue_editor_reauth()` now localizes `wpSudoEditorReauth` (grant nonce = the single `Challenge::NONCE_ACTION` `wp_sudo_challenge`, C1; AJAX action names; current-site `admin_url('admin-ajax.php')`, never network-admin, so a subsite editor posts its grant locally — design-review obj. 6), loaded even when a session is active (C2). New AJAX endpoint `Challenge::handle_ajax_refresh_nonce()` (`wp_sudo_refresh_grant_nonce`) re-mints a fresh grant nonce for an editor open past the ~24 h nonce lifetime — the primary staleness fix, since `check_ajax_referer` hard-`wp_die`s and can't be caught client-side (design-review obj. 2); logged-in-only, grants nothing (+3 unit tests).
 - `composer test:unit` passed on 2026-07-05 (unit totals in the Test Metrics table above). Block-editor reauth, Increment 1 (link-out snackbar): `Plugin::enqueue_editor_reauth()` enqueues a build-free `apiFetch` middleware (`admin/js/wp-sudo-editor-reauth.js`) on every block/site-editor screen — including when a sudo session is active at page load (condition C2, revised: the long-lived editor SPA outlives the short session) — that turns a gated action's `sudo_required` REST 403 into an in-editor "Reauthenticate" snackbar linking out to the challenge page. Notify + link-out only (no in-editor grant/modal yet); message stays generic (no rule-label echo). The `challenge_url` is validated (same-origin http(s)) before it is offered — a missing, malformed, cross-origin, or `javascript:` URL degrades to a plain message with no action (the cookie-auth branch always carries a valid same-origin URL; the no-action path is a defensive safety net) (+3 unit tests; +5 E2E in `editor-reauth.spec.ts`).
 - `composer test:unit` passed on 2026-07-05 (`997 tests`, `3032 assertions`). Harmonized user identity across the dashboard Session Activity widget and the Settings → Sudo Access tab: both now lead with the user's **full real name** (primary), with the **username secondary** (linked to user-edit when permitted), an avatar, and translated role chip(s). A shared `WP_Sudo\User_Identity` helper (`primary_name()` / `role_labels()`) is the single source of truth so the two surfaces cannot drift; role names go through `translate_user_role()`. Also fixed a latent no-op: `get_avatar()`'s force key is `force_display`, not `force` (the widget's avatar previously honored the site "Show Avatars" setting instead of always rendering); the stale Psalm baseline entry for it was removed (+11 tests: 6 `UserIdentityTest`, 5 Access-tab/widget cell + permission-branch).
 - `composer test:unit` passed on 2026-07-05 (`986 tests`, `3003 assertions`). Access-tab capability-holder table: each capability now renders as its own `wp-sudo-cap-item` row showing the human-readable label instead of the raw slug, with the Revoke control paired directly to it (responsive at narrow widths, no orphaned links); the slug moves to a tooltip + `screen-reader-text` span, and the Grant Capability dropdown drops the parenthetical slug from its visible option text. The revoke JS now removes the whole capability item container rather than a position-dependent `<code>` sibling. Each Revoke button also carries a capability-specific `aria-label` ("Revoke <label> capability") so screen-reader users tabbing through otherwise-identical controls get the capability context, and `get_cap_label()` now returns its labels through the text domain so localized installs get translated capability names (the label is the primary visible text now that the slug is hidden) (+1 test).

--- a/includes/class-challenge.php
+++ b/includes/class-challenge.php
@@ -438,6 +438,7 @@ class Challenge {
 	public function handle_ajax_refresh_nonce(): void {
 		if ( ! get_current_user_id() ) {
 			wp_send_json_error( array( 'message' => __( 'Not logged in.', 'wp-sudo' ) ), 403 );
+			return; // wp_send_json_error exits in core; explicit for unambiguous flow.
 		}
 
 		wp_send_json_success( array( 'nonce' => wp_create_nonce( self::NONCE_ACTION ) ) );

--- a/includes/class-challenge.php
+++ b/includes/class-challenge.php
@@ -48,6 +48,20 @@ class Challenge {
 	public const AJAX_2FA_ACTION = 'wp_sudo_challenge_2fa';
 
 	/**
+	 * AJAX action name for re-minting a fresh grant nonce.
+	 *
+	 * The grant nonce localized into a long-lived editor at page load ages out
+	 * (~24 h). A block/site editor left open past that point would open the reauth
+	 * modal but then fail `check_ajax_referer()` on the stale nonce — recreating
+	 * the dead-end this feature removes. The editor calls this endpoint to obtain
+	 * a fresh `NONCE_ACTION` nonce before authenticating. It grants nothing; its
+	 * CSRF proof is the login cookie (the `wp_ajax_` hook is logged-in-only).
+	 *
+	 * @var string
+	 */
+	public const AJAX_REFRESH_NONCE_ACTION = 'wp_sudo_refresh_grant_nonce';
+
+	/**
 	 * Query arg used to show a notice after redirecting instead of replaying
 	 * a POST that contained redacted secret fields.
 	 *
@@ -94,6 +108,7 @@ class Challenge {
 
 		add_action( 'wp_ajax_' . self::AJAX_AUTH_ACTION, array( $this, 'handle_ajax_auth' ), 10, 0 );
 		add_action( 'wp_ajax_' . self::AJAX_2FA_ACTION, array( $this, 'handle_ajax_2fa' ), 10, 0 );
+		add_action( 'wp_ajax_' . self::AJAX_REFRESH_NONCE_ACTION, array( $this, 'handle_ajax_refresh_nonce' ), 10, 0 );
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ), 10, 0 );
 		add_action( 'admin_notices', array( $this, 'render_redacted_replay_notice' ), 10, 0 );
 		add_action( 'network_admin_notices', array( $this, 'render_redacted_replay_notice' ), 10, 0 );
@@ -403,6 +418,29 @@ class Challenge {
 			</div>
 		</div>
 		<?php
+	}
+
+	/**
+	 * Re-mint a fresh grant nonce for a long-open editor (Increment 2, Task 2).
+	 *
+	 * The editor localizes the `NONCE_ACTION` grant nonce at page load; after it
+	 * ages out (~24 h) the reauth modal would otherwise dead-end on a stale-nonce
+	 * `check_ajax_referer()`. The editor calls this to obtain a fresh nonce first.
+	 *
+	 * Auth model: the `wp_ajax_` hook is logged-in-only; the explicit
+	 * `get_current_user_id()` guard makes that a hard requirement. No nonce is
+	 * verified here — this endpoint issues a CSRF token and changes no state, so
+	 * its CSRF proof is the login cookie, not a nonce (it cannot require the very
+	 * nonce it exists to refresh). It never grants a session.
+	 *
+	 * @return void
+	 */
+	public function handle_ajax_refresh_nonce(): void {
+		if ( ! get_current_user_id() ) {
+			wp_send_json_error( array( 'message' => __( 'Not logged in.', 'wp-sudo' ) ), 403 );
+		}
+
+		wp_send_json_success( array( 'nonce' => wp_create_nonce( self::NONCE_ACTION ) ) );
 	}
 
 	/**

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -318,8 +318,10 @@ class Plugin {
 	 * loaded even when a session is active (C2, same rationale as the enqueue).
 	 * `admin-ajax.php` is resolved via `admin_url()` (current site), never
 	 * `network_admin_url()` — a subsite editor must post its grant to its own
-	 * `admin-ajax.php`. A stale nonce (editor open past the ~24 h lifetime) is
-	 * recovered via `Challenge::AJAX_REFRESH_NONCE_ACTION`, not localized here.
+	 * `admin-ajax.php`. Only the initial nonce value is minted here; when it goes
+	 * stale (editor open past the ~24 h lifetime) a fresh one is fetched at runtime
+	 * from the `Challenge::AJAX_REFRESH_NONCE_ACTION` endpoint (whose action name is
+	 * localized above, but not a nonce value).
 	 *
 	 * @since 4.6.0
 	 *

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -310,9 +310,16 @@ class Plugin {
 	 * sudo_required (condition C2, revised — see the design brief Part 3.6).
 	 * Unlike enqueue_shortcut(), it deliberately does NOT skip active sessions.
 	 *
-	 * No nonce is localized here: the link-out path grants the session on the
-	 * challenge page, not in-editor. The grant nonce arrives in Increment 2 with
-	 * the in-editor modal.
+	 * Localizes (Increment 2, Task 2) the grant nonce, the AJAX action names, and
+	 * the current-site `admin-ajax.php` URL so the in-editor modal can grant a sudo
+	 * session in place. The nonce is the single `Challenge::NONCE_ACTION`
+	 * (`wp_sudo_challenge`) — a CSRF token reused as-is, never broadened to
+	 * authorization (C1). It is localized on block/site-editor screens only, but
+	 * loaded even when a session is active (C2, same rationale as the enqueue).
+	 * `admin-ajax.php` is resolved via `admin_url()` (current site), never
+	 * `network_admin_url()` — a subsite editor must post its grant to its own
+	 * `admin-ajax.php`. A stale nonce (editor open past the ~24 h lifetime) is
+	 * recovered via `Challenge::AJAX_REFRESH_NONCE_ACTION`, not localized here.
 	 *
 	 * @since 4.6.0
 	 *
@@ -329,6 +336,18 @@ class Plugin {
 			array( 'wp-api-fetch', 'wp-data', 'wp-notices', 'wp-i18n' ),
 			WP_SUDO_VERSION,
 			true
+		);
+
+		wp_localize_script(
+			'wp-sudo-editor-reauth',
+			'wpSudoEditorReauth',
+			array(
+				'ajaxUrl'            => admin_url( 'admin-ajax.php' ),
+				'nonce'              => wp_create_nonce( Challenge::NONCE_ACTION ),
+				'authAction'         => Challenge::AJAX_AUTH_ACTION,
+				'twoFactorAction'    => Challenge::AJAX_2FA_ACTION,
+				'refreshNonceAction' => Challenge::AJAX_REFRESH_NONCE_ACTION,
+			)
 		);
 
 		wp_set_script_translations( 'wp-sudo-editor-reauth', 'wp-sudo' );

--- a/tests/Unit/ChallengeTest.php
+++ b/tests/Unit/ChallengeTest.php
@@ -66,6 +66,10 @@ class ChallengeTest extends TestCase
 			->once()
 			->with(array($this->challenge, 'handle_ajax_2fa'), \Mockery::any(), 0);
 
+		Actions\expectAdded('wp_ajax_' . Challenge::AJAX_REFRESH_NONCE_ACTION)
+			->once()
+			->with(array($this->challenge, 'handle_ajax_refresh_nonce'), \Mockery::any(), 0);
+
 		Actions\expectAdded('admin_enqueue_scripts')
 			->once()
 			->with(array($this->challenge, 'enqueue_assets'), \Mockery::any(), 0);
@@ -104,6 +108,55 @@ class ChallengeTest extends TestCase
 	{
 		$this->assertSame('wp_sudo_challenge_auth', Challenge::AJAX_AUTH_ACTION);
 		$this->assertSame('wp_sudo_challenge_2fa', Challenge::AJAX_2FA_ACTION);
+		$this->assertSame('wp_sudo_refresh_grant_nonce', Challenge::AJAX_REFRESH_NONCE_ACTION);
+	}
+
+	/**
+	 * The nonce-refresh endpoint returns a fresh grant nonce for a logged-in
+	 * user and performs no state change (it grants nothing). Lets a long-open
+	 * editor re-mint the wp_sudo_challenge CSRF nonce after the localized one
+	 * ages out, instead of dead-ending on a stale-nonce check_ajax_referer.
+	 */
+	public function test_handle_ajax_refresh_nonce_returns_fresh_nonce(): void
+	{
+		Functions\when('get_current_user_id')->justReturn(7);
+		Functions\expect('wp_create_nonce')
+			->once()
+			->with(Challenge::NONCE_ACTION)
+			->andReturn('fresh-nonce-123');
+		Functions\expect('wp_send_json_success')
+			->once()
+			->with(array('nonce' => 'fresh-nonce-123'));
+
+		$this->challenge->handle_ajax_refresh_nonce();
+	}
+
+	/**
+	 * The nonce-refresh endpoint rejects a request with no current user.
+	 */
+	public function test_handle_ajax_refresh_nonce_rejects_logged_out(): void
+	{
+		Functions\when('get_current_user_id')->justReturn(0);
+		Functions\expect('wp_create_nonce')->never();
+		Functions\expect('wp_send_json_success')->never();
+
+		// wp_send_json_error dies in production; throw here to short-circuit and
+		// prove no nonce is minted for a logged-out request (mirrors the suite's
+		// early-exit pattern).
+		Functions\expect('wp_send_json_error')
+			->once()
+			->andReturnUsing(
+				function () {
+					throw new \RuntimeException('stop');
+				}
+			);
+
+		try {
+			$this->challenge->handle_ajax_refresh_nonce();
+			$this->fail('Expected wp_send_json_error to short-circuit.');
+		} catch (\RuntimeException $e) {
+			$this->assertSame('stop', $e->getMessage());
+		}
 	}
 
 	/**
@@ -740,6 +793,10 @@ class ChallengeTest extends TestCase
 		Actions\expectAdded('wp_ajax_' . Challenge::AJAX_2FA_ACTION)
 			->once()
 			->with(array($this->challenge, 'handle_ajax_2fa'), \Mockery::any(), 0);
+
+		Actions\expectAdded('wp_ajax_' . Challenge::AJAX_REFRESH_NONCE_ACTION)
+			->once()
+			->with(array($this->challenge, 'handle_ajax_refresh_nonce'), \Mockery::any(), 0);
 
 		Actions\expectAdded('admin_enqueue_scripts')
 			->once()

--- a/tests/Unit/ChallengeTest.php
+++ b/tests/Unit/ChallengeTest.php
@@ -137,26 +137,13 @@ class ChallengeTest extends TestCase
 	public function test_handle_ajax_refresh_nonce_rejects_logged_out(): void
 	{
 		Functions\when('get_current_user_id')->justReturn(0);
+		Functions\expect('wp_send_json_error')->once();
+		// The explicit return after wp_send_json_error prevents fallthrough to the
+		// success path even when the error helper is a no-op mock (no nonce minted).
 		Functions\expect('wp_create_nonce')->never();
 		Functions\expect('wp_send_json_success')->never();
 
-		// wp_send_json_error dies in production; throw here to short-circuit and
-		// prove no nonce is minted for a logged-out request (mirrors the suite's
-		// early-exit pattern).
-		Functions\expect('wp_send_json_error')
-			->once()
-			->andReturnUsing(
-				function () {
-					throw new \RuntimeException('stop');
-				}
-			);
-
-		try {
-			$this->challenge->handle_ajax_refresh_nonce();
-			$this->fail('Expected wp_send_json_error to short-circuit.');
-		} catch (\RuntimeException $e) {
-			$this->assertSame('stop', $e->getMessage());
-		}
+		$this->challenge->handle_ajax_refresh_nonce();
 	}
 
 	/**

--- a/tests/Unit/PluginTest.php
+++ b/tests/Unit/PluginTest.php
@@ -614,7 +614,7 @@ class PluginTest extends TestCase {
 			->once()
 			->with(
 				'wp-sudo-editor-reauth',
-				\Mockery::type( 'string' ),
+				'wpSudoEditorReauth',
 				\Mockery::on(
 					function ( $data ) {
 						return is_array( $data )

--- a/tests/Unit/PluginTest.php
+++ b/tests/Unit/PluginTest.php
@@ -569,6 +569,9 @@ class PluginTest extends TestCase {
 
 	public function test_enqueue_editor_reauth_loads_for_logged_in_user(): void {
 		Functions\when( 'get_current_user_id' )->justReturn( 1 );
+		Functions\when( 'admin_url' )->justReturn( 'http://example.test/wp-admin/admin-ajax.php' );
+		Functions\when( 'wp_create_nonce' )->justReturn( 'grant-nonce' );
+		Functions\when( 'wp_localize_script' )->justReturn( true );
 
 		Functions\expect( 'wp_enqueue_script' )
 			->once()
@@ -583,6 +586,46 @@ class PluginTest extends TestCase {
 		Functions\expect( 'wp_set_script_translations' )
 			->once()
 			->with( 'wp-sudo-editor-reauth', 'wp-sudo' );
+
+		$plugin = new Plugin();
+		$plugin->enqueue_editor_reauth();
+	}
+
+	/**
+	 * Increment 2 (Task 2): the editor script is localized with the grant nonce,
+	 * the AJAX action names, and the SUBSITE admin-ajax URL (never network-admin,
+	 * so a subsite editor posts to its own admin-ajax.php — design review obj. 6).
+	 * The single wp_sudo_challenge nonce is reused (C1); no new nonce action.
+	 */
+	public function test_enqueue_editor_reauth_localizes_grant_data(): void {
+		Functions\when( 'get_current_user_id' )->justReturn( 1 );
+		Functions\when( 'wp_enqueue_script' )->justReturn( true );
+		Functions\when( 'wp_set_script_translations' )->justReturn( true );
+
+		Functions\expect( 'admin_url' )
+			->once()
+			->with( 'admin-ajax.php' )
+			->andReturn( 'http://example.test/wp-admin/admin-ajax.php' );
+		Functions\expect( 'wp_create_nonce' )
+			->once()
+			->with( Challenge::NONCE_ACTION )
+			->andReturn( 'grant-nonce-abc' );
+		Functions\expect( 'wp_localize_script' )
+			->once()
+			->with(
+				'wp-sudo-editor-reauth',
+				\Mockery::type( 'string' ),
+				\Mockery::on(
+					function ( $data ) {
+						return is_array( $data )
+							&& 'grant-nonce-abc' === $data['nonce']
+							&& 'http://example.test/wp-admin/admin-ajax.php' === $data['ajaxUrl']
+							&& Challenge::AJAX_AUTH_ACTION === $data['authAction']
+							&& Challenge::AJAX_2FA_ACTION === $data['twoFactorAction']
+							&& Challenge::AJAX_REFRESH_NONCE_ACTION === $data['refreshNonceAction'];
+					}
+				)
+			);
 
 		$plugin = new Plugin();
 		$plugin->enqueue_editor_reauth();
@@ -611,6 +654,9 @@ class PluginTest extends TestCase {
 			return '';
 		} );
 		Functions\when( 'wp_set_script_translations' )->justReturn( true );
+		Functions\when( 'admin_url' )->justReturn( 'http://example.test/wp-admin/admin-ajax.php' );
+		Functions\when( 'wp_create_nonce' )->justReturn( 'grant-nonce' );
+		Functions\when( 'wp_localize_script' )->justReturn( true );
 
 		$_COOKIE[ Sudo_Session::TOKEN_COOKIE ] = $token;
 


### PR DESCRIPTION
## Summary

**Increment 2, Task 2** of block-editor reauthentication — the **PHP grant-plumbing** for an in-editor reauth modal. Builds on Increment 1 (link-out snackbar, #165).

This PR is a **PHP-only, fully unit-tested slice**. The modal + 2FA + automatic re-dispatch JS (Tasks 3–4) is **intentionally deferred to a wp-env session**, where it can be built and verified against a live block editor — the design review flagged real sharp edges there (2FA challenge-cookie round-trip over XHR must be *proven*, single-flight concurrency, server-rendered 2FA partial vs. link-out) that shouldn't be guessed through CI.

## Changes

- **`Challenge::handle_ajax_refresh_nonce()`** (new `wp_sudo_refresh_grant_nonce` AJAX endpoint) — re-mints a fresh `wp_sudo_challenge` nonce for an editor left open past the ~24 h nonce lifetime. This is the **primary** staleness fix: the alternative ("retry once on a `check_ajax_referer` failure") is unviable because `check_ajax_referer` hard-`wp_die()`s and can't be caught client-side. Logged-in-only, returns only a nonce, changes no state, **grants nothing**; its CSRF proof is the login cookie (it cannot require the nonce it exists to refresh).
- **`Plugin::enqueue_editor_reauth()`** now localizes `wpSudoEditorReauth`: the single `Challenge::NONCE_ACTION` grant nonce (**C1** — a CSRF token, never broadened to authorization), the three AJAX action names, and `admin_url('admin-ajax.php')` (current site, **never** `network_admin_url()`, so a subsite editor posts its grant locally). Loaded even when a session is active (**C2**).

## Process & review

- Passed the mandatory **pre-implementation design review**; the *refresh-endpoint-primary* and *subsite-ajaxurl* decisions come directly from its findings (obj. 2 and obj. 6).
- Pre-commit **reviewer-approved** with the refresh endpoint's no-`check_ajax_referer` model as the highest-scrutiny item — cleared: no state change, SOP blocks cross-origin nonce-farming, and the grant endpoints still enforce `check_ajax_referer` + password/2FA + `Sudo_Session` (C1 holds).

## Verification

- ✅ `composer test:unit` — 1,026 tests / 3,102 assertions (+3)
- ✅ `composer analyse` — PHPStan L6 + Psalm, no errors
- ✅ `composer lint` — clean
- ✅ `docs/current-metrics.md` synced (prod 17,720 / tests 36,955 / total 55,742)

## Risk

Security-sensitive (new AJAX endpoint + CSRF-nonce localization into the editor), reviewed accordingly. No new gating rule, no `Request_Stash`, no content-save gating, no build step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)