### PR TITLE
docs: pre-release demo fix, canonical editor-scope doc, and lockdown research

### DIFF
--- a/.planning/todos/pending/2026-07-15-mu-role-cap-lockdown-mode.md
+++ b/.planning/todos/pending/2026-07-15-mu-role-cap-lockdown-mode.md
@@ -1,0 +1,106 @@
+# Research: MU-plugin role/capability lockdown mode
+
+## Status
+
+Tentative research backlog. Do not implement until the research questions below
+are answered and the operator/recovery story is clear.
+
+## Hypothesis
+
+The optional WP Sudo MU-plugin could provide a high-assurance lockdown mode that
+loads an operator-reviewed file manifest of trusted privileged principals and
+uses it to detect, deny, or repair database-stored role/capability drift.
+
+This would be valuable mainly against **database-only compromise** or accidental
+role-editor drift: an attacker or plugin can mutate `wp_user_roles`, a user's
+`{prefix}capabilities` meta row, or multisite `site_admins`, but cannot write PHP
+or alter the manifest file.
+
+## Why this might fit WP Sudo
+
+- WP Sudo already treats direct role/capability tampering as a security concern:
+  it strips `unfiltered_html` from the Editor role and fires
+  `wp_sudo_capability_tampered` when that canary drifts.
+- The admin-escalation guard catches many *hooked* administrator/super-admin
+  grants, but direct `$wpdb` writes bypass the user-meta hooks.
+- The MU-plugin loads earlier than normal plugins and is the right deployment
+  surface for policy that should be file-backed rather than database-backed.
+
+## Candidate scope
+
+Start narrow. Protect privileged authority, not every role on the site.
+
+Potential manifest entries:
+
+- allowed administrator users per site;
+- allowed multisite super admins;
+- allowed WP Sudo governance capability holders:
+  - `manage_wp_sudo`
+  - `view_wp_sudo_activity`
+  - `export_wp_sudo_activity`
+  - `revoke_wp_sudo_sessions`
+- optionally, holders of dangerous primitive caps such as:
+  - `manage_options`
+  - `manage_network_options`
+  - `promote_users`
+  - `activate_plugins`
+  - `install_plugins`
+  - `delete_plugins`
+
+Potential modes:
+
+1. **Audit only** — detect drift, fire hooks/events, and show admin/site-health
+   warnings.
+2. **Deny effective capability** — filter effective caps for principals not in
+   the manifest without rewriting the database.
+3. **Repair stored state** — remove unauthorized DB role/cap/super-admin grants.
+   This is strongest but operationally sharpest.
+
+Likely MVP: audit-only plus an explicit operator command/workflow to generate a
+reviewable manifest. Enforce mode should come later, if at all.
+
+## Required research questions
+
+- What exact WordPress load point gives reliable access to roles, current user,
+  multisite context, and capability filters without racing core initialization?
+- Should enforcement filter effective capabilities, rewrite stored state, or both?
+- How can the manifest represent multisite safely:
+  - network super admins;
+  - main-site administrators;
+  - per-site administrators on secondary blogs?
+- How should legitimate dynamic provisioning work:
+  - SSO/SAML/OIDC directory sync;
+  - Members/User Role Editor-style plugins;
+  - deployment scripts that create admins;
+  - emergency access changes?
+- What is the break-glass mechanism if the manifest is stale or wrong?
+- How should the feature interact with `WP_SUDO_RECOVERY_MODE` and
+  `WP_SUDO_ALLOW_ESCALATION`?
+- Which audit hooks/events should fire for detected drift vs. enforced repair?
+- Can this be tested deterministically in unit/integration tests without creating
+  brittle assumptions about core role loading?
+
+## Security boundaries
+
+This does **not** protect against:
+
+- filesystem/PHP write access;
+- malicious code that can edit the manifest;
+- runtime capability grants through `user_has_cap` / `map_meta_cap` unless the
+  chosen enforcement model explicitly filters final effective caps;
+- legitimate admins operating inside an already-active sudo window;
+- direct database writes to non-role application state.
+
+It should be documented as a high-assurance integrity control for trusted
+operators, not a generic firewall.
+
+## Acceptance criteria before implementation planning
+
+- A short design note compares audit-only, deny-effective, and repair-stored-state
+  approaches.
+- A concrete manifest format is proposed and reviewed.
+- A recovery/break-glass path is defined before any enforce mode is implemented.
+- Compatibility risks with role-management and identity-provider plugins are
+  listed with opt-out or allowlist mechanics.
+- The first implementation slice has tests for single-site, multisite, direct
+  DB mutation, manifest drift, and recovery bypass behavior.

--- a/.planning/todos/pending/2026-07-15-mu-role-cap-lockdown-mode.md
+++ b/.planning/todos/pending/2026-07-15-mu-role-cap-lockdown-mode.md
@@ -104,3 +104,41 @@ operators, not a generic firewall.
   listed with opt-out or allowlist mechanics.
 - The first implementation slice has tests for single-site, multisite, direct
   DB mutation, manifest drift, and recovery bypass behavior.
+
+## Reviewer notes (added during PR review, 2026-07-15)
+
+Sharpening the research before any design phase — these are the load-bearing
+tensions to resolve:
+
+- **Draw the boundary against the existing escalation guard.** `Gate::arm_escalation_guard`
+  (default-OFF, filter `wp_sudo_guard_escalation`) already blocks a hooked
+  administrator/super-admin grant by hooking the `{prefix}capabilities` meta write
+  and `grant_super_admin`. This lockdown mode's *unique* value is precisely the
+  path that guard misses: a direct `$wpdb` write to `wp_usermeta` / `wp_user_roles`
+  / multisite `site_admins` that never fires those hooks. The design must state how
+  the two compose — same manifest/allowlist? shared audit event? — so they don't
+  double-fire, disagree, or leave a gap between them.
+- **The "dangerous primitive caps" list mostly restates "all administrators."**
+  `manage_options`, `activate_plugins`, `install_plugins`, `promote_users`, etc.
+  are held by every administrator, so allowlisting their holders is nearly the same
+  set as the administrator allowlist. The primitive-cap layer only earns its keep
+  for **non-admin roles that have been granted these caps directly** (custom roles,
+  role-editor drift). Scope it to that case explicitly, or drop it as redundant.
+- **Deterministic testing is already tractable.** The integration harness
+  (`WP_UnitTestCase`, real WP + MySQL) can mutate `wp_user_roles` /
+  `{prefix}capabilities` / `site_admins` directly and assert detection, drift
+  repair, and break-glass — single-site and `WP_TESTS_MULTISITE=1`. This is how the
+  `wp_sudo_capability_tampered` canary is already exercised; the open testability
+  question is answerable with that pattern, not a blocker.
+- **Enforcement cost must be named.** A "deny effective capability" model that
+  filters `user_has_cap` / `map_meta_cap` runs on **every** capability check on
+  **every** request — a real hot path. Weigh that against "repair stored state"
+  (a one-shot DB rewrite that is operationally sharper and can lock out a
+  legitimately-provisioned admin). This reinforces the audit-only MVP: ship
+  detection + events first, and treat any enforce mode as a separate, later,
+  heavily-gated decision.
+- **Manifest lifecycle is an operational burden, not just a format.** Beyond the
+  file schema, define how the manifest is generated, reviewed, versioned, and kept
+  in sync across environments (dev/stage/prod), and how a snapshot is regenerated
+  safely after a legitimate change — otherwise the feature trades a compromise risk
+  for a self-inflicted lockout risk.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -380,11 +380,19 @@ and are excluded from the distributed plugin ZIP (see [`.pressshipignore`](.pres
 |------|------|---------|----------------|---------------|
 | [`blueprint.json`](blueprint.json) | Public demo | "Try latest release" — stable-tag demo with the standard seed | `archive/refs/tags/vX.Y.Z.zip` (bumped at tag time) | readme.md / readme.txt badges |
 | [`blueprint-main.json`](blueprint-main.json) | Public demo | "Try main" — tracks the `main` branch | `archive/refs/heads/main.zip` | readme.md / readme.txt badges |
+| [`blueprint-editor-reauth.json`](blueprint-editor-reauth.json) | Public/reviewer scenario | In-editor reauthentication demo — opens the block editor without an active sudo session so Block Directory plugin install/activate can trigger the modal | release branch or `main` while the feature is unreleased; tag-pinned copy after release if kept as a public demo | readme.md while featured; [`docs/ui-ux-testing-prompts.md`](docs/ui-ux-testing-prompts.md) §6c |
 | [`blueprint-recovery-mode.json`](blueprint-recovery-mode.json) | Reviewer scenario | Break-glass `WP_SUDO_RECOVERY_MODE` demo | `main` | [`docs/ui-ux-testing-prompts.md`](docs/ui-ux-testing-prompts.md) §6a |
 | [`blueprint-user-switching.json`](blueprint-user-switching.json) | Reviewer scenario | Session-theft demo via the User Switching plugin | `main` | [`docs/ui-ux-testing-prompts.md`](docs/ui-ux-testing-prompts.md) §6b |
 | [`.github/playground/sqlite-stack-smoke.blueprint.json`](.github/playground/sqlite-stack-smoke.blueprint.json) | CI smoke | SQLite drop-in stack smoke used by the E2E-SQLite workflow | (CI-driven) | [`.github/workflows/e2e-sqlite.yml`](.github/workflows/e2e-sqlite.yml) |
 
-The two **public** blueprints are surfaced via the readme "Try in Playground" badges; the two **reviewer** blueprints stage hard-to-reach states for manual review (not linked from the readme by design); the **CI smoke** blueprint is owned by its workflow. When adding a new blueprint, add it to `.pressshipignore` and to this table.
+The two standard **public** blueprints are surfaced via the readme "Try in
+Playground" badges. Feature-specific public demos, such as the in-editor
+reauthentication blueprint, may be temporarily surfaced while the feature is new;
+before tagging a release, either tag-pin them like `blueprint.json` or clearly
+move them back to reviewer-only status. The **reviewer** blueprints stage
+hard-to-reach states for manual review (not linked from the readme by default);
+the **CI smoke** blueprint is owned by its workflow. When adding a new blueprint,
+add it to `.pressshipignore` and to this table.
 
 ### WordPress 7.0 Final Prep Checklist
 
@@ -424,6 +432,26 @@ Use this checklist for each later RC and again at GA:
 | Session expiry by time | ✅ wait out the configured duration (1–15 min) |
 | Two Factor plugin (TOTP) | ✅ installed automatically via blueprint |
 | `unfiltered_html` removed from Editor role | ✅ |
+| Block-editor reauthentication UI | ✅ use `blueprint-editor-reauth.json`; in the editor, open the inserter, search a Block Directory block, and install/activate it to trigger the password modal |
+
+### Editor-triggered sudo challenge scope
+
+The block/site editor middleware handles any cookie-authenticated REST response
+with `code: "sudo_required"`, but the default WordPress UI only exposes a small
+set of dangerous actions from inside editor screens.
+
+| Editor/admin action | Default visible editor UI? | Sudo behavior |
+|---|---:|---|
+| Install/activate a block from the Block Directory (`/wp/v2/plugins`) | Yes, in the block editor inserter when block installation is available | Gated; this is the primary Playground demo path for the in-editor modal |
+| Plugin deactivate/delete through REST (`/wp/v2/plugins/{plugin}`) | Not a normal block/site editor control | Gated if an editor-adjacent script or extension sends the request |
+| User create/delete/role/password changes through REST (`/wp/v2/users…`) | Not a normal block/site editor control | Gated if an editor-adjacent script or extension sends the request |
+| Application-password creation through REST (`/wp/v2/users/{id}/application-passwords`) | Not a normal block/site editor control | Gated if an editor-adjacent script or extension sends the request |
+| Critical settings or connector credential writes through REST (`/wp/v2/settings`) | Not a normal block/site editor control | Gated when the request contains a covered critical option or connector API-key field |
+| Posts, pages, templates, template parts, global styles, navigation, media, widgets, fonts, reusable blocks | Yes | Deliberately not gated; these are content/design operations, not sudo-trigger demos |
+
+For release demos, prefer the visible Block Directory path. If a future release
+adds a first-party visible editor control for another gated REST route, update
+this table, the release checklist, and the Playground instructions together.
 
 ### What won't work in Playground
 
@@ -433,7 +461,7 @@ Use this checklist for each later RC and again at GA:
 | REST / XML-RPC entry point policies | Network disabled in Playground |
 | Two Factor email / magic-link providers | PHP outbound network is off |
 | WebAuthn bridge (security key gating) | Browser WebAuthn API unavailable in Playground sandbox |
-| Multisite behaviour | Single-site only |
+| Multisite behaviour in the standard public demos | The default public blueprints are single-site; add a dedicated multisite blueprint/link when a release needs a network-admin demo |
 | State after refreshing Playground | Full reset on page reload |
 
 Transients and user meta persist across normal WP navigation within a session,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -438,20 +438,19 @@ Use this checklist for each later RC and again at GA:
 
 The block/site editor middleware handles any cookie-authenticated REST response
 with `code: "sudo_required"`, but the default WordPress UI only exposes a small
-set of dangerous actions from inside editor screens.
+set of dangerous actions from inside editor screens — chiefly Block Directory
+install/activate (`/wp/v2/plugins`), which is the primary Playground demo path.
+Ordinary content/design saves (posts, pages, templates, global styles,
+navigation, media, widgets, fonts, reusable blocks) are deliberately **not**
+gated.
 
-| Editor/admin action | Default visible editor UI? | Sudo behavior |
-|---|---:|---|
-| Install/activate a block from the Block Directory (`/wp/v2/plugins`) | Yes, in the block editor inserter when block installation is available | Gated; this is the primary Playground demo path for the in-editor modal |
-| Plugin deactivate/delete through REST (`/wp/v2/plugins/{plugin}`) | Not a normal block/site editor control | Gated if an editor-adjacent script or extension sends the request |
-| User create/delete/role/password changes through REST (`/wp/v2/users…`) | Not a normal block/site editor control | Gated if an editor-adjacent script or extension sends the request |
-| Application-password creation through REST (`/wp/v2/users/{id}/application-passwords`) | Not a normal block/site editor control | Gated if an editor-adjacent script or extension sends the request |
-| Critical settings or connector credential writes through REST (`/wp/v2/settings`) | Not a normal block/site editor control | Gated when the request contains a covered critical option or connector API-key field |
-| Posts, pages, templates, template parts, global styles, navigation, media, widgets, fonts, reusable blocks | Yes | Deliberately not gated; these are content/design operations, not sudo-trigger demos |
-
-For release demos, prefer the visible Block Directory path. If a future release
-adds a first-party visible editor control for another gated REST route, update
-this table, the release checklist, and the Playground instructions together.
+The canonical, per-route inventory of which editor actions can trip a sudo
+challenge lives in
+[`docs/ui-ux-testing-prompts.md` §6c](docs/ui-ux-testing-prompts.md) (the
+*Editor-triggerable gated-action inventory*). Keep it as the single source; if a
+future release adds a first-party visible editor control for another gated REST
+route, update that inventory, this release checklist, and the Playground
+instructions together.
 
 ### What won't work in Playground
 

--- a/blueprint-editor-reauth.json
+++ b/blueprint-editor-reauth.json
@@ -28,7 +28,7 @@
       "step": "installPlugin",
       "pluginData": {
         "resource": "url",
-        "url": "https://wordpress-playground-cors-proxy.net/?https://github.com/dknauss/Sudo/archive/refs/heads/feat/gutenberg-reauth-increment-3.zip"
+        "url": "https://wordpress-playground-cors-proxy.net/?https://github.com/dknauss/Sudo/archive/refs/heads/main.zip"
       },
       "options": {
         "activate": true,

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1116,6 +1116,29 @@ shapes. Tracked here so they are not forgotten:
    orthogonal (per-action re-prompt for the highest-risk grants, CSRF hardening) and
    trade UX for coverage; tracked, not scheduled.
 
+**Tentative: MU-plugin role/capability lockdown mode (research backlog).**
+Explore whether the optional MU-plugin should support a high-assurance mode that
+loads an operator-reviewed file manifest of trusted privileged principals and
+denies or repairs database-stored role/capability drift at runtime. This would be
+aimed at **database-only compromise or accidental role-editor drift**, where an
+attacker can mutate `wp_user_roles`, `{prefix}capabilities`, or multisite
+`site_admins` but cannot write PHP/files. It should be treated as an
+audit-first / enforce-later hardening feature, not a default behavior:
+
+- start with administrator, super-admin, and WP Sudo governance-cap holders;
+- explicitly account for per-user capabilities, role definitions, and multisite
+  super admins rather than only locking `wp_user_roles`;
+- provide a safe snapshot/generate workflow plus filesystem-only break-glass;
+- document blind spots: filesystem compromise, runtime grants via
+  `user_has_cap` / `map_meta_cap`, SSO/directory sync, role-management plugins,
+  and legitimate provisioning changes.
+
+Do not scope implementation until research answers whether enforcement should
+filter effective capabilities, rewrite stored state, or only alert; how false
+positives are avoided on sites with dynamic roles; and how recovery works if the
+manifest is stale. Research tracker:
+`.planning/todos/pending/2026-07-15-mu-role-cap-lockdown-mode.md`.
+
 Bridge coverage is also incomplete: the WSAL/Stream bridges do not yet map the
 4.1.0 `wp_sudo_escalation_blocked` event — adding it would let SIEM/audit tools
 alert on escalation blocks directly. See the bridge-coverage backlog below.

--- a/docs/ui-ux-testing-prompts.md
+++ b/docs/ui-ux-testing-prompts.md
@@ -432,6 +432,13 @@ local wp-env/Studio browser run plus a screenshot instead. Do not rewrite the de
 as a content save: ordinary post, template, navigation, global-style, media,
 widget, font, and reusable-block saves are intentionally not gated.
 
+**Two-factor accounts:** the demo admin has no 2FA, so it exercises the in-editor
+modal. A **2FA-enrolled** account behaves differently by design (Milestone A): the
+middleware *skips* the modal and surfaces the "Reauthenticate" link-out snackbar
+instead, because the password-only modal cannot complete a second factor and would
+otherwise force a second password entry on the challenge page. To demo the 2FA
+path, expect the link-out, not the modal. In-modal 2FA is Milestone B.
+
 #### Editor-triggerable gated-action inventory
 
 The editor middleware handles any cookie-authenticated REST response with

--- a/docs/ui-ux-testing-prompts.md
+++ b/docs/ui-ux-testing-prompts.md
@@ -359,7 +359,11 @@ Keep the URL from 5b, method DELETE:
 
 ## 6. Playground Scenario Links
 
-Two specialized [WordPress Playground](https://playground.wordpress.net/) blueprints stage hard-to-reach states deterministically, so a reviewer can exercise them without building the precondition by hand. Both install the plugin from the `main` branch (where the relevant features live) on top of the standard demo seed (users, sessions, sample audit events) defined in `blueprint-main.json`.
+[WordPress Playground](https://playground.wordpress.net/) blueprints stage
+hard-to-reach states deterministically, so a reviewer can exercise them without
+building the precondition by hand. The standard public demos install from the
+latest release tag or `main`; feature/reviewer scenarios may install from the
+branch under test until a release creates a tag-pinned copy.
 
 To launch, host the blueprint JSON at a public URL and open:
 `https://playground.wordpress.net/?blueprint-url=<RAW_URL>`
@@ -399,5 +403,76 @@ This blueprint installs the [User Switching](https://wordpress.org/plugins/user-
 - User Switching is *consensual admin impersonation*, not literal theft. It is a faithful proxy because the end state is identical — authenticated as a user whose password you do not hold — but it is not an exploit.
 - The **switch action itself is not gated** by default; it is not a built-in rule. The protection demonstrated is on the gated actions performed *as the switched-into user*, not on switching.
 - Playground is a single sandboxed origin, so genuine cross-browser cookie theft cannot be simulated — only the in-session identity swap.
+
+### 6c. In-editor reauthentication — `blueprint-editor-reauth.json`
+
+This blueprint lands on the block editor with the admin logged in but without an
+active sudo session. It exists to demonstrate the front-end/editor UI rather than
+the classic full-page challenge: a gated editor REST request opens the
+`Confirm your identity` password modal over the editor, grants the sudo session,
+and re-dispatches the original request without losing editor state.
+
+**Primary demo path:** use the block editor's Block Directory integration.
+
+- [ ] Open the block inserter (`+`) in the editor.
+- [ ] Search for a block that is not already installed, such as "Icon Block" or
+  another WordPress.org block plugin.
+- [ ] Click the result to install/activate it.
+- [ ] Confirm the WP Sudo modal appears over the editor.
+- [ ] Enter `password`.
+- [ ] Confirm the modal closes, the original install/activate request resumes,
+  and the editor tab remains on the post editor.
+- [ ] Confirm the admin-bar sudo countdown appears after the grant.
+- [ ] Capture or refresh a release screenshot of this modal before tagging a
+  release that promotes the feature.
+
+If Playground cannot install blocks from the Block Directory in the current
+WordPress/Playground build, record that as a demo-environment blocker and use a
+local wp-env/Studio browser run plus a screenshot instead. Do not rewrite the demo
+as a content save: ordinary post, template, navigation, global-style, media,
+widget, font, and reusable-block saves are intentionally not gated.
+
+#### Editor-triggerable gated-action inventory
+
+The editor middleware handles any cookie-authenticated REST response with
+`code: "sudo_required"`, but the visible default editor UI only exposes a small
+slice of WP Sudo's broader REST rule set.
+
+| Action family | Route/rule surface | Visible in default block/site editor? | Demo guidance |
+|---|---|---:|---|
+| Block Directory install/activate | `/wp/v2/plugins` (`plugin.install`, `plugin.activate`) | Yes, when block installation is available | Primary in-editor demo path |
+| Plugin deactivate/delete/update via REST | `/wp/v2/plugins/{plugin}` (`plugin.deactivate`, `plugin.delete`, plugin status writes) | No ordinary editor control | Only demo with an explicit editor-adjacent script/extension |
+| User create/delete/role/password changes | `/wp/v2/users…` (`user.*`) | No ordinary editor control | Covered by REST tests; not a normal editor UI demo |
+| Application-password creation | `/wp/v2/users/{id}/application-passwords` (`auth.app_password`) | No ordinary editor control | Covered by REST tests; not a normal editor UI demo |
+| Critical settings / connector credentials | `/wp/v2/settings` (`options.critical`, `connectors.update_credentials`) | No ordinary editor control | Covered by REST tests; not a normal editor UI demo |
+| Posts/pages/templates/global styles/navigation/media/widgets/fonts/reusable blocks | Core content/design routes | Yes | Deliberately not gated; do not use as a sudo demo |
+
+**Site editor note:** the same middleware is enqueued for block editor assets,
+including site-editor contexts, but default Site Editor design operations are
+content/design saves and should not trip Sudo. A Site Editor demo should only be
+added when there is a visible, default Site Editor path to a genuinely gated REST
+route or a dedicated extension scenario being reviewed.
+
+### 6d. Multisite/network-admin Playground demo — release decision point
+
+The standard public blueprints are single-site. Playground can stage multisite,
+so each pre-release pass should decide whether the release needs a dedicated
+multisite/network-admin demo blueprint in addition to the automated multisite
+integration and Playwright lanes.
+
+Candidate network-admin demo actions:
+
+- [ ] Network plugin activation/deactivation from Network Admin › Plugins.
+- [ ] Network theme enable/disable from Network Admin › Themes.
+- [ ] Site delete/deactivate/archive/spam from Network Admin › Sites.
+- [ ] Grant/revoke super-admin status.
+- [ ] Network settings save.
+
+If a multisite Playground blueprint is added, document its raw URL, landing page,
+credentials, and exact trigger action here and in `CONTRIBUTING.md`. The demo
+should make clear that network-admin rules are classic admin/network-admin
+surfaces, not block-editor surfaces. If the blueprint is deferred, record the
+reason in the release checklist and rely on `WP_MULTISITE=1` integration plus the
+multisite Playwright/release-confidence lanes for behavioral coverage.
 
 > **Note on 2FA in Playground:** the bundled Two Factor plugin installs and activates, but TOTP requires an authenticator secret and email codes are not delivered in the sandbox. Interactive 2FA reauth is the one scenario these links cannot fully exercise.

--- a/docs/wporg-submission-checklist.md
+++ b/docs/wporg-submission-checklist.md
@@ -44,6 +44,37 @@ These gates protect the GitHub/package release itself. They are required before 
 - [ ] **Changelog/readme/release-status sanity** — `CHANGELOG.md`, `readme.txt`, and
   [`docs/release-status.md`](release-status.md) agree on the intended version,
   release posture, and whether work is tagged or still unreleased on `main`.
+- [ ] **Public screenshot refresh gate** — if the release changes any public UI,
+  refresh or deliberately re-approve the README/readme/WordPress.org screenshot
+  set before tagging. The next pre-release pass must include a current screenshot
+  of the block-editor reauthentication UI (password modal over the editor, plus
+  the 2FA/link-out fallback if that path is materially visible). Run
+  `npm run screenshots` for the `.wordpress-org/` listing set, add any new
+  non-listing README assets deliberately, and update `readme.txt` screenshot
+  captions when the numbered listing set changes.
+- [ ] **Editor-triggered sudo coverage documented** — document which block/site
+  editor actions can actually trip a sudo challenge in the current release. Keep
+  the distinction explicit: the visible default demo path is Block Directory
+  plugin install/activate via `/wp/v2/plugins`; ordinary content/design saves
+  (posts, pages, templates, template parts, global styles, navigation, media,
+  widgets, fonts) are intentionally not gated. If new editor-reachable gated
+  routes are added, update the demo instructions and `docs/ui-ux-testing-prompts.md`
+  in the same release.
+- [ ] **Playground UI demo link checked** — provide or refresh a Playground link
+  that demonstrates the current front-end/block-editor reauthentication UI. The
+  demo must land on a screen where a reviewer can trigger the challenge without
+  extra setup, or the docs must state the one required action (for example:
+  open the block inserter, search a Block Directory block, then install/activate
+  it). Verify whether the Playground environment permits installing blocks from
+  the editor; if it does not, record the blocker and keep an alternate demo path
+  or screenshot.
+- [ ] **Multisite/network-admin demo posture decided** — because Playground can
+  stage multisite, decide before release whether to ship a dedicated multisite
+  Playground blueprint/link for the network-admin context. If shipped, it should
+  demonstrate a network-admin sudo challenge (for example a network plugin,
+  network theme, site-management, or network settings action) and be listed in
+  `CONTRIBUTING.md` and `docs/ui-ux-testing-prompts.md`. If deferred, record
+  the reason and rely on the multisite Playwright/integration release gates.
 - [ ] **Package metadata sanity** — `Tested up to` reflects the current latest stable
   WordPress release (see `docs/release-status.md` → *Package metadata rule*), and
   `License: GPLv2 or later` / `GPL-2.0-or-later` is consistent across

--- a/readme.md
+++ b/readme.md
@@ -17,21 +17,21 @@ Require password confirmation before high-risk changes go through on your WordPr
 [![Type Coverage](https://shepherd.dev/github/dknauss/Sudo/coverage.svg)](https://shepherd.dev/github/dknauss/Sudo)
 [![Try latest release in Playground](https://img.shields.io/badge/Try%20release-Playground-3858e9?logo=wordpress&logoColor=white)](https://playground.wordpress.net/?blueprint-url=https%3A%2F%2Fraw.githubusercontent.com%2Fdknauss%2FSudo%2Fmain%2Fblueprint.json)
 [![Try main in Playground](https://img.shields.io/badge/Try%20main-Playground-23282d?logo=wordpress&logoColor=white)](https://playground.wordpress.net/?blueprint-url=https%3A%2F%2Fraw.githubusercontent.com%2Fdknauss%2FSudo%2Fmain%2Fblueprint-main.json)
-[![Try in-editor reauth in Playground](https://img.shields.io/badge/Try%20in--editor%20reauth-Playground-8a63d2?logo=wordpress&logoColor=white)](https://playground.wordpress.net/?blueprint-url=https%3A%2F%2Fraw.githubusercontent.com%2Fdknauss%2FSudo%2Ffeat%2Fgutenberg-reauth-increment-3%2Fblueprint-editor-reauth.json)
+[![Try in-editor reauth in Playground](https://img.shields.io/badge/Try%20in--editor%20reauth-Playground-8a63d2?logo=wordpress&logoColor=white)](https://playground.wordpress.net/?blueprint-url=https%3A%2F%2Fraw.githubusercontent.com%2Fdknauss%2FSudo%2Fmain%2Fblueprint-editor-reauth.json)
 
 Playground demo credentials are `admin` / `password`. When Sudo asks for reauthentication, enter the same password: `password`.
 
-## In-editor reauthentication (Gutenberg — in development)
+## In-editor reauthentication (Gutenberg — Milestone A)
 
 When a gated action trips Sudo *inside the block editor* — for example, installing or activating a block from the inserter's Block Directory — reauthentication happens in place: a password modal opens over the editor, grants the sudo session, and transparently resumes the original request. No full-page redirect, and the editor state is preserved.
 
-[**Try the in-editor reauth demo in Playground →**](https://playground.wordpress.net/?blueprint-url=https%3A%2F%2Fraw.githubusercontent.com%2Fdknauss%2FSudo%2Ffeat%2Fgutenberg-reauth-increment-3%2Fblueprint-editor-reauth.json) In the editor, open the inserter (**+**), search a Block-Directory block (e.g. *Icon Block*), and install it — the modal appears; enter `password` to continue.
+[**Try the in-editor reauth demo in Playground →**](https://playground.wordpress.net/?blueprint-url=https%3A%2F%2Fraw.githubusercontent.com%2Fdknauss%2FSudo%2Fmain%2Fblueprint-editor-reauth.json) In the editor, open the inserter (**+**), search a Block-Directory block (e.g. *Icon Block*), and install it — the modal appears; enter `password` to continue.
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/dknauss/Sudo/feat/gutenberg-reauth-increment-3/assets/editor-reauth-modal.png" alt="WP Sudo &quot;Confirm your identity&quot; reauthentication modal open over the WordPress block editor." width="80%">
+  <img src="https://raw.githubusercontent.com/dknauss/Sudo/main/assets/editor-reauth-modal.png" alt="WP Sudo &quot;Confirm your identity&quot; reauthentication modal open over the WordPress block editor." width="80%">
 </p>
 
-> This is unreleased work on the `feat/gutenberg-reauth-increment-3` branch; the demo installs the plugin from that branch. Password-only for now — accounts with two-factor fall back to the standard challenge page (2FA in the modal is planned).
+> This has merged to `main` (Milestone A) but is not yet in a tagged release; the demo installs the plugin from `main`. Password-only for now — accounts with two-factor skip the in-editor modal and use the standard challenge page (in-modal 2FA is planned for Milestone B).
 
 ## Screenshots
 

--- a/readme.md
+++ b/readme.md
@@ -25,7 +25,7 @@ Playground demo credentials are `admin` / `password`. When Sudo asks for reauthe
 
 When a gated action trips Sudo *inside the block editor* — for example, installing or activating a block from the inserter's Block Directory — reauthentication happens in place: a password modal opens over the editor, grants the sudo session, and transparently resumes the original request. No full-page redirect, and the editor state is preserved.
 
-[**Try the in-editor reauth demo in Playground →**](https://playground.wordpress.net/?blueprint-url=https%3A%2F%2Fraw.githubusercontent.com%2Fdknauss%2FSudo%2Fmain%2Fblueprint-editor-reauth.json) In the editor, open the inserter (**+**), search a Block-Directory block (e.g. *Icon Block*), and install it — the modal appears; enter `password` to continue.
+[**Try the in-editor reauth demo in Playground →**](https://playground.wordpress.net/?blueprint-url=https%3A%2F%2Fraw.githubusercontent.com%2Fdknauss%2FSudo%2Fmain%2Fblueprint-editor-reauth.json) In the editor, open the inserter (**+**), search a Block-Directory block (e.g. *contact form*), and install it — the modal appears; enter `password` to continue.
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/dknauss/Sudo/main/assets/editor-reauth-modal.png" alt="WP Sudo &quot;Confirm your identity&quot; reauthentication modal open over the WordPress block editor." width="80%">


### PR DESCRIPTION
## Summary

Pre-release documentation pass: track the Playground demos, canonicalize the editor-scope reference, and open a research backlog item for an MU-plugin role/capability lockdown mode. Started as codex's draft (`5d00893`); this PR adds a review pass (`a1e4fcf`, `35ad3ed`) that fixes a **broken demo**, deduplicates docs to a single canonical source, and records an empirical Playground verification.

## What's in here

- **`.planning/todos/pending/…-mu-role-cap-lockdown-mode.md`** — new research backlog for a file-manifest-backed lockdown mode that detects/denies/repairs DB-stored role/cap drift (the gap direct `$wpdb` writes leave open past the escalation guard). Includes reviewer notes sharpening the open questions before any design phase.
- **`blueprint-editor-reauth.json`** — repointed the plugin install target to `main.zip` (see broken-demo fix below).
- **`readme.md`** — repointed the in-editor-reauth badge, demo link, and screenshot to `main`; corrected the release-state prose (merged to `main` / Milestone A, not yet tagged); noted 2FA accounts skip the in-editor modal; and swapped the demo's example search term to one verified in Playground.
- **`CONTRIBUTING.md` / `docs/ui-ux-testing-prompts.md`** — collapsed a duplicated "editor-triggered sudo challenge scope" table down to one canonical copy (see canonical-doc decision below).
- **`docs/ROADMAP.md`, `docs/wporg-submission-checklist.md`** — pre-release tracking updates.

## Review findings

**1. Critical — the in-editor demo was broken.** `blueprint-editor-reauth.json` and `readme.md` installed the plugin from the branch `feat/gutenberg-reauth-increment-3`, which was deleted when its PR squash-merged. Playground failed at the `installPlugin` step with a 404. Fixed by repointing all references (blueprint zip URL + 4 readme links/prose spots) to `main`.

**2. Empirical verification — the fixed demo works end-to-end in Playground.** Booted the fixed blueprint and walked the full flow:
   - Boots clean to the block editor, session-less (0 console errors — the dead-branch 404 is gone).
   - Block Directory install works in Playground (the CORS proxy returns installable blocks).
   - Clicking **Install block** → `POST wp/v2/plugins` → `403 sudo_required` → the apiFetch middleware intercepts and opens the in-editor modal, with the correct generic copy ("This action requires reauthentication" — no rule label leaked).
   - Entering the password grants the session, dismisses the modal, and the original install **transparently resumes**: the block (`gutena/forms`) installs and is inserted into the canvas.
   - The readme example search term was changed to `contact form` (verified to return Block-Directory results) since the prior "Icon Block" is now ambiguous against the built-in "Icon" block.

**3. Canonical-doc decision.** The editor-triggered sudo challenge scope was documented in two places (`CONTRIBUTING.md` and `docs/ui-ux-testing-prompts.md`). Chose **`docs/ui-ux-testing-prompts.md §6c` as canonical** — it is the structured UI/UX reference already linked from CLAUDE.md's doc index, and scope belongs with the testing prompts that exercise it. `CONTRIBUTING.md` now carries a one-line takeaway plus a link, so the two can't drift. Added the 2FA-skip note to the canonical copy only.

**4. Technical claims verified.** All third-party/internal references in codex's draft were checked against the code (caps, rule IDs, constants, the escalation guard boundary, the npm/blueprint targets) — accurate, no confabulation.

## Test plan

- [x] Fixed blueprint boots in Playground with no console errors
- [x] Block Directory install trips the in-editor sudo modal (generic copy, no label leak)
- [x] Password confirm resumes the install transparently (block inserted)
- [ ] CI (docs-lint et al.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
