### PR TITLE
chore: ignore .codex/ and .playwright-mcp/ agent artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,8 @@ test-results/
 
 # Agent stuff (Claude / LLMs)
 .claude/
+.codex/
+.playwright-mcp/
 
 # VS Code workspace files and settings
 *.code-workspace


### PR DESCRIPTION
Local scratch dirs from agent tooling (codex; Playwright MCP screenshots) that were showing up as untracked. `.playwright-mcp-output/` was already ignored — add the actual `.playwright-mcp/` output dir and `.codex/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)