### PR TITLE
fix(challenge): strip provider _ajax_nonce before the full-page 2FA submit

### DIFF
--- a/admin/js/wp-sudo-challenge.js
+++ b/admin/js/wp-sudo-challenge.js
@@ -194,10 +194,15 @@
 			var body = new FormData(twofaForm);
 
 			// The Two Factor provider's authentication_page() may render hidden
-			// fields named "action" and "_wpnonce". Delete them before setting
-			// ours so the AJAX request hits our handler, not the provider's.
+			// fields named "action", "_wpnonce", or "_ajax_nonce". Delete them
+			// before setting ours so the AJAX request hits our handler, not the
+			// provider's, and carries our nonce. `_ajax_nonce` is load-bearing:
+			// check_ajax_referer() reads $_REQUEST['_ajax_nonce'] BEFORE
+			// '_wpnonce', so a provider-emitted one would take precedence over the
+			// value we append and fail verification.
 			body.delete('action');
 			body.delete('_wpnonce');
+			body.delete('_ajax_nonce');
 			body.append('action', config.tfaAction);
 			body.append('_wpnonce', config.nonce);
 			if (config.stashKey) {

--- a/docs/current-metrics.md
+++ b/docs/current-metrics.md
@@ -20,10 +20,10 @@ Verification environment: local workspace, PHP 8.x
 | Metric | Value | Verification |
 |---|---:|---|
 | Production PHP lines (`includes/`, `wp-sudo.php`, `uninstall.php`, `mu-plugin/`, `bridges/`) | 17,910 | `find ./includes ./wp-sudo.php ./uninstall.php ./mu-plugin ./bridges -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
-| Tests PHP lines (`tests/`) | 37,716 | `find ./tests -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
-| Production + tests PHP lines | 55,626 | sum of the two rows above |
-| Test-to-production ratio | 2.11:1 | `37716 / 17910` |
-| Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`, `.claude/`) | 56,767 | `find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/vendor_test/*" ! -path "*/.tmp/*" ! -path "*/.git/*" ! -path "*/.claude/*" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Tests PHP lines (`tests/`) | 37,717 | `find ./tests -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Production + tests PHP lines | 55,627 | sum of the two rows above |
+| Test-to-production ratio | 2.11:1 | `37717 / 17910` |
+| Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`, `.claude/`) | 56,768 | `find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/vendor_test/*" ! -path "*/.tmp/*" ! -path "*/.git/*" ! -path "*/.claude/*" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
 
 ## Footprint & Performance
 

--- a/tests/e2e/fixtures/wp-sudo-e2e-two-factor.php
+++ b/tests/e2e/fixtures/wp-sudo-e2e-two-factor.php
@@ -111,6 +111,7 @@ add_action(
 		<?php if ( '1' === (string) get_user_meta( $user->ID, '_wp_sudo_e2e_two_factor_provider_hidden_fields', true ) ) : ?>
 			<input type="hidden" name="action" value="e2e_provider_shadow_action" />
 			<input type="hidden" name="_wpnonce" value="e2e-provider-shadow-nonce" />
+			<input type="hidden" name="_ajax_nonce" value="e2e-provider-shadow-ajax-nonce" />
 		<?php endif; ?>
 		<?php if ( '1' === (string) get_user_meta( $user->ID, '_wp_sudo_e2e_two_factor_use_provider', true ) ) : ?>
 			<input

--- a/tests/e2e/specs/challenge.spec.ts
+++ b/tests/e2e/specs/challenge.spec.ts
@@ -877,7 +877,13 @@ test.describe( 'Challenge flow', () => {
     } );
 
     /**
-     * CHAL-08: Provider-rendered hidden action/_wpnonce fields must not break the AJAX 2FA submit.
+     * CHAL-08: Provider-rendered hidden action/_wpnonce/_ajax_nonce fields must not break the AJAX 2FA submit.
+     *
+     * The submit handler deletes all three reserved names from the FormData before
+     * appending WP Sudo's own. `_ajax_nonce` is load-bearing: check_ajax_referer()
+     * reads $_REQUEST['_ajax_nonce'] BEFORE '_wpnonce', so a provider-emitted one
+     * that survived would take precedence over WP Sudo's appended nonce and fail
+     * verification — the flow below would then never redirect.
      */
     test( 'CHAL-08: provider hidden fields do not interfere with AJAX 2FA submit', async ( {
         page,
@@ -896,6 +902,11 @@ test.describe( 'Challenge flow', () => {
             await expect(
                 page.locator( '#wp-sudo-challenge-2fa-form input[name="_wpnonce"][value="e2e-provider-shadow-nonce"]' ),
                 'Test fixture must render a provider-style hidden nonce field for this regression'
+            ).toHaveCount( 1 );
+
+            await expect(
+                page.locator( '#wp-sudo-challenge-2fa-form input[name="_ajax_nonce"][value="e2e-provider-shadow-ajax-nonce"]' ),
+                'Test fixture must render a provider-style hidden _ajax_nonce field for this regression'
             ).toHaveCount( 1 );
 
             await page.fill( '#wp-sudo-e2e-two-factor-code', E2E_TWO_FACTOR_CODE );


### PR DESCRIPTION
Follow-up from the #185 review. The in-editor 2FA fix (`4a910a1`) excluded reserved routing/CSRF names from the serialized POST; its sibling — the **full-page** challenge's 2FA submit in `admin/js/wp-sudo-challenge.js` — had the same class of gap for `_ajax_nonce`.

## The gap
The 2FA submit builds a `FormData` from the provider-rendered form and deletes `action`/`_wpnonce` before appending WP Sudo's own — but not `_ajax_nonce`. `check_ajax_referer()` reads `$_REQUEST['_ajax_nonce']` **before** `_wpnonce`, so a provider- or `wp_sudo_render_two_factor_fields` hook-emitted `_ajax_nonce` hidden field would take precedence over WP Sudo's appended nonce and fail verification.

## Fix
Add `body.delete('_ajax_nonce')` alongside the existing deletes — parity with the in-editor modal fix and the full-page `action`/`_wpnonce` guard.

## Test
**CHAL-08** (the existing "provider hidden fields don't interfere" regression) now:
- the `wp-sudo-e2e-two-factor` fixture also renders a shadow `_ajax_nonce` hidden field, and
- the test asserts it is present and that the 2FA submit still redirects to a granted session.

RED without the delete (the bogus `_ajax_nonce` clobbers the nonce → no redirect); GREEN with it. Runs in the wp-env E2E lane (CI); JS + PHP fixture syntax verified locally.

## Playground
No blueprint changes needed: `blueprint.json` correctly pins the latest release (`v4.6.0`), and the `main`-tracking blueprints (incl. `blueprint-editor-reauth.json`) already serve current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)