### PR TITLE
ci: harden wp-env startup against hangs in E2E workflows

### DIFF
--- a/.github/workflows/e2e-visual.yml
+++ b/.github/workflows/e2e-visual.yml
@@ -32,18 +32,7 @@ jobs:
         run: npx playwright install --with-deps chromium
 
       - name: Start WordPress environment
-        run: npx wp-env start --config .wp-env.e2e.json
-
-      - name: Wait for WordPress to be ready
-        run: |
-          for i in $(seq 1 30); do
-            if curl -s -o /dev/null -w "%{http_code}" http://localhost:8889/wp-login.php | grep -q "200"; then
-              echo "WordPress is ready"
-              break
-            fi
-            echo "Waiting for WordPress... (attempt $i)"
-            sleep 2
-          done
+        run: bash bin/wp-env-up.sh .wp-env.e2e.json
 
       - name: Assert pinned WordPress beta version
         env:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -117,18 +117,7 @@ jobs:
         run: npx playwright install --with-deps chromium
 
       - name: Start WordPress environment
-        run: npx wp-env start --config .wp-env.e2e.json
-
-      - name: Wait for WordPress to be ready
-        run: |
-          for i in $(seq 1 30); do
-            if curl -s -o /dev/null -w "%{http_code}" http://localhost:8889/wp-login.php | grep -q "200"; then
-              echo "WordPress is ready"
-              break
-            fi
-            echo "Waiting for WordPress... (attempt $i)"
-            sleep 2
-          done
+        run: bash bin/wp-env-up.sh .wp-env.e2e.json
 
       - name: Assert pinned WordPress beta version
         env:

--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -88,7 +88,9 @@ jobs:
           JSON
 
       - name: Start WordPress
-        run: wp-env start --config .tmp/plugin-check-wp-env.json
+        env:
+          WP_ENV_BIN: wp-env
+        run: bash bin/wp-env-up.sh .tmp/plugin-check-wp-env.json http://localhost:8880/wp-login.php
 
       - name: Install Plugin Check
         run: wp-env --config .tmp/plugin-check-wp-env.json run cli wp plugin install plugin-check --activate

--- a/.github/workflows/release-confidence.yml
+++ b/.github/workflows/release-confidence.yml
@@ -36,19 +36,7 @@ jobs:
         run: npx playwright install --with-deps chromium
 
       - name: Start WordPress environment
-        run: npx wp-env start --config .wp-env.e2e.json
-
-      - name: Wait for WordPress to be ready
-        run: |
-          for i in $(seq 1 30); do
-            if curl -s -o /dev/null -w "%{http_code}" http://localhost:8889/wp-login.php | grep -q "200"; then
-              echo "WordPress is ready"
-              exit 0
-            fi
-            echo "Waiting for WordPress... (attempt $i)"
-            sleep 2
-          done
-          exit 1
+        run: bash bin/wp-env-up.sh .wp-env.e2e.json
 
       - name: Assert pinned WordPress beta version
         env:

--- a/bin/wp-env-up.sh
+++ b/bin/wp-env-up.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Bring up the wp-env Docker stack for CI, resiliently.
+#
+# `wp-env start` boots a Docker WordPress+DB stack (image pulls, container boot,
+# WP install). A transient Docker/registry stall can leave it hanging with no
+# output; unbounded, that hang consumes the entire job timeout (~30 min) and the
+# run dies with no useful signal. Playwright's own retries do not help — they
+# re-run tests, not the environment bring-up.
+#
+# This wrapper:
+#   1. bounds each `wp-env start` attempt with a hard timeout,
+#   2. tears the partial stack down and retries from a clean slate on failure,
+#   3. verifies the site actually answers HTTP 200 before returning,
+# so a stalled boot fails fast and self-heals instead of eating the job, and
+# downstream test steps never start against a half-booted stack.
+#
+# Usage: bin/wp-env-up.sh [config-path] [ready-url]
+# Tunables (env): WP_ENV_BIN (default "npx wp-env"; set "wp-env" when the tool
+#                 is installed globally), WP_ENV_START_ATTEMPTS,
+#                 WP_ENV_START_TIMEOUT, WP_ENV_READY_TRIES, WP_ENV_READY_SLEEP
+set -uo pipefail
+
+CONFIG="${1:-.wp-env.e2e.json}"
+READY_URL="${2:-http://localhost:8889/wp-login.php}"
+ATTEMPTS="${WP_ENV_START_ATTEMPTS:-3}"
+ATTEMPT_TIMEOUT="${WP_ENV_START_TIMEOUT:-360}"   # seconds per start attempt
+READY_TRIES="${WP_ENV_READY_TRIES:-30}"          # readiness polls
+READY_SLEEP="${WP_ENV_READY_SLEEP:-2}"           # seconds between polls
+
+# wp-env invocation, split into an array so a two-word default ("npx wp-env")
+# and a one-word global install ("wp-env") both expand safely.
+read -r -a WP_ENV <<< "${WP_ENV_BIN:-npx wp-env}"
+
+ready() {
+	local i code
+	for i in $(seq 1 "${READY_TRIES}"); do
+		code="$(curl -s -o /dev/null -w '%{http_code}' "${READY_URL}" || true)"
+		if [ "${code}" = "200" ]; then
+			echo "WordPress is ready (${READY_URL})"
+			return 0
+		fi
+		echo "Waiting for WordPress... (poll ${i}/${READY_TRIES}, last=${code:-none})"
+		sleep "${READY_SLEEP}"
+	done
+	return 1
+}
+
+for attempt in $(seq 1 "${ATTEMPTS}"); do
+	echo "::group::wp-env start (attempt ${attempt}/${ATTEMPTS}, ${ATTEMPT_TIMEOUT}s cap)"
+	timeout -k 30 "${ATTEMPT_TIMEOUT}" "${WP_ENV[@]}" start --config "${CONFIG}"
+	start_status=$?
+	echo "::endgroup::"
+
+	if [ "${start_status}" -eq 0 ] && ready; then
+		echo "wp-env up on attempt ${attempt}"
+		exit 0
+	fi
+
+	echo "::warning::wp-env not ready on attempt ${attempt} (start exit ${start_status})"
+	if [ "${attempt}" -lt "${ATTEMPTS}" ]; then
+		echo "::group::docker state + wp-env destroy (cleanup before retry)"
+		docker ps -a || true
+		printf 'y\n' | timeout 120 "${WP_ENV[@]}" destroy --config "${CONFIG}" || true
+		echo "::endgroup::"
+	fi
+done
+
+echo "::error::wp-env failed to come up after ${ATTEMPTS} attempts" >&2
+exit 1


### PR DESCRIPTION
## Problem

The `Start WordPress environment` step ran `npx wp-env start` with **no timeout**. `wp-env start` boots a Docker WordPress+DB stack (image pulls, container boot, WP install); a transient Docker/registry stall leaves it hanging with no output, consuming the entire 30-min job `timeout-minutes` before the separate readiness curl-loop ever runs. Playwright's own `retries` don't help — they re-run tests, not env bring-up.

Two of the three readiness loops also used `break` (not a failing exit), so a **half-booted stack silently proceeded to tests**, producing confusing downstream failures.

## Fix

New **`bin/wp-env-up.sh`**:
- bounds each `wp-env start` attempt with `timeout -k 30 ${WP_ENV_START_TIMEOUT:-360}`,
- retries up to `${WP_ENV_START_ATTEMPTS:-3}` times, tearing the partial stack down with `wp-env destroy` between attempts,
- then polls the site for **HTTP 200** and **exits non-zero if it never comes up** (fixes the silent `break` fall-through),
- `WP_ENV_BIN` selects `npx wp-env` (default) vs a global `wp-env`, array-split so both expand safely.

Worst-case wall clock ≈ 3×360s + readiness ≈ 18 min, safely under the 30-min job cap; happy path returns in ~60–120s.

Workflows updated to call it, collapsing the start+readiness step pair into one:
- `e2e.yml`, `e2e-visual.yml`, `release-confidence.yml` — `bash bin/wp-env-up.sh .wp-env.e2e.json` (port 8889)
- `plugin-check.yml` — `WP_ENV_BIN=wp-env bash bin/wp-env-up.sh .tmp/plugin-check-wp-env.json http://localhost:8880/wp-login.php` (global install, port 8880)

## Validation

- `bash -n bin/wp-env-up.sh` clean
- All four workflows parse (js-yaml)
- Array-split smoke-tested for both `npx wp-env` (2 words) and `wp-env` (1 word)

🤖 Generated with [Claude Code](https://claude.com/claude-code)