### PR TITLE
chore(release): bump version to 4.8.0

### DIFF
--- a/blueprint.json
+++ b/blueprint.json
@@ -19,7 +19,7 @@
       "step": "installPlugin",
       "pluginData": {
         "resource": "url",
-        "url": "https://wordpress-playground-cors-proxy.net/?https://github.com/dknauss/Sudo/archive/refs/tags/v4.7.0.zip"
+        "url": "https://wordpress-playground-cors-proxy.net/?https://github.com/dknauss/Sudo/archive/refs/tags/v4.8.0.zip"
       },
       "options": {
         "activate": true

--- a/phpstan-bootstrap.php
+++ b/phpstan-bootstrap.php
@@ -10,7 +10,7 @@
  */
 
 // Plugin constants (defined in wp-sudo.php at runtime).
-define( 'WP_SUDO_VERSION', '4.7.0' );
+define( 'WP_SUDO_VERSION', '4.8.0' );
 define( 'WP_SUDO_PLUGIN_DIR', __DIR__ . '/' );
 define( 'WP_SUDO_PLUGIN_URL', 'https://example.com/wp-content/plugins/wp-sudo/' );
 define( 'WP_SUDO_PLUGIN_BASENAME', 'wp-sudo/wp-sudo.php' );

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags:              reauthentication, access control, admin protection, multisite
 Requires at least: 6.4
 Tested up to:      7.0
 Requires PHP:      8.2
-Stable tag:        4.7.0
+Stable tag:        4.8.0
 License:           GPL-2.0-or-later
 License URI:       https://spdx.org/licenses/GPL-2.0-or-later.html
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -19,7 +19,7 @@ define( 'WPMU_PLUGIN_DIR', WP_CONTENT_DIR . '/mu-plugins' );
 define( 'WPMU_PLUGIN_URL', 'https://example.com/wp-content/mu-plugins' );
 
 // ── Plugin constants (normally defined in wp-sudo.php) ───────────────
-define( 'WP_SUDO_VERSION', '4.7.0' );
+define( 'WP_SUDO_VERSION', '4.8.0' );
 define( 'WP_SUDO_PLUGIN_DIR', dirname( __DIR__ ) . '/' );
 define( 'WP_SUDO_PLUGIN_URL', 'https://example.com/wp-content/plugins/wp-sudo/' );
 define( 'WP_SUDO_PLUGIN_BASENAME', 'wp-sudo/wp-sudo.php' );

--- a/wp-sudo.php
+++ b/wp-sudo.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Sudo – Admin Action Gating
  * Plugin URI:        https://github.com/dknauss/Sudo
  * Description:       Action-gated reauthentication for WordPress. Dangerous operations require password confirmation before they proceed — regardless of user role.
- * Version:           4.7.0
+ * Version:           4.8.0
  * Requires at least: 6.4
  * Requires PHP:      8.2
  * Author:            Dan Knauss
@@ -28,7 +28,7 @@ require_once __DIR__ . '/includes/functions-challenge-url.php';
 add_filter( 'map_meta_cap', 'wp_sudo_map_governance_meta_cap', 10, 4 );
 
 // Plugin version.
-define( 'WP_SUDO_VERSION', '4.7.0' );
+define( 'WP_SUDO_VERSION', '4.8.0' );
 
 // Plugin directory path.
 define( 'WP_SUDO_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );


### PR DESCRIPTION
Version-sync for the 4.8.0 release, per the `CLAUDE.md` checklist. Bumps `4.7.0` → `4.8.0` in all six locations:

- `wp-sudo.php` — plugin header `Version:` + `WP_SUDO_VERSION` constant
- `phpstan-bootstrap.php` — `WP_SUDO_VERSION`
- `tests/bootstrap.php` — `WP_SUDO_VERSION`
- `readme.txt` — `Stable tag`
- `blueprint.json` — Playground install target → `v4.8.0.zip`

No migration routine needed — 4.8.0's changes are code-only / opt-in. Suite green (1111 tests), PHPStan clean.

## ⚠️ Merge/tag ordering

`blueprint.json` now points at `archive/refs/tags/v4.8.0.zip`, which resolves **only once the `v4.8.0` git tag exists**. Merging this to `main` before tagging will 404 the "Try the latest release in Playground" badge. **Merge this as part of cutting the tag**, not before. (Auto-merge intentionally not enabled.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)