### PR TITLE
ci: exclude 4.8.0 security-test-results log from docs-lint

### DIFF
--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -31,6 +31,7 @@ jobs:
             "docs/e2e-runtime-review.md"
             "docs/llm-lies-log.md"
             "docs/release-status.md"
+            "docs/security-test-results-4.8.0.md"
             "docs/release-environment-log.md"
             "docs/security-model.md"
             "docs/two-factor-authentication-flow.md"


### PR DESCRIPTION
`docs/security-test-results-4.8.0.md` is a dated point-in-time record; its fixed date is correct. Adds it to docs-lint EXCLUDED_FILES so main's docs-lint passes.