### PR TITLE
docs: acknowledge John Blackbourn and Tim Nash

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -235,6 +235,13 @@ composer analyse
 
 For full setup, integration tests, E2E workflows, and contributor expectations, see [CONTRIBUTING.md](CONTRIBUTING.md).
 
+## Acknowledgements
+
+Sudo's core design owes a debt to two people:
+
+- **John Blackbourn**, for the action-gating concept — that consequential operations should require a fresh proof of intent, regardless of role. It is the single biggest conceptual contribution to the project.
+- **Tim Nash**, for the idea of locking down roles and permissions, which became Sudo's admin-escalation guard (refusing to grant administrator or super-admin without an active sudo session) and its role and capability lockdown.
+
 ## License
 
 GPL-2.0-or-later.

--- a/readme.md
+++ b/readme.md
@@ -240,7 +240,7 @@ For full setup, integration tests, E2E workflows, and contributor expectations, 
 Sudo's core design owes a debt to two people:
 
 - **John Blackbourn**, for the action-gating concept — that consequential operations should require a fresh proof of intent, regardless of role. It is the single biggest conceptual contribution to the project.
-- **Tim Nash**, for the idea of locking down roles and permissions, which became Sudo's admin-escalation guard (refusing to grant administrator or super-admin without an active sudo session) and its role and capability lockdown.
+- **Tim Nash**, for the idea of locking down roles and permissions, which shaped Sudo's opt-in admin-escalation guard and its opt-in role/capability lockdown audit.
 
 ## License
 

--- a/readme.txt
+++ b/readme.txt
@@ -170,6 +170,13 @@ CI: GitHub Actions runs PHPStan level 6 and PHPCS on every push and PR, unit tes
 
 Extensibility: the action registry is filterable via wp_sudo_gated_actions. Audit hooks cover session lifecycle, gated actions, policy decisions, preset application, lockouts, tamper detection, and the high-severity admin-escalation block. See the GitHub repository for hook reference, CONTRIBUTING.md, and the full developer documentation.
 
+== Acknowledgements ==
+
+Sudo's core design owes a debt to two people:
+
+* **John Blackbourn**, for the action-gating concept — that consequential operations should require a fresh proof of intent, regardless of role. It is the single biggest conceptual contribution to the project.
+* **Tim Nash**, for the idea of locking down roles and permissions, which became Sudo's admin-escalation guard (refusing to grant administrator or super-admin without an active sudo session) and its role and capability lockdown.
+
 == Screenshots ==
 
 1. Challenge page — reauthentication interstitial with password field.

--- a/readme.txt
+++ b/readme.txt
@@ -175,7 +175,7 @@ Extensibility: the action registry is filterable via wp_sudo_gated_actions. Audi
 Sudo's core design owes a debt to two people:
 
 * **John Blackbourn**, for the action-gating concept — that consequential operations should require a fresh proof of intent, regardless of role. It is the single biggest conceptual contribution to the project.
-* **Tim Nash**, for the idea of locking down roles and permissions, which became Sudo's admin-escalation guard (refusing to grant administrator or super-admin without an active sudo session) and its role and capability lockdown.
+* **Tim Nash**, for the idea of locking down roles and permissions, which shaped Sudo's opt-in admin-escalation guard and its opt-in role/capability lockdown audit.
 
 == Screenshots ==
 


### PR DESCRIPTION
Adds an **Acknowledgements** section to `readme.txt` and `readme.md` crediting the two people behind Sudo's core ideas:

- **John Blackbourn** — the action-gating concept (consequential operations require a fresh proof of intent, regardless of role); the single biggest conceptual contribution to the project.
- **Tim Nash** — the roles/permissions lockdown idea, which became the admin-escalation guard and role/capability lockdown.

Docs-only. No version/Stable-tag change. Placed as a new top-level section (before Screenshots in readme.txt; before License in readme.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)