### PR TITLE
docs(roadmap): link per-rule sudo TTL item to #269

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -62,7 +62,8 @@ the full backlog is in the [issues](https://github.com/dknauss/Sudo/issues), lab
 - **REST sudo-grant endpoint** (`POST /wp/v2/sudo`) for headless clients.
 - **Per-session / device sudo isolation** via `WP_Session_Tokens` — deferred:
   architectural, not a hardening item.
-- **Per-rule / per-action sudo TTL** — a shorter sudo window for the highest-risk
+- **Per-rule / per-action sudo TTL** ([#269](https://github.com/dknauss/Sudo/issues/269), `priority: low`) —
+  a shorter sudo window for the highest-risk
   rules (e.g. `user.delete`, `options.critical`) than for routine ones (e.g.
   `plugin.activate`), instead of one global `session_duration`. Borrowed (adapted to
   WP Sudo's per-rule, role-agnostic model) from Fortress's per-capability timeout


### PR DESCRIPTION
Adds the `(#269)` tracking-issue reference and `priority: low` label to the **Per-rule / per-action sudo TTL** item under ROADMAP → Later, matching how other roadmap items cite their issues (#239, #240). Follow-up to #266.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)