### PR TITLE
docs(roadmap): re-surface in-editor session-status indicator (#262)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -52,6 +52,14 @@ the full backlog is in the [issues](https://github.com/dknauss/Sudo/issues), lab
 - **Test-scaffolding hardening** — blueprint rot-guard smoke lane (do first),
   tag-pinned blueprint copies at each release, and run the release environment matrix
   every release.
+- **In-editor sudo session-status indicator — client UI** ([#262](https://github.com/dknauss/Sudo/issues/262), `priority: low`) —
+  complete the half-shipped indicator. The server-side feed (localized `remaining`,
+  gated on `is_active()`) and a design brief
+  ([`in-editor-session-indicator-design-brief.md`](in-editor-session-indicator-design-brief.md))
+  shipped in #204; the client UI remains — a `core/notices` snackbar baseline (WP 6.4+
+  floor) plus a feature-detected `PluginSidebar`/header countdown (WP 6.6+, degrading to
+  the snackbar). Distinct from the shipped in-editor reauth *modal* (Milestones A/B,
+  v4.6/4.7).
 
 ## Later (need design work)
 


### PR DESCRIPTION
Re-adds the **in-editor sudo session-status indicator** to ROADMAP → Next. It's half-shipped — the server-side data feed and design brief landed in #204 — but fell out of the roadmap during the #258 forward-only restructure. Entry clarifies it's distinct from the already-shipped in-editor reauth *modal* (Milestones A/B, v4.6/4.7).

Companion to labeling #262 (`enhancement`, `priority: low`). Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)