### PR TITLE
docs(roadmap): link #262 draft skeletons + fix broken brief link

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -54,12 +54,14 @@ the full backlog is in the [issues](https://github.com/dknauss/Sudo/issues), lab
   every release.
 - **In-editor sudo session-status indicator — client UI** ([#262](https://github.com/dknauss/Sudo/issues/262), `priority: low`) —
   complete the half-shipped indicator. The server-side feed (localized `remaining`,
-  gated on `is_active()`) and a design brief
-  ([`in-editor-session-indicator-design-brief.md`](in-editor-session-indicator-design-brief.md))
-  shipped in #204; the client UI remains — a `core/notices` snackbar baseline (WP 6.4+
-  floor) plus a feature-detected `PluginSidebar`/header countdown (WP 6.6+, degrading to
-  the snackbar). Distinct from the shipped in-editor reauth *modal* (Milestones A/B,
-  v4.6/4.7).
+  gated on `is_active()`) shipped in #204; the cross-module contract, a
+  [design brief](../.planning/in-editor-session-indicator-design-brief.md), and
+  implementation-ready
+  [draft skeletons](../.planning/262-implementation-draft.md) landed in #274. The client
+  UI remains — a `core/notices` snackbar baseline (WP 6.4+ floor) plus a feature-detected
+  `PluginSidebar`/header countdown (WP 6.6+, degrading to the snackbar); it needs a
+  browser-capable session to build + E2E-verify. Distinct from the shipped in-editor
+  reauth *modal* (Milestones A/B, v4.6/4.7).
 
 ## Later (need design work)
 


### PR DESCRIPTION
Updates the ROADMAP in-editor indicator entry to link the implementation-draft skeletons (`.planning/262-implementation-draft.md`, from #274), and **fixes a broken link**: the design-brief reference was a bare relative path resolving to `docs/` when the brief actually lives in `.planning/` — corrected to `../.planning/`. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)