### PR TITLE
docs(roadmap): fix broken in-editor design-brief link (unblocks CI)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -55,7 +55,7 @@ the full backlog is in the [issues](https://github.com/dknauss/Sudo/issues), lab
 - **In-editor sudo session-status indicator — client UI** ([#262](https://github.com/dknauss/Sudo/issues/262), `priority: low`) —
   complete the half-shipped indicator. The server-side feed (localized `remaining`,
   gated on `is_active()`) and a design brief
-  ([`in-editor-session-indicator-design-brief.md`](in-editor-session-indicator-design-brief.md))
+  ([`in-editor-session-indicator-design-brief.md`](../.planning/in-editor-session-indicator-design-brief.md))
   shipped in #204; the client UI remains — a `core/notices` snackbar baseline (WP 6.4+
   floor) plus a feature-detected `PluginSidebar`/header countdown (WP 6.6+, degrading to
   the snackbar). Distinct from the shipped in-editor reauth *modal* (Milestones A/B,


### PR DESCRIPTION
## Why

`#272` added a ROADMAP link to the in-editor indicator design brief as `in-editor-session-indicator-design-brief.md`, which resolves relative to `docs/` — but the brief lives at `.planning/in-editor-session-indicator-design-brief.md`. The `Markdown link and anchor check` (lychee) runs on **push to `main`** and on every **PR merge commit**, so this dead link turned `main` red and is blocking unrelated PRs (surfaced on #268).

## Fix

One line: point the link at `../.planning/in-editor-session-indicator-design-brief.md` (the real, tracked path). Verified the target resolves.

Alternative the maintainer may prefer: move the brief from `.planning/` into `docs/` (a published location) and keep the original link — but that's a larger call; this PR is the minimal unblock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)