### PR TITLE
docs: correct spec Acknowledgments to maintainer-confirmed attributions

### DIFF
--- a/docs/core-sudo-gate-implementation-spec.md
+++ b/docs/core-sudo-gate-implementation-spec.md
@@ -353,11 +353,10 @@ Seen from the other side, once core owns the primitive this posture layer become
 
 ## Acknowledgments
 
-This spec builds on prior art, tickets, and input from people across the WordPress community. Named here for their relevant work; any errors are the authors', not theirs.
+Named here only for contributions confirmed by the maintainer. The **"gate the effect, not the field"** framing is a WP Sudo concept and is deliberately left **uncredited**.
 
-- **John James Jacoby** and **Jeremy Felt** — the network-role / "network administrator" vs. "super admin" terminology work in [#37593](https://core.trac.wordpress.org/ticket/37593) and [#39174](https://core.trac.wordpress.org/ticket/39174), which this spec's multisite naming follows (§8). *(An earlier draft mis-cited these tickets as recent-auth prior art; they concern multisite role terminology, not sudo mode.)*
-- **John Blackbourn** ([@johnbillion](https://github.com/johnbillion)) — owner of [#16470](https://core.trac.wordpress.org/ticket/16470) (single-site email-change confirmation), whose `send_confirmation_on_profile_email()` flow the email-change chokepoint must accommodate (§4.1), and long-running WordPress core security work.
-- **Timothy Jacobs** (@TimothyBlynJacobs) — the WordPress REST API architecture this spec's cookie-REST enforcement and controller surfacing build on (§5.2, §6 row 13).
-- **Tim Nash** — WordPress security guidance informing the threat model and the "gate the effect, not the field" framing (§2, §3).
-- **Calvin Alkan** (Snicco / Fortress) — Fortress's server-side session-hardening and sudo-mode prior art (see [`sudo-architecture-comparison-matrix.md`](sudo-architecture-comparison-matrix.md)), and the scoping challenge that sharpened the core/plugin boundary and the not-a-SIEM non-goal (§1, §11).
-- The WordPress core contributors on the cited Trac tickets ([#20140](https://core.trac.wordpress.org/ticket/20140), #37593, #39174, #16470) and the maintainers of the surveyed protection layers.
+- **John Blackbourn** ([@johnbillion](https://github.com/johnbillion)) — the **action-gating concept** itself: the foundational idea behind WP Sudo and this spec, alongside his long-running WordPress core security work.
+- **Tim Nash** — the **roles/permissions lockdown** idea, which maps to WP Sudo's admin-escalation guard and role/capability lockdown work.
+- **Calvin Alkan** (Snicco / Fortress) — critical feedback on WP Sudo and Fortress as inspiration (see [`sudo-architecture-comparison-matrix.md`](sudo-architecture-comparison-matrix.md)); the argument that a regular plugin cannot achieve this on its own — a core motivation for moving parts of it into WordPress core; and the "this is becoming a SIEM" critique that shaped the explicit **not-a-SIEM** non-goal (§1, §11).
+
+Prior art and tickets are referenced impersonally in the body: WordPress core Trac [#20140](https://core.trac.wordpress.org/ticket/20140) (recent auth for consequential actions) and [#16470](https://core.trac.wordpress.org/ticket/16470) (single-site email-change confirmation, whose `send_confirmation_on_profile_email()` flow §4.1 must accommodate), plus the surveyed protection layers.

--- a/docs/llm-lies-log.md
+++ b/docs/llm-lies-log.md
@@ -644,6 +644,32 @@ Repos:   wp-sudo, wordpress-2fa-ecosystem
            before reporting an item "addressed/done," verify the artifact exists; do not
            treat thread-resolution or a merge as proof the work shipped.
 
+36. MISATTRIBUTED ACKNOWLEDGMENTS — public credit to real WordPress contributors
+   Files:  docs/core-sudo-gate-implementation-spec.md § Acknowledgments.
+   Claim:  Credited Tim Nash with the "gate the effect, not the field" framing;
+           credited John Blackbourn only as owner of Trac #16470 (email-change);
+           credited Timothy Jacobs for "the REST API architecture this spec builds
+           on"; and credited J.J. Jacoby / Jeremy Felt (#37593/#39174) as relevant
+           prior art.
+   Reality: Wrong or unsourced, and several contradicted the maintainer's own
+           recorded attributions. Per Dan: Blackbourn gave the ACTION-GATING CONCEPT
+           (the foundational idea), not merely an email-change ticket; Tim Nash gave
+           the ROLES/PERMISSIONS LOCKDOWN idea and must NOT be tied to "gate the
+           effect, not the field" (a deliberately uncredited WP Sudo concept).
+           Timothy Jacobs was a general WP-security educator years ago, nothing
+           Sudo-specific; JJJ/Felt are "on various tickets but not clearly related."
+           The one real acknowledgment — Calvin Alkan's critical feedback, Fortress
+           inspiration, the "a plugin can't do this -> needs core" argument, and the
+           "becoming a SIEM" critique behind the not-a-SIEM non-goal — was flattened
+           to a vague "scoping challenge."
+   Rule:   A project memory (sudo-contributor-attributions) recorded the correct
+           attributions specifically to prevent this; the section was written against
+           it anyway. Getting public credit to a prominent contributor wrong is
+           harmful and hard to walk back.
+   Fix:    Rewrote to the maintainer-confirmed attributions (Blackbourn = concept,
+           Nash = lockdown, Alkan = feedback/Fortress/why-core/SIEM), removed Timothy
+           Jacobs and JJJ/Felt, left "gate the effect, not the field" uncredited.
+
 ROOT CAUSE
 ----------
 All errors have stemmed from patterns that boil down to *not checking the 


### PR DESCRIPTION
Fixes misattributed public credit in the core-gate spec's Acknowledgments (contradicted the recorded contributor attributions). Blackbourn → action-gating concept; Nash → roles/permissions lockdown (not effect-vs-field, which stays uncredited); Alkan → corrected/enriched (feedback, Fortress, plugin-can't-do-this→core, the SIEM critique behind the not-a-SIEM non-goal); removed Timothy Jacobs and JJJ/Felt. Logged as llm-lies-log #35. Attributions confirmed by the maintainer. Docs-only.