### PR TITLE
docs(planning): commit scoped-recovery (#240) + protection-status-panel (#246) design briefs

### DIFF
--- a/.planning/240-scoped-recovery-design-brief.md
+++ b/.planning/240-scoped-recovery-design-brief.md
@@ -1,0 +1,167 @@
+# Design brief — #240: scoped break-glass recovery + Site Health critical status
+
+## Problem / threat model
+
+`WP_SUDO_RECOVERY_MODE` is the break-glass escape hatch for the "last Sudo
+manager locked out" scenario. Today `wp_sudo_is_recovery_mode()` treats the
+constant as boolean-only: while it is defined truthy, **every** user who still
+holds `manage_options` (single-site) / `manage_network_options` (multisite)
+regains full `manage_wp_sudo` governance authority. On a site with several
+administrators that is a wider blast radius than break-glass needs — the failure
+mode being contained is "one specific admin is locked out," not "all admins
+lost governance." A permanent-if-forgotten, all-admins grant is the risk.
+
+Second gap: recovery mode has no Site Health surface. An operator who defines
+the constant during an incident and forgets to remove it gets only the in-admin
+notice (visible only while on a Sudo screen). There is no health-dashboard
+signal that the governance model is currently weakened.
+
+## Proposed approach
+
+Two independent, additive changes to `includes/functions-governance.php` and
+`includes/class-site-health.php`.
+
+### 1. Scoped recovery user
+
+Allow `define( 'WP_SUDO_RECOVERY_MODE', <user_id | user_login> )` to scope the
+grant to a single user. Semantics, chosen to preserve the existing contract:
+
+- **`true` (strict boolean)** → unscoped legacy behavior: any admin passes the
+  role gate, exactly as today. Backward-compatible.
+- **`int`** → resolve as a user **ID**; recovery grants only that user.
+- **non-empty `string`** → resolve as a user **login** via `get_user_by('login')`;
+  grants only that user. (A numeric string is treated as a login first; this is
+  documented.)
+- **falsy / unresolvable value** (`false`, `''`, `0`, a login/ID that matches no
+  user) → recovery is inactive / matches nobody. Fail-closed: an unresolvable
+  target grants no one. The operator controls wp-config and can correct a typo;
+  break-glass failing closed on a bad target is safer than granting broadly.
+
+New helpers (bootstrap-safe, in `functions-governance.php`):
+
+- `wp_sudo_recovery_mode_user(): ?int` — resolves the constant to a target user
+  ID, or `null` when unscoped (boolean `true`) **or** inactive. Note the return
+  cannot by itself distinguish "unscoped" from "inactive"; callers pair it with
+  `wp_sudo_is_recovery_mode()`.
+- `wp_sudo_user_matches_recovery( int $user_id ): bool` — the single predicate
+  both governance callers use. Returns true iff recovery is active AND
+  (`unscoped` OR `$user_id === resolved target`).
+
+`wp_sudo_is_recovery_mode()` keeps its current boolean meaning — "is recovery
+active at all" — returning true for **both** the boolean and scoped forms, so
+every existing caller/test contract (the admin notice, event recorder,
+dashboard widget label) is preserved.
+
+Wiring — replace the inline `get_current_user_id() === $user_id` current-user
+check in the two governance functions with the new predicate:
+
+- `wp_sudo_can()` path 2: add `&& wp_sudo_user_matches_recovery( $user_id )`
+  alongside the existing current-user and role-gate checks.
+- `wp_sudo_map_governance_meta_cap()`: the recovery branch already keys on
+  `get_current_user_id() === $user_id`; add the scoped predicate so a scoped
+  constant maps `manage_wp_sudo` → primitive admin cap only for the target user.
+  Non-target users fall through to the strict `array( $cap )` path (core then
+  denies, since they lack the granted governance cap).
+
+### 2. Site Health critical status
+
+Add `Site_Health::test_recovery_mode()`, registered in `register_tests()` beside
+`wp_sudo_stale_sessions` as a `direct` test. Pull-based (runs on the Site Health
+screen / `wp cli site-health`), no scheduling.
+
+- Recovery inactive → `good`: "Break-glass recovery mode is not active."
+- Recovery active → `critical`: names that the governance model is currently
+  weakened, whether it is scoped (report the target login/ID) or unscoped (any
+  admin), and instructs removing the constant from wp-config.php once normal
+  access is restored. Badge: Security.
+
+## What this explicitly blocks / does NOT block
+
+- **Blocks:** a scoped constant granting governance to any admin other than the
+  named target. Blocks a silent/undiscoverable "recovery left on" state (Site
+  Health now flags it critical).
+- **Must NOT block / must preserve:**
+  - Legacy `define( ..., true )` unscoped behavior — unchanged.
+  - The multisite super-admin short-circuit in `wp_sudo_can()` (runs before the
+    recovery branch) — super admins never depend on recovery.
+  - The role gate: even a scoped target still must hold `manage_options` /
+    `manage_network_options`. Scoping is additive, not a replacement.
+  - The reauth challenge — recovery has never bypassed it and still must not.
+  - `wp_sudo_is_recovery_mode()` returning true for the scoped form, so the
+    existing admin notice / audit hook / widget label still fire.
+
+## Open questions for the reviewer
+
+1. **`define(..., 1)` ambiguity.** An operator who wrote `1` as "truthy/on" now
+   scopes to user ID 1. The plugin has no shipped install base (release delayed,
+   per release-status.md), so back-compat cost is low — but is treating only a
+   strict boolean `true` as "unscoped" the right cut, or should there be an
+   explicit sentinel (e.g. `true` vs any scalar)? Current plan: strict `true`
+   (`=== true`) is the only unscoped form.
+2. **Numeric login vs ID.** Plan treats any string as a login first. Is an
+   int-vs-string type split the least-surprising rule, or should a numeric
+   string try ID-then-login?
+3. **Fail-closed on unresolvable target.** Is granting nobody on a bad
+   login/ID the right call for a break-glass control, given the operator can
+   still fall back to `true`?
+4. **Execution-context coverage.** `get_user_by()` is available on all admin /
+   REST / CLI / cron paths where governance checks run; the resolver adds a user
+   lookup to `wp_sudo_can()`. Any hot path where that lookup is a concern, or
+   context where `get_user_by` is unsafe/unavailable at the load point?
+5. **Multisite target resolution.** `get_user_by('login')` is network-global;
+   the role gate already uses the network cap on multisite. Any per-site
+   subtlety where a login resolves to a user not present on the current blog?
+
+---
+
+## Review incorporated (design reviewer, pre-implementation)
+
+**B1 (blocking) — no `?int`-conflation fail-open.** The grant decision lives in a
+single seam `wp_sudo_user_matches_recovery( int $user_id ): bool` that classifies
+recovery into THREE explicit states before granting, never inferring "unscoped"
+from a null target:
+- inactive → `false`;
+- **unscoped** (`wp_sudo_recovery_mode_is_unscoped()` true) → legacy behavior:
+  current-user-only match (`get_current_user_id() === $user_id`), preserving the
+  pre-scoping contract;
+- **scoped** → grant iff `wp_sudo_recovery_mode_user()` resolves to a non-null ID
+  AND `$user_id === target`. An unresolvable target (typo'd login/ID) yields
+  `null` → **matches nobody** (fail-closed). A null target is never read as
+  unscoped.
+
+**B2 (blocking) — strict unscoped detection.** `wp_sudo_recovery_mode_is_unscoped()`
+uses `true === WP_SUDO_RECOVERY_MODE` (strict). `define(...,1)` is therefore a
+scoped user-ID-1, not unscoped. `wp_sudo_is_recovery_mode()` deliberately stays
+loose (`&& WP_SUDO_RECOVERY_MODE`) so a truthy scoped value still reports
+"active"; a code comment flags the intentional strictness split.
+
+**M3 — GovernanceTest churn is in scope.** Existing recovery-branch unit tests are
+re-pointed to stub the new `wp_sudo_user_matches_recovery()` seam. `SiteHealthTest`'s
+"adds four tests" count updates to five.
+
+**M4 — notice copy branches.** `Admin::render_recovery_mode_notice()` gains
+scoped vs unscoped copy (scoped names the target); the unscoped copy is unchanged.
+
+**N5/N6 — Site Health diagnosability + no leak.** `test_recovery_mode()` reports
+scoped-resolved (`login`, ID N), scoped-**unresolvable** ("does not resolve to any
+user; no one is granted — check for a typo"), or unscoped (any admin). The target
+is `esc_html()`'d and appears in the status result only — never in
+`debug_information`.
+
+**N8 — resolver does no cap checks.** `wp_sudo_recovery_mode_user()` calls only
+`get_user_by()` (no `user_can`/`current_user_can`), so it cannot re-enter
+`map_meta_cap`. Comment added. Int form does no lookup at all.
+
+**N9 — multisite documented.** Login resolution is network-global; access still
+hinges on the network role gate (fail-closed if the target lost admin). Noted in
+`security-model.md` §Break-glass.
+
+## Test split
+
+- **Unit (GovernanceTest):** the full three-state grant logic of
+  `wp_sudo_user_matches_recovery()` (B1), stubbing its sub-seams — including the
+  fail-closed "unresolvable target grants nobody" case. Plus guards that the
+  new helpers return false/null when the constant is undefined (the unit env).
+- **Integration:** `wp_sudo_recovery_mode_user()` constant + `get_user_by()`
+  resolution against real users (int-ID and login forms, target-grant vs
+  non-target-deny) — the correct environment for a real user lookup.

--- a/.planning/246-protection-status-panel-design-brief.md
+++ b/.planning/246-protection-status-panel-design-brief.md
@@ -1,0 +1,178 @@
+# Design brief — #246: Protection Status panel (operator health summary)
+
+## Problem / what it solves
+
+WP Sudo's protective posture is currently spread across surfaces an operator has
+to visit one at a time: MU-plugin state and policy review live in **Site Health**,
+recent drift/lockout events live in the **dashboard widget**, recovery-mode and
+policy-preset state show only as **notices on the Sudo settings screen**, and
+several postures (escalation guard on/off, role-manifest enabled/drifted,
+recovery-mode scope, HTTPS/cookie context) have **no consolidated view at all**.
+There is no single "is WP Sudo actually protecting this site right now?" answer.
+This panel is a **read-only** at-a-glance summary that aggregates that state.
+
+This is observability, **not** a control surface. It adds no new enforcement,
+no new write actions, and — critically — no new way to weaken protection. That
+constraint is the whole point: see [`246 non-goals`](#what-it-must-not-do).
+
+## Proposed approach
+
+Add a compact **Status** view to the existing Settings → Sudo page (a new tab in
+the `$tabs` array at `class-admin.php:1924` + `VALID_TABS` + the `switch` at
+:1940, rendered by a new `render_status_panel()`), **not** a new top-level admin
+screen (per #246). On multisite it renders network-appropriate state.
+
+**Reuse existing state sources — do not re-implement diagnostics** (#246 explicitly
+says reuse Site Health). Indicators, each mapped to an existing read:
+
+| Indicator | Source (read-only) |
+|---|---|
+| MU-plugin installed | `Site_Health::test_mu_plugin_status()` |
+| Entry-point policy summary | `Site_Health::test_policy_review()` |
+| Gated-action registry integrity | `Site_Health::test_gated_action_integrity()` |
+| Role/cap manifest: enabled + drift | `Role_Manifest::is_enabled()`; manifest audit result (side-effect-free) |
+| Recovery mode: active + scope | `wp_sudo_is_recovery_mode()` / `wp_sudo_recovery_mode_is_unscoped()` / `wp_sudo_recovery_mode_user()` (from #240) |
+| Escalation guard: armed? | `apply_filters( 'wp_sudo_guard_escalation', false )` |
+| Current user's session / grace state | `Sudo_Session::is_active()` / `is_within_grace()` |
+| HTTPS / secure-cookie context | `is_ssl()` + cookie flags (advisory; ties to #248) |
+| Recent lockouts / drift (last 24h) | `Event_Store` query (already powers the dashboard widget) |
+
+Render each as good / needs-attention / critical with a one-line explanation and
+a deep link to the setting or doc that explains remediation — mirroring the
+Site Health result shape the plugin already returns.
+
+## What it must NOT do (safety constraints for the reviewer)
+
+- **No control actions.** No enable/disable toggles for the escalation guard, the
+  sweep, recovery mode, or manifest generate/activate. Those establish or weaken
+  trust and must stay in the filesystem/CLI/constant layer — a UI switch is an
+  attack the panel would be handing to a compromised admin session. The panel
+  only *reports* posture.
+- **No writes on render.** ⚠️ Gotcha: `Site_Health::test_stale_sessions()` has a
+  **side effect** — it deletes stale session meta. The panel must **not** call
+  the mutating `test_*` methods as reads. It needs side-effect-free reads (e.g. a
+  count via the private `find_stale_sessions()` path, or a new read-only helper);
+  reaching private state from a read view should not add a production getter that
+  exists only for the panel — factor a genuine read helper or use the event store.
+- **No secret / PII leakage.** Same rule as #240's Site Health test: usernames may
+  appear in the panel (admin-only surface) but nothing sensitive, and nothing in
+  `debug_information` (the publicly-pasteable tab).
+- **True posture, not the remapped view.** Reading escalation-guard / recovery
+  state must reflect reality even under the recovery-mode `map_meta_cap` remap —
+  the same trap `render_drift_detection_panel()` already had to avoid by reading
+  raw caps.
+- **No new attack surface.** The panel is gated by `wp_sudo_can('manage_wp_sudo')`
+  like the rest of the settings page; it must not become reachable to a
+  lower-privilege user, and it must not itself be a gated *action* (it's read-only).
+
+## Scope
+
+MVP = the indicator grid above, read-only, one settings-page tab. **Out of scope
+for the MVP:** the network cross-site rollup (#243/#244), CSV/export (that's the
+separate Activity-screen item), HTTPS auto-remediation (#248 stays advisory), and
+any historical charts. Keep it a status view, not a reporting subsystem.
+
+## Open questions for the design reviewer
+
+1. **Tab vs. panel-on-Settings.** New "Status" tab, or a compact summary block at
+   the top of the existing Settings tab? #246 allows either; which is less
+   clutter and clearer as the canonical "health" home?
+2. **Stale-session read.** What is the cleanest side-effect-free source for the
+   session/lockout indicators without adding a test-only production getter or
+   triggering the cleanup write?
+3. **Escalation-guard posture read.** Is evaluating `apply_filters(
+   'wp_sudo_guard_escalation', false )` at render time a faithful "is it armed?"
+   signal, given the filter can be context-dependent — or is a dedicated
+   posture accessor warranted?
+4. **Multisite.** Which indicators are per-site vs. network-global, and does the
+   network-admin rendering need different sources than the per-site view?
+5. **Duplication risk.** Does adding this panel create two sources of truth vs.
+   Site Health, and if so should the panel link out to Site Health for detail
+   rather than restating it?
+
+---
+
+## Review incorporated (design reviewer)
+
+> Note: the reviewer ran while a concurrent session had the shared working tree
+> checked out on `feat/262` (the shared-tree hazard), so it read code without the
+> #240 recovery helpers. **B1 below is corrected accordingly**; the rest stand.
+
+**B1 (corrected → sequencing, not confabulation).** The recovery-mode *scope*
+indicator uses `wp_sudo_recovery_mode_is_unscoped()` / `wp_sudo_recovery_mode_user()`,
+which **do exist** — on PR #268 (`feat/240`), not yet merged to `main`. So:
+sequence #246 implementation **after #240 merges**. Until then the recovery
+indicator degrades to the boolean `wp_sudo_is_recovery_mode()` only. Re-verify the
+helper names against `main` at build time (they were added by #240).
+
+**B2 (blocking) — drop the stale-session indicator.** `Site_Health::test_stale_sessions()`
+**mutates** (`delete_user_meta` per stale user, `class-site-health.php:333-337`) and
+its result text is past-tense ("cleaned up"), so it can't be a read. Its pure
+sibling `find_stale_sessions()` runs an **unbounded per-render `get_users` meta
+scan** — too costly for a settings-page render, and we won't add a test-only
+production getter. Resolution: **remove the stale-session indicator**; derive any
+session/lockout signal from `Event_Store` (already queried for the lockout/drift
+row). Site Health still owns stale-session cleanup.
+
+**B3 (blocking) — no live filter-probe for the escalation guard.** Evaluating
+`apply_filters('wp_sudo_guard_escalation', false)` at render time is **not**
+faithful: the guard closure evaluates it in the *write-surface* context and
+early-returns for cli/cron/xmlrpc, and the guard is **fully bypassed when
+`WP_SUDO_ALLOW_ESCALATION` is defined truthy** (`class-gate.php` ~940/1037/1101) —
+which the filter alone doesn't reflect. Also, invoking a third-party filter purely
+as a probe is mildly risky. Resolution: either **drop the guard indicator for the
+MVP**, or add a **dedicated read-only posture accessor** that mirrors the guard's
+real preconditions (`filter-on AND ! WP_SUDO_ALLOW_ESCALATION`) — documented as a
+new stable contract.
+
+**B4 (blocking) — raw-state reads, per indicator.** Every indicator that touches
+capabilities must read **raw stored state** (`$user->allcaps`, the `site_admins`
+option, the constant directly) and **never** `current_user_can()`/`has_cap()`,
+because the recovery-mode `map_meta_cap` remap rewrites `manage_wp_sudo →
+manage_options` for the current user (the exact trap
+`render_drift_detection_panel()` already avoids, `class-admin.php:2250-2259`). Make
+this an explicit column/constraint in the indicator table.
+
+**N5 (decision) — capability/container.** A pure observability panel is
+conceptually a `view_wp_sudo_activity` surface, but a *settings tab* forces
+`manage_wp_sudo`. Resolve open-Q1 with this: if activity-viewers should see
+posture, host it on the **dashboard-widget context** (already
+`view_wp_sudo_activity`-scoped) rather than a settings tab — or accept the higher
+cap deliberately. Do not default silently.
+
+**N6 (decision) — multisite scope labels.** Label each indicator per-site vs
+network-global (sessions/events are network-global; policies are per-site
+`Admin::get()` reads). Verify `Admin::get(...POLICY)` resolves to the intended
+store under network admin, or the panel misreports.
+
+**N7 — reuse, don't re-derive.** Call the four side-effect-free Site Health tests
+directly (`test_mu_plugin_status`, `test_policy_review`, `test_gated_action_integrity`,
+`test_role_manifest` — verified pure; the drift `do_action` fires only in
+`Role_Audit::evaluate()`/`run_sweep()`, which the panel must **not** call). Link
+out to the dashboard widget for event data rather than restating it.
+
+**N8 — metrics + TDD.** A new `VALID_TABS` entry is fine **iff** it adds no
+settings field and no help tab (those counts in `current-metrics.md` stay 6/6-7).
+If a help tab is added, bump Help tabs 6→7 there **first** (verify:metrics gate).
+Extract a pure `collect_status_indicators(): array` (state assembly, zero render)
+and unit-test that it performs **no writes** — assert `delete_user_meta` /
+`update_option` / `set_transient` are `->never()` (Brain\Monkey), so a future
+mutation reintroduction fails the suite.
+
+**N9 — stay separate from the Access tab.** Do not embed/reuse
+`render_drift_detection_panel()`'s governance-coverage table — it renders
+grant/revoke controls wired to the `handle_grant_cap` AJAX **write**, which would
+break the read-only invariant.
+
+**N10 — nothing into `debug_information`.** Manifest baseline contents and any
+recovery-bound identity must never reach the publicly-pasteable Site Health debug
+tab.
+
+### Net MVP shape after review
+
+Read-only indicators, sourced as: MU-plugin / policy / registry / role-manifest →
+the four pure `test_*` methods; recovery-mode → `wp_sudo_is_recovery_mode()` (scope
+detail after #240 merges); recent lockouts/drift → `Event_Store`; HTTPS →
+`is_ssl()`. **Dropped from MVP:** stale-session indicator (B2) and the live guard
+filter-probe (B3, unless a real accessor is added). **Decide before TDD:** N5
+(container/cap) and N6 (multisite scope). Build **after #240 is on main**.


### PR DESCRIPTION
Adds the two remaining `.planning/` design briefs to the repo for the record. Docs-only.

- `240-scoped-recovery-design-brief.md`
- `246-protection-status-panel-design-brief.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)