### PR TITLE
ci: unbreak docs-lint on main (red since #338)

### DIFF
--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -27,6 +27,7 @@ jobs:
             "docs/abilities-api-assessment.md"
             "docs/connectors-api-reference.md"
             "docs/core-action-gate-proposal.md"
+            "docs/core-sudo-gate-implementation-spec.md"
             "docs/current-metrics.md"
             "docs/collaboration-analysis.md"
             "docs/sudo-design-notes.md"


### PR DESCRIPTION
`docs-lint` has failed on `main` since #338 landed — runs [30211461238](https://github.com/dknauss/Sudo/actions/runs/30211461238) (d665e19) and [30212011322](https://github.com/dknauss/Sudo/actions/runs/30212011322) (a094d3f), after passing on 1788beb.

**Cause:** #338 added a dated provenance caveat to `docs/core-sudo-gate-implementation-spec.md` — "the signed-updates keys lapsed 2021-04-01 … verified against `wordpress-develop` trunk, 2026-07-26". Those dates are the *point* of the passage: it is a claim about upstream state at a moment in time, which is what the verification rules ask contributors to write. But docs-lint flags any `YYYY-MM-DD` outside its canonical-docs allowlist.

**Fix:** put the spec on that allowlist, beside `core-action-gate-proposal.md`, which is already excluded for the same reason — both are dated analyses of external state, not prose that goes stale silently.

docs-lint is not a required check, so nothing was blocked. That is precisely why it sat red for two commits with nobody noticing, and it is the third instance today of a check that had quietly stopped meaning anything — after `e2e-visual.yml`'s swallowed exit code (#342) and `composer verify:i18n` being wired into no workflow at all (#332).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V4kcGFoqkxivzk9BSRUhEs