### PR TITLE
feat(security): #322 v2 — informed confirmation + origin-bound replay

### DIFF
--- a/includes/class-challenge.php
+++ b/includes/class-challenge.php
@@ -309,6 +309,13 @@ class Challenge {
 
 			$action_label = $stash['label'] ?? $stash['rule_id'] ?? __( 'this action', 'wp-sudo' );
 		}
+
+		// #322 v2: name the concrete target. A coarse label ("Activate plugin") is a
+		// blank cheque — an attacker who lures the user into a gated request gets the
+		// same prompt as a legitimate action. Showing WHAT is about to happen makes
+		// the password submit an informed decision, which is the control that holds
+		// even if the browser binding is bypassed.
+		$action_target  = $this->describe_stash_target( $stash );
 		$throttle_delay = Sudo_Session::throttle_remaining( $user_id );
 		$is_locked      = Sudo_Session::is_locked_out( $user_id );
 		$is_throttled   = $throttle_delay > 0;
@@ -329,6 +336,17 @@ class Challenge {
 					);
 					?>
 				</p>
+				<?php if ( '' !== $action_target ) : ?>
+					<p class="wp-sudo-challenge-target">
+						<?php
+						printf(
+							/* translators: %s: the concrete target of the action (e.g. a plugin file or user login) */
+							esc_html__( 'Target: %s', 'wp-sudo' ),
+							'<code>' . esc_html( $action_target ) . '</code>'
+						);
+						?>
+					</p>
+				<?php endif; ?>
 
 				<ol class="wp-sudo-lecture">
 					<li><?php esc_html_e( 'Respect the privacy of others.', 'wp-sudo' ); ?></li>
@@ -658,7 +676,8 @@ class Challenge {
 		switch ( $result['code'] ) {
 			case 'success':
 				if ( $stash_key ) {
-					$this->replay_stash( $user_id, $stash_key );
+					// Password just verified on this request → bound replay is eligible.
+					$this->replay_stash( $user_id, $stash_key, true );
 				} else {
 					// Session-only flow — session is now active, user retries manually.
 					// `remaining` seeds the in-editor indicator's countdown (#182).
@@ -873,7 +892,8 @@ class Challenge {
 		Sudo_Session::activate( $user_id );
 
 		if ( $stash_key ) {
-			$this->replay_stash( $user_id, $stash_key );
+			// Second factor just verified on this request → bound replay is eligible.
+			$this->replay_stash( $user_id, $stash_key, true );
 		} else {
 			// Session-only flow — session is now active, user retries manually.
 			// `remaining` seeds the in-editor indicator's countdown (#182).
@@ -893,12 +913,13 @@ class Challenge {
 	 *   - Redirects for GET requests.
 	 *   - Builds and submits a hidden form for POST requests.
 	 *
-	 * @param int    $user_id   The user ID.
-	 * @param string $stash_key The stash key.
+	 * @param int    $user_id             The user ID.
+	 * @param string $stash_key           The stash key.
+	 * @param bool   $credential_verified Whether a password/2FA was verified on this request (#322 v2).
 	 * @return void
 	 */
-	private function replay_stash( int $user_id, string $stash_key ): void {
-		wp_send_json_success( $this->build_replay_response_data( $user_id, $stash_key ) );
+	private function replay_stash( int $user_id, string $stash_key, bool $credential_verified = false ): void {
+		wp_send_json_success( $this->build_replay_response_data( $user_id, $stash_key, null, $credential_verified ) );
 	}
 
 	/**
@@ -1022,14 +1043,113 @@ class Challenge {
 	}
 
 	/**
+	 * Describe the concrete target of a stashed action for informed confirmation.
+	 *
+	 * Display only — never used to route or replay. Values were sanitized and
+	 * length-capped at stash time; they are escaped again at render.
+	 *
+	 * @param array<string, mixed>|null $stash The stash data, if any.
+	 * @return string Human-readable target, or '' when the stash records none.
+	 */
+	private function describe_stash_target( ?array $stash ): string {
+		if ( ! $stash || empty( $stash['target'] ) || ! is_array( $stash['target'] ) ) {
+			return '';
+		}
+
+		$parts = array();
+
+		foreach ( $stash['target'] as $key => $value ) {
+			if ( ! is_string( $key ) || ! is_scalar( $value ) || '' === (string) $value ) {
+				continue;
+			}
+
+			$parts[] = $key . '=' . (string) $value;
+		}
+
+		return implode( ', ', $parts );
+	}
+
+	/**
+	 * Whether a stash may be auto-replayed under the #322 v2 origin binding.
+	 *
+	 * Every condition must hold; anything else falls back to the v1 fail-closed
+	 * landing. Binding is defence-in-depth, never the sole authorization — the
+	 * challenge page names the concrete target so the credential the user just
+	 * supplied is consent to a KNOWN action, not a blank cheque.
+	 *
+	 * @param array<string, mixed> $stash               The stash data.
+	 * @param bool                 $credential_verified Whether a password/2FA was verified on THIS request.
+	 * @return bool
+	 */
+	private function may_replay_bound_stash( array $stash, bool $credential_verified ): bool {
+		// Only the post-credential paths. The already-active resume paths involve no
+		// password step at all and auto-submit on page load, so the cookie would be
+		// the only control between "victim opens a link" and "stashed POST executes".
+		if ( ! $credential_verified ) {
+			return false;
+		}
+
+		// Never replay a stash whose body was redacted or explicitly not replayable —
+		// it would submit a form with secret fields silently missing.
+		if ( ! empty( $stash['redacted_fields_omitted'] ) || ! empty( $stash['post_replay_blocked'] ) ) {
+			return false;
+		}
+
+		$expected = isset( $stash['binding_hash'] ) && is_string( $stash['binding_hash'] ) ? $stash['binding_hash'] : '';
+
+		if ( '' === $expected ) {
+			return false;
+		}
+
+		// phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
+		$presented = isset( $_COOKIE[ Request_Stash::BINDING_COOKIE ] ) ? sanitize_text_field( wp_unslash( (string) $_COOKIE[ Request_Stash::BINDING_COOKIE ] ) ) : '';
+
+		if ( '' === $presented ) {
+			return false;
+		}
+
+		return hash_equals( $expected, hash( 'sha256', $presented ) );
+	}
+
+	/**
+	 * Clear the one-time stash binding cookie.
+	 *
+	 * Cleared on BOTH the replay and fail-closed paths so a proof never outlives the
+	 * stash it belonged to.
+	 *
+	 * @return void
+	 */
+	private function clear_binding_cookie(): void {
+		if ( headers_sent() ) {
+			return;
+		}
+
+		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.cookies_setcookie
+		setcookie(
+			Request_Stash::BINDING_COOKIE,
+			'',
+			array(
+				'expires'  => time() - 3600,
+				'path'     => '/',
+				'secure'   => true,
+				'httponly' => true,
+				'samesite' => 'Strict',
+			)
+		);
+
+		unset( $_COOKIE[ Request_Stash::BINDING_COOKIE ] ); // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE -- Clearing a one-time proof for the current request; not a caching decision.
+	}
+
+	/**
 	 * Build replay response data for a stashed request.
 	 *
 	 * @param int         $user_id      The user ID.
 	 * @param string      $stash_key    The stash key.
 	 * @param string|null $fallback_url Fallback redirect when stash is missing.
+	 * @param bool        $credential_verified Whether a password/2FA was verified on this request (#322 v2).
 	 * @return array<string, mixed>
 	 */
-	private function build_replay_response_data( int $user_id, string $stash_key, ?string $fallback_url = null ): array {
+	private function build_replay_response_data( int $user_id, string $stash_key, ?string $fallback_url = null, bool $credential_verified = false ): array {
 		$stash = $this->stash->get( $stash_key, $user_id );
 
 		if ( ! $fallback_url ) {
@@ -1045,6 +1165,45 @@ class Challenge {
 
 		// Consume the stash (one-time use).
 		$this->stash->delete( $stash_key, $user_id );
+
+		if ( $this->may_replay_bound_stash( $stash, $credential_verified ) ) {
+			$safe_url = wp_validate_redirect( $stash['url'], '' );
+
+			// Refuse rather than re-target: if validation altered the URL (e.g. a
+			// cross-host stash on multisite — stash transients are network-wide but
+			// wp_validate_redirect only allows the current host), fall through to the
+			// fail-closed landing instead of replaying against a different URL.
+			if ( '' !== $safe_url && $safe_url === $stash['url'] ) {
+				$this->clear_binding_cookie();
+
+				/**
+				 * Fires when a stashed request is about to be replayed.
+				 *
+				 * @since 2.0.0
+				 *
+				 * @param int    $user_id The user who reauthenticated.
+				 * @param string $rule_id The rule ID that was gated.
+				 */
+				do_action( 'wp_sudo_action_replayed', $user_id, $stash['rule_id'] ?? '' );
+
+				if ( 'GET' === strtoupper( (string) ( $stash['method'] ?? 'GET' ) ) ) {
+					return array(
+						'code'     => 'success',
+						'redirect' => $safe_url,
+					);
+				}
+
+				return array(
+					'code'      => 'success',
+					'replay'    => true,
+					'method'    => $stash['method'],
+					'url'       => $safe_url,
+					'post_data' => $stash['post'] ?? array(),
+				);
+			}
+		}
+
+		$this->clear_binding_cookie();
 
 		/*
 		 * #322 — fail closed, with a soft landing. The stashed action is NEVER

--- a/includes/class-request-stash.php
+++ b/includes/class-request-stash.php
@@ -47,6 +47,38 @@ class Request_Stash {
 	private const KEY_LENGTH = 16;
 
 	/**
+	 * Cookie carrying the per-browser stash binding proof (#322 v2).
+	 *
+	 * `__Host-` prefixed on purpose: the prefix forces Secure + Path=/ and, crucially,
+	 * forbids a `Domain` attribute, so the cookie is host-only and a sibling subdomain
+	 * cannot plant or overwrite it (cookie tossing). On subdomain multisite
+	 * COOKIE_DOMAIN is `.example.com`, which would otherwise let any host under the
+	 * network transplant a proof the attacker legitimately owns.
+	 *
+	 * @var string
+	 */
+	public const BINDING_COOKIE = '__Host-wp_sudo_stash_proof';
+
+	/**
+	 * Request params that identify the concrete target of a gated action.
+	 *
+	 * Recorded so the challenge can name what is about to happen ("Activate plugin:
+	 * evil/evil.php") instead of only the coarse rule label. Informed confirmation is
+	 * the control that survives a binding bypass — the user is consenting to a NAMED
+	 * action, not signing a blank cheque.
+	 *
+	 * @var string[]
+	 */
+	private const TARGET_PARAMS = array( 'plugin', 'theme', 'stylesheet', 'template', 'user_id', 'users', 'option', 'file', 'id', 'post', 'blog_id', 'app_name' );
+
+	/**
+	 * Maximum stored length of a single target value.
+	 *
+	 * @var int
+	 */
+	private const TARGET_MAX_LENGTH = 100;
+
+	/**
 	 * Reason code for POST requests that are intentionally not replayed.
 	 *
 	 * @var string
@@ -156,6 +188,8 @@ class Request_Stash {
 			'post_replay_blocked'      => $post_replay_blocked || $redacted_fields_omitted,
 			'post_replay_block_reason' => $redacted_fields_omitted ? 'redacted_fields_omitted' : $post_replay_block_reason,
 			'created'                  => time(),
+			'target'                   => $this->capture_target(),
+			'binding_hash'             => $this->mint_binding_proof(),
 		);
 
 		$this->set_stash_transient( self::TRANSIENT_PREFIX . $key, $data, self::TTL );
@@ -164,6 +198,100 @@ class Request_Stash {
 		$this->add_to_stash_index( $user_id, $key );
 
 		return $key;
+	}
+
+	/**
+	 * Capture the concrete target of the gated request for informed confirmation.
+	 *
+	 * Read-only, sanitized, length-capped. Never used to route or replay — it exists
+	 * solely so the challenge page can name the action the user is authorizing.
+	 *
+	 * @return array<string, string>
+	 */
+	private function capture_target(): array {
+		$target = array();
+
+		foreach ( self::TARGET_PARAMS as $param ) {
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- Display metadata only, never used to route or replay; sanitized below.
+			$raw = $_GET[ $param ] ?? $_POST[ $param ] ?? null;
+
+			if ( null === $raw || is_array( $raw ) || '' === $raw ) {
+				continue;
+			}
+
+			$value = sanitize_text_field( wp_unslash( (string) $raw ) );
+
+			if ( '' === $value ) {
+				continue;
+			}
+
+			$target[ $param ] = substr( $value, 0, self::TARGET_MAX_LENGTH );
+		}
+
+		return $target;
+	}
+
+	/**
+	 * Mint a per-browser binding proof for this stash (#322 v2).
+	 *
+	 * Returns the sha256 of a fresh random secret and sets the plaintext secret in a
+	 * host-only, httponly, SameSite=Strict cookie. Only the HASH is ever stored, so a
+	 * stash read does not yield the proof.
+	 *
+	 * Deliberately refuses to mint (returns '') unless ALL hold:
+	 *  - the gated request was same-origin initiated (`Sec-Fetch-Site: same-origin`).
+	 *    WordPress nonces are bound to the session token, NOT the browser, so an
+	 *    attacker holding a stolen login cookie can mint a valid nonce and lure the
+	 *    victim into issuing the gated request — which would otherwise mint the
+	 *    binding in the VICTIM's browser and defeat the whole mechanism. A missing or
+	 *    cross-site/same-site header fails closed.
+	 *  - cookies are Secure (`__Host-` requires it; without TLS there is no binding
+	 *    worth trusting anyway).
+	 *  - headers are not already sent, so the cookie can actually reach the browser.
+	 *    Storing a hash the browser can never satisfy would strand the stash.
+	 *
+	 * Binding is defence-in-depth only. It is never sufficient on its own to authorize
+	 * a replay — informed confirmation of the named target is the primary control.
+	 *
+	 * @return string sha256 hex digest, or '' when no binding is minted.
+	 */
+	private function mint_binding_proof(): string {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Fetch metadata header, not user input.
+		$fetch_site = isset( $_SERVER['HTTP_SEC_FETCH_SITE'] ) ? sanitize_text_field( wp_unslash( (string) $_SERVER['HTTP_SEC_FETCH_SITE'] ) ) : '';
+
+		if ( 'same-origin' !== $fetch_site ) {
+			return '';
+		}
+
+		if ( ! Sudo_Session::cookie_secure() || headers_sent() ) {
+			return '';
+		}
+
+		// random_bytes(): unfilterable, unlike wp_generate_password(), whose
+		// `random_password` filter a third-party plugin could collapse.
+		try {
+			$secret = bin2hex( random_bytes( 32 ) );
+		} catch ( \Exception $e ) {
+			return '';
+		}
+
+		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.cookies_setcookie
+		setcookie(
+			self::BINDING_COOKIE,
+			$secret,
+			array(
+				'expires'  => time() + self::TTL,
+				// __Host- requires path=/ and forbids an explicit domain.
+				'path'     => '/',
+				'secure'   => true,
+				'httponly' => true,
+				'samesite' => 'Strict',
+			)
+		);
+
+		$_COOKIE[ self::BINDING_COOKIE ] = $secret; // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
+
+		return hash( 'sha256', $secret );
 	}
 
 	/**

--- a/includes/class-sudo-session.php
+++ b/includes/class-sudo-session.php
@@ -796,7 +796,7 @@ class Sudo_Session {
 	 *
 	 * @return bool
 	 */
-	private static function cookie_secure(): bool {
+	public static function cookie_secure(): bool {
 		$secure = is_ssl() || force_ssl_admin();
 
 		/**

--- a/tests/Unit/ChallengeTest.php
+++ b/tests/Unit/ChallengeTest.php
@@ -1722,6 +1722,181 @@ class ChallengeTest extends TestCase
 	}
 
 	// -----------------------------------------------------------------
+	// #322 v2 — origin-bound replay. Auto-replay is allowed ONLY when a
+	// credential was verified on THIS request AND the browser presents the
+	// binding proof minted when the stash was created. Everything else keeps
+	// the v1 fail-closed landing.
+	// -----------------------------------------------------------------
+
+	/**
+	 * Build a clean, replayable POST stash bound to $secret.
+	 *
+	 * @param string $secret Binding secret whose hash the stash stores.
+	 * @return array<string, mixed>
+	 */
+	private function boundPostStash(string $secret): array
+	{
+		return array(
+			'method' => 'POST',
+			'url' => 'https://example.com/wp-admin/users.php',
+			'return_url' => 'https://example.com/wp-admin/user-new.php',
+			'rule_id' => 'user.create',
+			'post' => array('role' => 'administrator'),
+			'binding_hash' => hash('sha256', $secret),
+		);
+	}
+
+	/**
+	 * Stub the functions the replay chokepoint needs.
+	 */
+	private function stubReplayEnv(): void
+	{
+		Functions\when('admin_url')->justReturn('https://example.com/wp-admin/');
+		Functions\when('wp_validate_redirect')->returnArg();
+		Functions\when('sanitize_text_field')->returnArg();
+		Functions\when('headers_sent')->justReturn(true); // skip setcookie in unit context
+		Functions\when('add_query_arg')->alias(
+			static function ( string $key, string $value, string $url ): string {
+				$separator = str_contains($url, '?') ? '&' : '?';
+				return $url . $separator . $key . '=' . $value;
+			}
+		);
+	}
+
+	/**
+	 * Invoke the replay chokepoint directly.
+	 *
+	 * @param bool $credentialVerified Whether a credential was verified this request.
+	 * @return array<string, mixed>
+	 */
+	private function invokeReplay(string $stashKey, bool $credentialVerified): array
+	{
+		$method = new \ReflectionMethod($this->challenge, 'build_replay_response_data');
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible(true);
+		}
+		return $method->invoke($this->challenge, 42, $stashKey, 'https://example.com/wp-admin/', $credentialVerified);
+	}
+
+	/**
+	 * #322 v2: the legitimate same-browser flow replays again (UX restored).
+	 */
+	public function test_bound_stash_replays_after_credential_verified(): void
+	{
+		$secret = 'super-secret-proof';
+		$_COOKIE[\WP_Sudo\Request_Stash::BINDING_COOKIE] = $secret;
+
+		$this->stash->shouldReceive('get')->once()->andReturn($this->boundPostStash($secret));
+		$this->stash->shouldReceive('delete')->once();
+		$this->stubReplayEnv();
+
+		$data = $this->invokeReplay('bound-key', true);
+
+		$this->assertTrue($data['replay'] ?? false, 'Matching binding + verified credential must replay.');
+		$this->assertSame(array('role' => 'administrator'), $data['post_data']);
+
+		unset($_COOKIE[\WP_Sudo\Request_Stash::BINDING_COOKIE]);
+	}
+
+	/**
+	 * #322 v2: the attacker's planted stash — victim's browser has no proof.
+	 */
+	public function test_planted_stash_without_binding_cookie_fails_closed(): void
+	{
+		unset($_COOKIE[\WP_Sudo\Request_Stash::BINDING_COOKIE]);
+
+		$this->stash->shouldReceive('get')->once()->andReturn($this->boundPostStash('attacker-secret'));
+		$this->stash->shouldReceive('delete')->once();
+		$this->stubReplayEnv();
+
+		$data = $this->invokeReplay('planted-key', true);
+
+		$this->assertArrayNotHasKey('replay', $data, 'No proof in this browser → must not replay.');
+		$this->assertArrayNotHasKey('post_data', $data);
+	}
+
+	/**
+	 * #322 v2: cookie transplant — a proof that does not match this stash is refused.
+	 */
+	public function test_transplanted_binding_cookie_is_refused(): void
+	{
+		$_COOKIE[\WP_Sudo\Request_Stash::BINDING_COOKIE] = 'a-different-stashs-proof';
+
+		$this->stash->shouldReceive('get')->once()->andReturn($this->boundPostStash('the-real-proof'));
+		$this->stash->shouldReceive('delete')->once();
+		$this->stubReplayEnv();
+
+		$data = $this->invokeReplay('transplant-key', true);
+
+		$this->assertArrayNotHasKey('replay', $data, 'Mismatched proof must not replay.');
+
+		unset($_COOKIE[\WP_Sudo\Request_Stash::BINDING_COOKIE]);
+	}
+
+	/**
+	 * #322 v2: the no-password resume paths stay fail-closed even with a valid proof.
+	 */
+	public function test_bound_stash_is_not_replayed_without_credential_verification(): void
+	{
+		$secret = 'super-secret-proof';
+		$_COOKIE[\WP_Sudo\Request_Stash::BINDING_COOKIE] = $secret;
+
+		$this->stash->shouldReceive('get')->once()->andReturn($this->boundPostStash($secret));
+		$this->stash->shouldReceive('delete')->once();
+		$this->stubReplayEnv();
+
+		$data = $this->invokeReplay('resume-key', false);
+
+		$this->assertArrayNotHasKey('replay', $data, 'Resume path (no credential this request) must not replay.');
+
+		unset($_COOKIE[\WP_Sudo\Request_Stash::BINDING_COOKIE]);
+	}
+
+	/**
+	 * #322 v2: a redacted/blocked stash is never replayed, binding or not.
+	 */
+	public function test_bound_but_redacted_stash_is_not_replayed(): void
+	{
+		$secret = 'super-secret-proof';
+		$_COOKIE[\WP_Sudo\Request_Stash::BINDING_COOKIE] = $secret;
+
+		$stash = $this->boundPostStash($secret);
+		$stash['redacted_fields_omitted'] = true;
+
+		$this->stash->shouldReceive('get')->once()->andReturn($stash);
+		$this->stash->shouldReceive('delete')->once();
+		$this->stubReplayEnv();
+
+		$data = $this->invokeReplay('redacted-key', true);
+
+		$this->assertArrayNotHasKey('replay', $data, 'Redacted stash must never replay (secrets are missing).');
+		$this->assertStringContainsString('wp_sudo_redacted_replay=1', $data['redirect']);
+
+		unset($_COOKIE[\WP_Sudo\Request_Stash::BINDING_COOKIE]);
+	}
+
+	/**
+	 * #322 v2: refuse rather than re-target when validation alters the stashed URL.
+	 */
+	public function test_bound_stash_with_unvalidatable_url_is_not_replayed(): void
+	{
+		$secret = 'super-secret-proof';
+		$_COOKIE[\WP_Sudo\Request_Stash::BINDING_COOKIE] = $secret;
+
+		$this->stash->shouldReceive('get')->once()->andReturn($this->boundPostStash($secret));
+		$this->stash->shouldReceive('delete')->once();
+		$this->stubReplayEnv();
+		// Simulate wp_validate_redirect() rejecting/altering the stashed URL.
+		Functions\when('wp_validate_redirect')->justReturn('https://example.com/wp-admin/');
+
+		$data = $this->invokeReplay('crosshost-key', true);
+
+		$this->assertArrayNotHasKey('replay', $data, 'Altered URL must fail closed, not re-target the POST.');
+
+		unset($_COOKIE[\WP_Sudo\Request_Stash::BINDING_COOKIE]);
+	}
+
+	// -----------------------------------------------------------------
 	// handle_ajax_2fa — Two Factor provider: pre_process_authentication resend
 	// -----------------------------------------------------------------
 

--- a/tests/Unit/RequestStashTest.php
+++ b/tests/Unit/RequestStashTest.php
@@ -95,6 +95,107 @@ class RequestStashTest extends TestCase {
 	}
 
 	/**
+	 * #322 v2 (BLOCKER 1): no binding is minted for a cross-site-initiated request.
+	 *
+	 * WordPress nonces are bound to the session token, NOT the browser, so an attacker
+	 * holding a stolen login cookie can mint a valid nonce and lure the victim into
+	 * issuing the gated request. If we minted a binding then, it would land in the
+	 * VICTIM's browser and the victim's own reauth would release the attacker's
+	 * action. Anything other than `Sec-Fetch-Site: same-origin` must fail closed.
+	 *
+	 * @dataProvider non_same_origin_fetch_sites
+	 */
+	public function test_save_does_not_bind_unless_same_origin_initiated( ?string $fetch_site ): void {
+		$this->stub_stash_index_meta_io();
+
+		$_SERVER['REQUEST_METHOD'] = 'GET';
+		$_SERVER['HTTP_HOST']      = 'example.com';
+		$_SERVER['REQUEST_URI']    = '/wp-admin/plugins.php?action=activate&plugin=evil.php';
+
+		if ( null === $fetch_site ) {
+			unset( $_SERVER['HTTP_SEC_FETCH_SITE'] );
+		} else {
+			$_SERVER['HTTP_SEC_FETCH_SITE'] = $fetch_site;
+		}
+
+		Functions\when( 'wp_generate_password' )->justReturn( 'abc123def456ghij' );
+		Functions\when( 'esc_url_raw' )->returnArg();
+		Functions\when( 'is_ssl' )->justReturn( true );
+		Functions\when( 'sanitize_text_field' )->returnArg();
+
+		$stored = null;
+		Functions\expect( 'set_transient' )
+			->once()
+			->andReturnUsing(
+				function ( $key, $value ) use ( &$stored ) {
+					$stored = $value;
+					return true;
+				}
+			);
+
+		$this->stash->save( 1, array( 'id' => 'plugin.activate', 'label' => 'Activate plugin' ) );
+
+		$this->assertSame(
+			'',
+			$stored['binding_hash'] ?? 'MISSING',
+			'A lured (non-same-origin) request must not mint a browser binding.'
+		);
+
+		unset( $_SERVER['REQUEST_METHOD'], $_SERVER['HTTP_HOST'], $_SERVER['REQUEST_URI'], $_SERVER['HTTP_SEC_FETCH_SITE'] );
+	}
+
+	/**
+	 * Fetch-site values that must NOT produce a binding.
+	 *
+	 * @return array<string, array{0: string|null}>
+	 */
+	public static function non_same_origin_fetch_sites(): array {
+		return array(
+			'cross-site'    => array( 'cross-site' ),
+			'same-site'     => array( 'same-site' ),
+			'none'          => array( 'none' ),
+			'absent header' => array( null ),
+		);
+	}
+
+	/**
+	 * #322 v2: the stash records the concrete target for informed confirmation.
+	 */
+	public function test_save_captures_target_for_informed_confirmation(): void {
+		$this->stub_stash_index_meta_io();
+
+		$_SERVER['REQUEST_METHOD'] = 'GET';
+		$_SERVER['HTTP_HOST']      = 'example.com';
+		$_SERVER['REQUEST_URI']    = '/wp-admin/plugins.php?action=activate&plugin=evil%2Fevil.php';
+		$_GET['plugin']            = 'evil/evil.php';
+
+		Functions\when( 'wp_generate_password' )->justReturn( 'abc123def456ghij' );
+		Functions\when( 'esc_url_raw' )->returnArg();
+		Functions\when( 'is_ssl' )->justReturn( true );
+		Functions\when( 'sanitize_text_field' )->returnArg();
+
+		$stored = null;
+		Functions\expect( 'set_transient' )
+			->once()
+			->andReturnUsing(
+				function ( $key, $value ) use ( &$stored ) {
+					$stored = $value;
+					return true;
+				}
+			);
+
+		$this->stash->save( 1, array( 'id' => 'plugin.activate', 'label' => 'Activate plugin' ) );
+
+		$this->assertSame(
+			'evil/evil.php',
+			$stored['target']['plugin'] ?? null,
+			'The challenge must be able to name WHAT is being authorized.'
+		);
+
+		unset( $_SERVER['REQUEST_METHOD'], $_SERVER['HTTP_HOST'], $_SERVER['REQUEST_URI'], $_GET['plugin'] );
+	}
+
+	/**
 	 * Test save() still returns the key when transient storage fails.
 	 */
 	public function test_save_returns_key_when_set_transient_fails(): void {


### PR DESCRIPTION
## #322 v2 — restores replay UX without reopening the confused deputy

**Stacked on #350 (v1).** Base is `fix/322-stash-fail-closed`; retarget to `main` once v1 merges.

### The design review killed the original plan — and was right

The first v2 plan was "bind the stash to a browser cookie." A pre-implementation review rejected it, and I verified the finding against core:

- `wp_create_nonce()` hashes `$i|$action|$uid|$token`, and `wp_get_session_token()` returns the **`logged_in` cookie's token** (`pluggable.php`, `user.php`).
- Core sets **no SameSite** on auth cookies → browser default `Lax` sends them on top-level GET navigation.

So an attacker with the stolen cookie mints a **valid nonce** and lures the victim to a normal admin action URL. The gate stashes at `admin_init` priority **1** — long before core's `check_admin_referer` — so the binding would have been minted **in the victim's browser**, and the victim's organic-looking reauth would release the attacker's action. That is *easier* than the original #322.

### Primary control: informed confirmation

The stash records the **concrete target** (`plugin`, `theme`, `user_id`, `option`, …; sanitized, capped, display-only) and the challenge names it:

> To continue: **Activate plugin** — please enter your password.
> Target: `plugin=evil/evil.php`

A coarse label alone is a blank cheque: the lure produces an identical prompt. Naming the target makes the credential **consent to a known action** — and that holds even if the binding is bypassed.

### Defence-in-depth: origin-bound replay

Per-browser proof (sha256 stored, plaintext in cookie), hardened per the review:

| Control | Why |
|---|---|
| Mint only when `Sec-Fetch-Site: same-origin` (cross-site/same-site/none/absent → no binding) | defeats the lure chain |
| `__Host-` cookie (host-only, no `Domain`) | blocks subdomain cookie-tossing (`COOKIE_DOMAIN` is `.example.com` on subdomain multisite) |
| `bin2hex(random_bytes(32))` | `wp_generate_password()` is filterable via `random_password` |
| No binding when `headers_sent()` | never strand a stash with an unsatisfiable proof |
| Credential verified **on this request** | no-password resume paths auto-submit on load — stay fail-closed |
| Not redacted / not replay-blocked | never submit a form with secrets missing |
| `wp_validate_redirect` must leave the URL unchanged | refuse rather than re-target a cross-host stash |
| Proof cleared on **both** paths | no proof outlives its stash |

Anything failing these keeps the v1 fail-closed landing. `wp_sudo_action_replayed` fires again on genuine same-browser replays.

### Tests

11 new: lure defence (4 `Sec-Fetch-Site` variants), target capture, bound replay succeeds, planted stash without proof, transplanted proof, resume-without-credential, redacted-but-bound, unvalidatable URL. **Mutation-verified** — disabling the guard fails 4.

`composer test` 1165 green · `analyse:phpstan` clean · `composer lint` exit 0.

### Process note

v1 was strict TDD (red tests adopted from the abandoned branch, verified failing). v2 was implemented **before** its tests because the design changed substantially mid-flight; I compensated with the mutation check rather than claiming red-green I didn't do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)