### PR TITLE
fix(verify-sources): keep gitignored files out of the orphan scan

### DIFF
--- a/bin/verify-sources.sh
+++ b/bin/verify-sources.sh
@@ -395,6 +395,23 @@ orphans="$(grep -roIE \
 	| cut -d: -f1 | sort -u || true)"
 while IFS= read -r f; do
 	[ -n "$f" ] || continue
+	# The scan walks the WORKING TREE, which holds files git does not: `reviewer-approved`,
+	# the pre-commit reviewer agent's approval flag, is gitignored and routinely records the
+	# upstream URLs the reviewer verified. It made `composer verify:sources` fail for any
+	# developer holding a current approval flag while CI — a clean checkout with no flag —
+	# stayed green. A checker that reds only on the developer's machine is a checker people
+	# learn to run with their eyes closed, which costs more than the rule it enforces.
+	# .github/workflows/docs-lint.yml scopes its own scan with `git ls-files` for this reason.
+	#
+	# The filter is "ignored", not "untracked", on purpose: a doc you have written but not
+	# yet committed still has to satisfy the registry rule, or the check would arrive one
+	# commit too late to stop the citation. `git check-ignore` consults the index first, so
+	# a TRACKED file that also matches an ignore rule stays in scope. Outside a git work
+	# tree git exits 128, nothing is skipped, and the scan behaves exactly as it did before
+	# — the failure mode here is a false positive, so degrading toward loud is correct.
+	if git -C "$REPO_ROOT" check-ignore -q -- "$f" 2>/dev/null; then
+		continue
+	fi
 	rel="${f#"$REPO_ROOT/"}"
 	if printf '%s\n' "$GRANDFATHERED_ORPHANS" | grep -qxF -- "$rel"; then
 		add_warning "$rel cites upstream code outside the registry (grandfathered — migrate as you touch it)"

--- a/tests/verify-sources/run.sh
+++ b/tests/verify-sources/run.sh
@@ -365,6 +365,41 @@ run
 expect_rc 1
 expect_out "raw-text source"
 
+# 14. Gitignored working-tree files are outside the orphan scan. The live case is
+#     `reviewer-approved`, the pre-commit reviewer agent's flag: it is gitignored, never
+#     committed, and routinely records the upstream URLs the reviewer verified. Scanning
+#     it failed on every developer machine holding a current approval while CI, on a
+#     clean checkout, passed. Needs a real git work tree, so this sandbox gets `git init`.
+start "gitignored file is not an orphan"
+new_sandbox gitignored
+git -C "$SANDBOX" init -q
+printf 'reviewer-approved\n' > "$SANDBOX/.gitignore"
+registry "$HDR
+| GB-A | $URL | 2 | needle here | sym | a claim |"
+fixture "$URL" 200 0 $'x\nneedle here'
+printf 'verified https://raw.githubusercontent.com/WordPress/gutenberg/trunk/z.js\n' \
+	> "$SANDBOX/reviewer-approved"
+run
+expect_rc 0
+
+# 14b. The same git work tree, same URL, in a file nothing ignores: still a failure.
+#      Without this, case 14 would also pass if the fix had disabled the scan outright.
+#      Untracked and uncommitted on purpose — the rule has to bite before the commit,
+#      not one commit later.
+start "non-ignored file in a git work tree is still an orphan"
+new_sandbox gitkept
+git -C "$SANDBOX" init -q
+printf 'reviewer-approved\n' > "$SANDBOX/.gitignore"
+registry "$HDR
+| GB-A | $URL | 2 | needle here | sym | a claim |"
+fixture "$URL" 200 0 $'x\nneedle here'
+printf 'verified https://raw.githubusercontent.com/WordPress/gutenberg/trunk/z.js\n' \
+	> "$SANDBOX/docs/new-note.md"
+run
+expect_rc 1
+expect_out "outside the registry"
+expect_out "new-note.md"
+
 # --- summary ---------------------------------------------------------------------
 echo
 echo "verify-sources tests: $pass passed, $fail failed"


### PR DESCRIPTION
## The bug

`bin/verify-sources.sh`'s orphan scan walks the **working tree**, which holds files git does not.

`reviewer-approved` — the pre-commit reviewer agent's approval flag — is gitignored, never committed, and routinely records the upstream URLs the reviewer just verified. So:

```
Source drift detected in docs/upstream-sources.md:
  - reviewer-approved cites upstream code outside the registry
```

…on any developer machine holding a current approval, while CI — a clean checkout with no flag — stayed green. I hit this repeatedly while landing #348 and #343.

A checker that reds only on the developer's machine is one people learn to run with their eyes closed, which costs more than the rule it enforces. `docs-lint.yml` already scopes its own scan with `git ls-files` for exactly this reason.

## The fix

Skip paths `git check-ignore` matches.

The filter is **"ignored", not "untracked"**, deliberately: a doc you have written but not yet committed still has to satisfy the registry rule, or the check would arrive one commit too late to stop the citation. `git check-ignore` consults the index first, so a *tracked* file that also matches an ignore rule stays in scope. Outside a git work tree git exits 128, nothing is skipped, and the scan behaves exactly as before — the failure mode here is a false positive, so degrading toward loud is correct.

## Tests

+2 cases in `tests/verify-sources/run.sh`, both needing a real work tree so the sandboxes get `git init`:

- **14** — a gitignored file carrying an upstream URL passes.
- **14b** — a non-ignored, untracked file in the *same* tree still fails. Without it, 14 would also pass if the fix had simply disabled the scan.

`46 passed, 0 failed`. Verified against the live repo too: reproduced the failure with the fix reverted, confirmed clean with it applied (`27 citations checked, all snippets present`).

Related: #361 (widen the ID prefix beyond `GB-`) is a separate concern in the same script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)