### PR TITLE
chore(release): roll main back to 4.9.0 — the MAJOR trigger no longer exists

### DIFF
--- a/docs/release-status.md
+++ b/docs/release-status.md
@@ -80,10 +80,10 @@ which is a ⚠️ **retroactive gap still open** for a maintainer reuse-or-rerun
 
 ## Current `main` release state
 
-- **Current `main` version:** `5.0.0` (runtime constant) — **unreleased**. The latest tag remains `v4.8.0` (cut 2026-07-23, on `10587a4`). `main` was bumped off the released identity on 2026-07-26 so that an unreleased tree stops advertising a shipped version; the bump carries no payload of its own. Unlike the `4.7.0` state, `main` has progressed **past** the tag with unreleased work (see next bullet). (`4.8.0` is the REST-gate security-hardening release plus the opt-in role/capability lockdown audit MVP; see the payload note above.)
+- **Current `main` version:** `4.9.0` (runtime constant) — **unreleased**. The latest tag remains `v4.8.0` (cut 2026-07-23, on `10587a4`). `main` was bumped off the released identity on 2026-07-26 so that an unreleased tree stops advertising a shipped version; the bump carries no payload of its own. Unlike the `4.7.0` state, `main` has progressed **past** the tag with unreleased work (see next bullet). (`4.8.0` is the REST-gate security-hardening release plus the opt-in role/capability lockdown audit MVP; see the payload note above.)
 - **Unreleased work on `main` past `v4.8.0`:** one security-hardening change plus three small features, documentation, and CI tooling — none version-bumped. **Security (the largest unreleased change):** the sudo proof format is replaced by a **self-authenticating, per-login-session record** (`_wp_sudo_proofs`, keyed by `sha256(verifier)`, entries `{ token, expires, hmac }`). The enforcement path verifies an `hash_hmac('sha256', …, wp_salt('auth'))` over the record and reads it **cache-bypassed**, closing a forged-assurance path in which an object-cache-poisoning primitive could plant a token hash for an attacker-controlled cookie and obtain sudo with no challenge (#278); keying per login session additionally gives a user's concurrent browsers independent sudo sessions (#279), and a just-expired proof is retained through its 120 s grace window so one browser's reauth cannot cancel another's in-flight replay. Pre-5.0.0 sessions carry no proof entry and require one reauthentication after upgrade (no migration). Doc'd in `docs/security-model.md`; the docblocks name the format as **5.0.0**. The next tag is **MAJOR** — decided, not open: the `#322` fix removes the documented `wp_sudo_action_replayed` hook, which `VERSIONING.md` classes as MAJOR (see *Development lanes* below). This assurance change on its own would have been a MINOR. **Features:** (1) the optional critical-event alert bridge now pushes a high-severity alert on role/capability drift (`wp_sudo_role_drift_detected` → bridge push), a backward-compatible addition in the optional companion bridge (PR #226); (2) **scoped break-glass recovery** — `WP_SUDO_RECOVERY_MODE` now accepts a user ID or login (grants break-glass to one named user instead of every `manage_options` holder), plus a pull-based Site Health critical status that flags active recovery mode and names its scope (PR #268, issue #240); (3) the **in-editor sudo session-status indicator** client UI — a build-free editor module surfacing session state via an announce-once snackbar (WP 6.4+) and a feature-detected countdown sidebar (WP 6.6+), with no read endpoint and no polling (PR #277 / #262). **Docs/CI:** the 4.8.0 live/manual security-test checklist + results (#223–#225); core-proposal, roadmap, and accuracy docs (#227–#234); the **ROADMAP restructure** — Pass 1/2 (forward-only Now/Next/Later + design essays promoted to standalone docs) merged as PR #236. (The feature backlog has been *filed* as GitHub issues **#238–#257**, but the ROADMAP sections that duplicate them are removed only by the **still-open Pass-3 PR #258** — so on `main` the backlog still lives in `ROADMAP.md` for now.) And the **persistent-options metrics gate** — a tokenizer-based dev/CI scanner (`bin/scan-persistent-options.php`) wired into `composer verify:metrics` (PR #237). None of those bumped `WP_SUDO_VERSION` when they landed; `main` now carries `5.0.0` (see the version bullets above). **This bullet is a convenience summary — the canonical, always-current drift source is `git log v4.8.0..main --oneline`.**
-- **Runtime version constant:** `5.0.0` on `main`. `WP_SUDO_VERSION` is set in `wp-sudo.php` (header + constant), `tests/bootstrap.php`, and `phpstan-bootstrap.php`; `readme.txt` Stable tag is `5.0.0`. All five version-sync points are in sync at `5.0.0`. **`blueprint.json` deliberately still targets the `v4.8.0` tag ZIP:** per [`VERSIONING.md`](../VERSIONING.md) the Playground install target is bumped **after** the tag is cut, never before, because the public "Try latest release" badge loads `blueprint.json` from `main` and a pre-tag bump would point the demo at a ZIP that does not exist yet. Bumping it is a tag-time step, not a drift.
-- **Current package metadata (on `main`):** `readme.txt` Stable tag `5.0.0` == header Version (no `stable_tag_mismatch`); `Requires at least 6.4`, `Requires PHP 8.2`, `Tested up to 7.0`. Package/listing name: **"Sudo – Admin Action Gating"** (UI brand "Sudo"; slug/text-domain stay `wp-sudo`).
+- **Runtime version constant:** `4.9.0` on `main`. `WP_SUDO_VERSION` is set in `wp-sudo.php` (header + constant), `tests/bootstrap.php`, and `phpstan-bootstrap.php`; `readme.txt` Stable tag is `5.0.0`. All five version-sync points are in sync at `5.0.0`. **`blueprint.json` deliberately still targets the `v4.8.0` tag ZIP:** per [`VERSIONING.md`](../VERSIONING.md) the Playground install target is bumped **after** the tag is cut, never before, because the public "Try latest release" badge loads `blueprint.json` from `main` and a pre-tag bump would point the demo at a ZIP that does not exist yet. Bumping it is a tag-time step, not a drift.
+- **Current package metadata (on `main`):** `readme.txt` Stable tag `4.9.0` == header Version (no `stable_tag_mismatch`); `Requires at least 6.4`, `Requires PHP 8.2`, `Tested up to 7.0`. Package/listing name: **"Sudo – Admin Action Gating"** (UI brand "Sudo"; slug/text-domain stay `wp-sudo`).
 - **Last archived release checklist:** `docs/archive/release-3.0.0-checklist.md`
 
 ## Development lanes (established 2026-07-26)
@@ -96,37 +96,39 @@ post-`4.8.0` churn.
 
 | Lane | Milestone | Clock | Admits |
 |---|---|---|---|
-| Plugin security release | `5.0.0 — security` | **Yes** — the only lane with one | The `5.0.0` payload plus its tag-time gates |
-| Plugin, everything else | `post-5.0.0` | No | Features, non-blocking bugs, follow-ups deferred out of `5.0.0` |
-| Plugin, next feature batch | `v5.1.0` | No | Curated multisite governance/break-glass batch — renumbered from `v5.0.0` when `5.0.0` was claimed by this security release. All backward-compatible additions, so MINOR is the correct class. |
+| Plugin security release | `4.9.0 — security` | **Yes** — the only lane with one | The `4.0.0` payload plus its tag-time gates |
+| Plugin, everything else | `post-4.9.0` | No | Features, non-blocking bugs, follow-ups deferred out of `4.9.0` |
+| Plugin, next feature batch | `v4.10.0` | No | Curated multisite governance/break-glass batch. All backward-compatible additions, so MINOR is the correct class. It had been renumbered to `v5.1.0` while this security release was claiming `5.0.0`; with that release now `4.9.0`, the batch returns to the next MINOR. |
 | Core proposal research | `core-gate proposal — v1 readiness` | No | Proposal/spec findings; **no plugin release depends on these** |
 | Core proposal, deferred | `core-gate: provenance/automation policy (deferred project)` | No | The automated-update provenance split (#320) |
 
-**Why `5.0.0` and not `4.9.0`.** The `#322` fix removes the only call site of
-`wp_sudo_action_replayed` — the gate no longer replays a stashed request, so there is
-no replay left to announce. That hook is a **documented public extension point**
-(`docs/developer-reference.md`, event code `1900009`), and [`VERSIONING.md`](../VERSIONING.md)
-classes removing a documented hook as **MAJOR**. Taken by the rule rather than by
-override: the release is `5.0.0`. Everything else in the payload would have been a
-MINOR on its own.
+**Why `4.9.0` — and why it was briefly `5.0.0`.** The MAJOR was taken by the rule, not by
+preference: the `#322` fix removed the only call site of `wp_sudo_action_replayed`, a
+**documented public extension point** (`docs/developer-reference.md`, event code `1900009`),
+and [`VERSIONING.md`](../VERSIONING.md) classes removing a documented hook as MAJOR.
 
-**`5.0.0` payload.** Landed: forge-resistant per-login-session assurance (#278, #279,
-PR #348) and the reauth-lockout out-of-band clear (#280, PR #343). Open: the stash
-confused-deputy fix (#322, PR #368 — the v1 fail-closed half). #273
-(release-environment matrix) rides the milestone as a **tag-time gate**, not payload —
-it was left open through `4.8.0` and must be run or explicitly waived before the tag
-is cut.
+**That fact no longer holds.** The `#322` **v2** layer (informed confirmation + origin-bound
+replay, PR #350) has since merged, and it restores replay — and with it the hook.
+`do_action( 'wp_sudo_action_replayed', … )` is live on `main` in
+`includes/class-challenge.php`. Nothing documented is removed in the shipping state, so the
+MAJOR trigger is gone and the same rule that produced `5.0.0` now produces a MINOR.
 
-**Deferred out of `5.0.0`.** The `#322` **v2** layer (informed confirmation +
-origin-bound replay, PR #350) is held back: all of its open review threads sit on that
-layer, none on v1. It restores replay, and therefore probably restores the removed
-hook — so its own version classification must be decided on its merits, not inherited
-from this release.
+This is the rule re-applied to changed facts, not an override of it — and it is exactly the
+outcome this document anticipated when it deferred v2: *"it restores replay, and therefore
+probably restores the removed hook — so its own version classification must be decided on its
+merits, not inherited from this release."* It was, and the merged payload is additive plus
+security fixes: **`4.9.0`**.
+
+**`4.9.0` payload.** Forge-resistant per-login-session assurance (#278, #279, PR #348), the
+reauth-lockout out-of-band clear (#280, PR #343), and the stash confused-deputy fix (#322) in
+its merged v2 form (PR #350). #273 (release-environment matrix) rides the milestone as a
+**tag-time gate**, not payload — it was left open through `4.8.0` and must be run or
+explicitly waived before the tag is cut.
 
 **Membership rule.** A review finding that is not a regression introduced by the PR
 under review gets **filed and deferred**, never bolted onto the PR in flight. #354,
 #355 and #356 are the worked examples — all three were split out of #348/#343 review
-rather than absorbed, and all three sit in `post-5.0.0`.
+rather than absorbed, and all three sit in `post-4.9.0`.
 
 ## WordPress.org publication status
 

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -337,7 +337,7 @@ attacker controls, forging an active sudo session with no challenge. This is a
 specific named exploit: the mitigations below do not depend on which primitive
 supplies the write.)
 
-**Mitigations (5.0.0):**
+**Mitigations (4.9.0):**
 
 - **Self-authenticating proof (HMAC).** Each proof entry carries
   `hash_hmac('sha256', "$user_id|$verifier|$token|$expires", wp_salt('auth'))`.

--- a/includes/class-site-health.php
+++ b/includes/class-site-health.php
@@ -342,7 +342,7 @@ class Site_Health {
 
 		// Clean up stale sessions automatically. The scalar expiry marker is
 		// >= every proof's expiry, so a stale scalar means all proofs are stale
-		// too; clear the whole proof record plus any legacy pre-5.0.0 rows.
+		// too; clear the whole proof record plus any legacy pre-4.9.0 rows.
 		foreach ( $stale_users as $uid ) {
 			delete_user_meta( $uid, Sudo_Session::META_KEY );
 			delete_user_meta( $uid, Sudo_Session::PROOF_META_KEY );

--- a/includes/class-sudo-session.php
+++ b/includes/class-sudo-session.php
@@ -71,13 +71,13 @@ class Sudo_Session {
 	 * the cache-bypass read still defends the cache-poison-only attacker. See
 	 * proposal #310 and docs/security-model.md.
 	 *
-	 * @since 5.0.0
+	 * @since 4.9.0
 	 * @var string
 	 */
 	public const PROOF_META_KEY = '_wp_sudo_proofs';
 
 	/**
-	 * Legacy user-meta key: pre-5.0.0 session binding token (SHA-256 of cookie).
+	 * Legacy user-meta key: pre-4.9.0 session binding token (SHA-256 of cookie).
 	 *
 	 * Superseded by PROOF_META_KEY. No longer read or written on the enforcement
 	 * path; retained only so teardown (clear_session_data), Site Health cleanup,
@@ -89,7 +89,7 @@ class Sudo_Session {
 	public const TOKEN_META_KEY = '_wp_sudo_token';
 
 	/**
-	 * Legacy user-meta key: pre-5.0.0 login-session bind (SHA-256 of verifier).
+	 * Legacy user-meta key: pre-4.9.0 login-session bind (SHA-256 of verifier).
 	 *
 	 * Superseded by the HMAC binding inside PROOF_META_KEY. No longer read or
 	 * written; retained only for teardown/uninstall cleanup of upgraded sites.
@@ -1043,7 +1043,7 @@ class Sudo_Session {
 
 		update_user_meta( $user_id, self::PROOF_META_KEY, $map );
 
-		// Cleanup: drop pre-5.0.0 token/bind rows from upgraded sites. Harmless
+		// Cleanup: drop pre-4.9.0 token/bind rows from upgraded sites. Harmless
 		// no-ops once removed; nothing on the enforcement path reads them.
 		delete_user_meta( $user_id, self::TOKEN_META_KEY );
 		delete_user_meta( $user_id, self::SESSION_BIND_META_KEY );
@@ -1258,7 +1258,7 @@ class Sudo_Session {
 	private static function clear_session_data( int $user_id ): void {
 		delete_user_meta( $user_id, self::META_KEY );
 		delete_user_meta( $user_id, self::PROOF_META_KEY );
-		// Legacy pre-5.0.0 keys — cleaned up on any teardown of an upgraded site.
+		// Legacy pre-4.9.0 keys — cleaned up on any teardown of an upgraded site.
 		delete_user_meta( $user_id, self::TOKEN_META_KEY );
 		delete_user_meta( $user_id, self::SESSION_BIND_META_KEY );
 

--- a/languages/wp-sudo.pot
+++ b/languages/wp-sudo.pot
@@ -2,7 +2,7 @@
 # This file is distributed under the GPL-2.0-or-later.
 msgid ""
 msgstr ""
-"Project-Id-Version: Sudo – Admin Action Gating 5.0.0\n"
+"Project-Id-Version: Sudo – Admin Action Gating 4.9.0\n"
 "Report-Msgid-Bugs-To: https://github.com/dknauss/Sudo/issues\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/phpstan-bootstrap.php
+++ b/phpstan-bootstrap.php
@@ -10,7 +10,7 @@
  */
 
 // Plugin constants (defined in wp-sudo.php at runtime).
-define( 'WP_SUDO_VERSION', '5.0.0' );
+define( 'WP_SUDO_VERSION', '4.9.0' );
 define( 'WP_SUDO_PLUGIN_DIR', __DIR__ . '/' );
 define( 'WP_SUDO_PLUGIN_URL', 'https://example.com/wp-content/plugins/wp-sudo/' );
 define( 'WP_SUDO_PLUGIN_BASENAME', 'wp-sudo/wp-sudo.php' );

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags:              reauthentication, access control, admin protection, multisite
 Requires at least: 6.4
 Tested up to:      7.0
 Requires PHP:      8.2
-Stable tag:        5.0.0
+Stable tag:        4.9.0
 License:           GPL-2.0-or-later
 License URI:       https://spdx.org/licenses/GPL-2.0-or-later.html
 

--- a/tests/Unit/ActionGatingCompletenessTest.php
+++ b/tests/Unit/ActionGatingCompletenessTest.php
@@ -175,7 +175,7 @@ class ActionGatingCompletenessTest extends TestCase {
 
 	/**
 	 * set_token() on a cookie-less surface (no login-session token) writes a proof
-	 * whose HMAC binds to the empty verifier, and clears the legacy pre-5.0.0 bind
+	 * whose HMAC binds to the empty verifier, and clears the legacy pre-4.9.0 bind
 	 * row so upgraded sites are cleaned up.
 	 */
 	public function test_set_token_clears_bind_when_no_session_token(): void {

--- a/tests/Unit/SudoSessionTest.php
+++ b/tests/Unit/SudoSessionTest.php
@@ -1946,7 +1946,7 @@ class SudoSessionTest extends TestCase
 		Functions\when( 'get_option' )->justReturn( array() );
 
 		// reset_failed_attempts deletes: legacy lockout + lockout_until + failure_event + throttle (4).
-		// set_token() also clears the two legacy pre-5.0.0 proof keys (TOKEN + BIND) (+2).
+		// set_token() also clears the two legacy pre-4.9.0 proof keys (TOKEN + BIND) (+2).
 		Functions\expect( 'delete_user_meta' )->times( 6 );
 
 		Sudo_Session::activate( 1 );

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -19,7 +19,7 @@ define( 'WPMU_PLUGIN_DIR', WP_CONTENT_DIR . '/mu-plugins' );
 define( 'WPMU_PLUGIN_URL', 'https://example.com/wp-content/mu-plugins' );
 
 // ── Plugin constants (normally defined in wp-sudo.php) ───────────────
-define( 'WP_SUDO_VERSION', '5.0.0' );
+define( 'WP_SUDO_VERSION', '4.9.0' );
 define( 'WP_SUDO_PLUGIN_DIR', dirname( __DIR__ ) . '/' );
 define( 'WP_SUDO_PLUGIN_URL', 'https://example.com/wp-content/plugins/wp-sudo/' );
 define( 'WP_SUDO_PLUGIN_BASENAME', 'wp-sudo/wp-sudo.php' );

--- a/uninstall.php
+++ b/uninstall.php
@@ -208,8 +208,8 @@ function wp_sudo_cleanup_mu_shim(): void {
 function wp_sudo_cleanup_user_meta(): void {
 	delete_metadata( 'user', 0, '_wp_sudo_expires', '', true );
 	delete_metadata( 'user', 0, '_wp_sudo_proofs', '', true );
-	delete_metadata( 'user', 0, '_wp_sudo_token', '', true ); // Legacy pre-5.0.0.
-	delete_metadata( 'user', 0, '_wp_sudo_session_bind', '', true ); // Legacy pre-5.0.0.
+	delete_metadata( 'user', 0, '_wp_sudo_token', '', true ); // Legacy pre-4.9.0.
+	delete_metadata( 'user', 0, '_wp_sudo_session_bind', '', true ); // Legacy pre-4.9.0.
 	delete_metadata( 'user', 0, '_wp_sudo_failed_attempts', '', true );
 	delete_metadata( 'user', 0, '_wp_sudo_failure_event', '', true );
 	delete_metadata( 'user', 0, '_wp_sudo_throttle_until', '', true );

--- a/wp-sudo.php
+++ b/wp-sudo.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Sudo – Admin Action Gating
  * Plugin URI:        https://github.com/dknauss/Sudo
  * Description:       Action-gated reauthentication for WordPress. Dangerous operations require password confirmation before they proceed — regardless of user role.
- * Version:           5.0.0
+ * Version:           4.9.0
  * Requires at least: 6.4
  * Requires PHP:      8.2
  * Author:            Dan Knauss
@@ -28,7 +28,7 @@ require_once __DIR__ . '/includes/functions-challenge-url.php';
 add_filter( 'map_meta_cap', 'wp_sudo_map_governance_meta_cap', 10, 4 );
 
 // Plugin version.
-define( 'WP_SUDO_VERSION', '5.0.0' );
+define( 'WP_SUDO_VERSION', '4.9.0' );
 
 // Plugin directory path.
 define( 'WP_SUDO_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );


### PR DESCRIPTION
## Why this isn't an override of the versioning rule

`5.0.0` was taken **by** the rule: #322 removed the only call site of `wp_sudo_action_replayed`, a documented public extension point (`developer-reference.md`, event code `1900009`), and [`VERSIONING.md`](VERSIONING.md) classes removing a documented hook as MAJOR.

**That fact no longer holds.** The #322 **v2** layer (PR #350) merged and restores replay — and with it the hook. `do_action( 'wp_sudo_action_replayed', … )` is live on `main` at `includes/class-challenge.php:1229`. Nothing documented is removed in the shipping state, so the MAJOR trigger is gone and the same rule now yields a **MINOR**.

This is the outcome `release-status.md` itself predicted when it deferred v2:

> *"it restores replay, and therefore probably restores the removed hook — so its own version classification must be decided on its merits, not inherited from this release."*

It was decided on its merits. The merged payload is additive plus security fixes → **4.9.0**.

## Changed (per the CLAUDE.md release checklist)
- `WP_SUDO_VERSION` in **all four** places + `readme.txt` Stable tag
- In-code proof-format boundary markers (`@since`, `legacy pre-X` comments in `class-sudo-session.php`, `uninstall.php`, `class-site-health.php`, and their tests) and the security-model mitigations heading — these name *the release the proof format changed in*, so they move with it
- `release-status.md`: the rationale is **rewritten, not deleted**, so the reversal and its reason stay on the record. The next feature batch returns to **`v4.10.0`** — it had only been pushed to `v5.1.0` because `5.0.0` was claimed.

## Deliberately untouched
`blueprint.json` still points at **`v4.8.0`**, the last tag that actually exists. Per `AGENTS.md` it is bumped **after** a tag is cut, never before — pointing it at an untagged version would serve a 404 to the public Playground demo.

## Gates
`test:unit` **1226 tests / 3611 assertions OK** · `lint` clean · PHPStan + Psalm clean · `verify:metrics` in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)