### PR TITLE
docs(planning): three traps from tonight's four-session coordination

### DIFF
--- a/.planning/SESSION-HANDOFF.md
+++ b/.planning/SESSION-HANDOFF.md
@@ -91,6 +91,25 @@ versioning has neither hazard — a doubled increment is harmless.
 4. **A `PHPUnit` red is often a cascade.** It is a summary job; when Code Quality fails
    (i18n, lint, static analysis), PHPUnit reports `dependency did not succeed`. Read the
    Code Quality log first.
+6. **`git diff A B` does not answer "what would merging do".** It is a two-tree diff, so
+   files that exist only on `main` read as *deletions* — one session concluded a branch
+   would delete the ~900-line `poc/` tree from that output alone. Use
+   `git merge-tree $(git merge-base A B) A B`, which shows those paths as **added in
+   remote**. The wrong command here does not error; it answers a different question
+   confidently.
+7. **A closed PR's patch survives its branch being deleted.**
+   `gh api repos/OWNER/REPO/pulls/N/files` still returns it. #390's branch was deleted as
+   redundant and its best paragraph was recovered from the closed PR afterwards. Do not
+   assume content is gone because the branch is.
+8. **Verify the enclosing symbol even when the claim comes from a source you trust.** A
+   hook was cited to `Challenge::handle_replay_response()` in cross-session messages and
+   in a PR comment; that method does not exist — the hook is in
+   `Challenge::build_replay_response_data()`. It survived because each reader verified the
+   parts they doubted and passed the symbol through, so repetition made it look
+   corroborated. `git grep -c "function <name>"` costs nothing and is the whole check.
+   Related: the repo's own prose rule already says a symbol you cannot name is a symbol you
+   have not read — that applies to symbols you were *handed*, not only ones you looked up.
+
 5. **Branches here can be shared.** Another session pushed to `fix/280-lockout-clear` while
    this one was working it. **Merge their commits, never force-push** — and re-run the gates
    after, since their new integration test arrived red.


### PR DESCRIPTION
Adds three traps to `SESSION-HANDOFF.md`. All cost real time tonight; none is discoverable from the code.

1. **`git diff A B` does not answer "what would merging do".** It's a two-tree diff, so main-only files read as **deletions** — one session concluded a branch would delete the ~900-line `poc/` tree from that output alone. `git merge-tree $(git merge-base A B) A B` shows them as *added in remote*. The wrong command doesn't error; it confidently answers a different question.
2. **A closed PR's patch survives branch deletion** — `gh api repos/OWNER/REPO/pulls/N/files`. #390's branch was deleted as redundant and its best paragraph recovered from the closed PR afterwards.
3. **Verify the enclosing symbol even when the claim comes from a source you trust.** A hook was cited to `Challenge::handle_replay_response()` across cross-session messages and a PR comment; that method doesn't exist — it's `Challenge::build_replay_response_data()`. It survived because each reader verified the parts they doubted and passed the symbol through, so repetition made it look corroborated. **I repeated it myself** in a #398 comment after independently checking every other claim in the same message; corrected [there](https://github.com/dknauss/Sudo/pull/398#issuecomment-5086113906).

The repo's prose rule already says a symbol you cannot name is one you have not read. Trap 3 extends it to symbols you were *handed*.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)