### PR TITLE
feat(322): make a refused replay auditable

### DIFF
--- a/bridges/wp-sudo-stream-bridge.php
+++ b/bridges/wp-sudo-stream-bridge.php
@@ -113,6 +113,16 @@ if ( ! function_exists( 'wp_sudo_stream_bridge_record_data' ) ) {
 				$record['args']['rule_id']    = (string) ( $args[1] ?? '' );
 				break;
 
+			case 'wp_sudo_replay_refused':
+				$record['message']            = 'WP Sudo replay refused';
+				$record['action']             = 'replay_refused';
+				$record['user_id']            = (int) ( $args[0] ?? 0 );
+				$record['object_id']          = $record['user_id'];
+				$record['args']['user_id']    = $record['user_id'];
+				$record['args']['rule_id']    = (string) ( $args[1] ?? '' );
+				$record['args']['reason']     = (string) ( $args[2] ?? '' );
+				break;
+
 			case 'wp_sudo_capability_tampered':
 				$record['message']              = 'WP Sudo capability tamper corrected';
 				$record['action']               = 'capability_tampered';
@@ -196,6 +206,7 @@ if ( ! function_exists( 'wp_sudo_stream_bridge_register' ) ) {
 			'wp_sudo_action_allowed'      => 3,
 			'wp_sudo_action_passed'       => 3,
 			'wp_sudo_action_replayed'     => 2,
+			'wp_sudo_replay_refused'      => 3,
 			'wp_sudo_capability_tampered' => 2,
 			'wp_sudo_policy_preset_applied' => 5,
 		);

--- a/bridges/wp-sudo-wsal-sensor.php
+++ b/bridges/wp-sudo-wsal-sensor.php
@@ -71,6 +71,12 @@ if ( ! function_exists( 'wp_sudo_wsal_bridge_event_payload' ) ) {
 				$payload['rule_id'] = (string) ( $args[1] ?? '' );
 				break;
 
+			case 'wp_sudo_replay_refused':
+				$payload['user_id'] = (int) ( $args[0] ?? 0 );
+				$payload['rule_id'] = (string) ( $args[1] ?? '' );
+				$payload['reason']  = (string) ( $args[2] ?? '' );
+				break;
+
 			case 'wp_sudo_capability_tampered':
 				$payload['role']       = (string) ( $args[0] ?? '' );
 				$payload['capability'] = (string) ( $args[1] ?? '' );
@@ -218,6 +224,14 @@ $wp_sudo_wsal_event_map = array(
 	'wp_sudo_capability_revoked'  => array( 'event_id' => 1900016, 'accepted_args' => 4 ),
 	'wp_sudo_gated_actions_missing_builtin_rules' => array( 'event_id' => 1900017, 'accepted_args' => 1 ),
 	'wp_sudo_rule_regex_error'    => array( 'event_id' => 1900018, 'accepted_args' => 3 ),
+	// #322 fail-closed counterpart to action_replayed (1900009). Distinct ID so
+	// alerting can subscribe to a refused replay separately from a successful one.
+	// Deliberately NOT throttled: the stash is consumed before the hook fires, so
+	// each event is a distinct one-shot refusal rather than one fact repeating.
+	// A time-window throttle would silently drop later refusals, and there is no
+	// ceiling that makes that safe — a user can create and consume stashes
+	// repeatedly, so an hour-long window could hide arbitrarily many.
+	'wp_sudo_replay_refused'      => array( 'event_id' => 1900019, 'accepted_args' => 3 ),
 );
 
 foreach ( $wp_sudo_wsal_event_map as $wp_sudo_hook => $wp_sudo_meta ) {

--- a/docs/current-metrics.md
+++ b/docs/current-metrics.md
@@ -9,9 +9,9 @@ Verification environment: local workspace, PHP 8.x
 
 | Metric | Value | Verification |
 |---|---:|---|
-| Unit tests | 1,231 tests | `composer test:unit` |
-| Unit assertions | 3,637 assertions | `composer test:unit` |
-| Integration tests in suite | 238 test methods | `rg -c "function test" tests/Integration/*.php | awk -F: '{sum+=$2} END{print sum}'` |
+| Unit tests | 1,238 tests | `composer test:unit` |
+| Unit assertions | 3,680 assertions | `composer test:unit` |
+| Integration tests in suite | 240 test methods | `rg -c "function test" tests/Integration/*.php | awk -F: '{sum+=$2} END{print sum}'` |
 | Unit test files | 38 | `ls tests/Unit/*.php | wc -l` |
 | Integration test files | 31 | `ls tests/Integration/*.php | wc -l` |
 
@@ -19,11 +19,11 @@ Verification environment: local workspace, PHP 8.x
 
 | Metric | Value | Verification |
 |---|---:|---|
-| Production PHP lines (`includes/`, `wp-sudo.php`, `uninstall.php`, `mu-plugin/`, `bridges/`) | 20,695 | `find ./includes ./wp-sudo.php ./uninstall.php ./mu-plugin ./bridges -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
-| Tests PHP lines (`tests/`) | 43,009 | `find ./tests -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
-| Production + tests PHP lines | 63,704 | sum of the two rows above |
-| Test-to-production ratio | 2.08:1 | `43009 / 20695` |
-| Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`, `.claude/`) | 65,979 | `find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/vendor_test/*" ! -path "*/.tmp/*" ! -path "*/.git/*" ! -path "*/.claude/*" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Production PHP lines (`includes/`, `wp-sudo.php`, `uninstall.php`, `mu-plugin/`, `bridges/`) | 20,832 | `find ./includes ./wp-sudo.php ./uninstall.php ./mu-plugin ./bridges -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Tests PHP lines (`tests/`) | 43,283 | `find ./tests -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Production + tests PHP lines | 64,115 | sum of the two rows above |
+| Test-to-production ratio | 2.08:1 | `43283 / 20832` |
+| Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`, `.claude/`) | 66,390 | `find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/vendor_test/*" ! -path "*/.tmp/*" ! -path "*/.git/*" ! -path "*/.claude/*" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
 
 ## Footprint & Performance
 
@@ -78,7 +78,7 @@ the count in prose without a verification command.
 | Gated rules (multisite) | 8 | `grep "'id'" includes/class-action-registry.php \| grep -c "network"` | v3.2.0 |
 | Gated rules (total) | 36 | `grep "'id'" includes/class-action-registry.php \| grep -v "rule\[" \| wc -l` | v3.2.0 |
 | Help tabs | 6 | `grep -c -- "->add_help_tab(" includes/class-admin.php` | v3.2.0 |
-| Audit hooks | 21 | `python3 - <<'PY'\nimport pathlib, re\nhooks = set()\nfor path in pathlib.Path('includes').glob('class-*.php'):\n    hooks.update(re.findall(r\"do_action\\(\\s*'([^']+)'\", path.read_text()))\nhooks.discard('wp_sudo_render_two_factor_fields')\nprint(len(hooks))\nPY` | Unreleased (wp_sudo_lockout_cleared, #280) |
+| Audit hooks | 22 | `python3 - <<'PY'\nimport pathlib, re\nhooks = set()\nfor path in pathlib.Path('includes').glob('class-*.php'):\n    hooks.update(re.findall(r\"do_action\\(\\s*'([^']+)'\", path.read_text()))\nhooks.discard('wp_sudo_render_two_factor_fields')\nprint(len(hooks))\nPY` | Unreleased (wp_sudo_lockout_cleared, #280) |
 | Settings fields (base) | 6 | 1 numeric (duration) + 1 preset chooser + 4 policy dropdowns (REST, CLI, Cron, XML-RPC) | v3.0.0 |
 | Settings fields (with WPGraphQL) | 7 | +1 conditional WPGraphQL policy dropdown | v3.0.0 |
 | E2E tests | 98 | `npx playwright test --config tests/e2e/playwright.config.ts --list` (verified 2026-07-26; +9 `editor-session-indicator.spec.ts` in-editor session-indicator tests — INDICATOR-01 grant→success snackbar (feed #2), INDICATOR-02 PluginSidebar M:SS countdown after grant, INDICATOR-03 feed-#1 active-at-load seeding, INDICATOR-04 deadline ticker → active→inactive at expiry + re-seed on a later grant, INDICATOR-05 page.clock setFixedTime past the deadline + refocus shows inactive — pinning that the display derives from the absolute deadline, not an interval tick count (fails if replaced by a decrementing counter; the focus/visibilitychange resync handler itself is code-review-verified since the panel also re-derives on remount), and the #288 at-a-glance padlock — INDICATOR-06 the at-rest button carries `dashicons-lock` on the stock button, INDICATOR-07 only the final minute paints a chip (active is the stock button; expiry reverts and leaves no body class behind), INDICATOR-08 all three states differ by SHAPE (lock / unlock / warning) and not only by colour, each tracked by a matching accessible name, INDICATOR-09 the active chip returns under core's `showIconLabels` preference — where core replaces the glyph with its own `check` and drops the tooltip — and does NOT paint without it, verified green against a live WP 7.0 wp-env; +3 `visual/regression-baselines.spec.ts` element snapshots, one per state (VISN-07 inactive closed padlock, VISN-05 active open padlock, VISN-06 expiring warning glyph on the red chip) and +1 guarded `capture-screenshots.spec.ts` test for the #284 listing screenshots 11-12, both of which run only in the `chromium-visual` project / under `WP_SUDO_CAPTURE=1` respectively but are counted by `--list`; 17 active `editor-reauth.spec.ts` in-editor-modal tests — EDITOR-01 modal-cancel→link-out, EDITOR-02 batch detect-and-surface (Q2), EDITOR-03/05 no-safe-URL degradation (C4), EDITOR-06 modal grant, EDITOR-07 rejected-submission recovery, EDITOR-08 2fa_pending links-out, EDITOR-09 stale-nonce refresh recovery, EDITOR-10 owner-scoped concurrent re-dispatch + EDITOR-11 shared-modal cancel fallback (Q3), EDITOR-12 modal never echoes the rule label (Q4), EDITOR-13 non-capable 2FA skips the modal + EDITOR-14 C4 wins over the 2FA skip, and Milestone B in-modal 2FA — EDITOR-15 modal-capable 2FA completes the second factor in place + generic serialize + neutralized native submit + re-dispatch, EDITOR-16 link_out partial falls back to snackbar, EDITOR-17 pending-expired 403 mid-2FA links out — verified green against a live WP Sudo env, no remaining `test.fixme`; +4 `wp-env-helper.spec.ts` pure-logic argv-safety tests — WPENV-01..04, no browser/wp-env — added with the E2E command-hardening refactor, re-verified 2026-07-26 via `--list` at 98 tests in 18 files) | v4.7.0 |

--- a/docs/developer-reference.md
+++ b/docs/developer-reference.md
@@ -617,9 +617,11 @@ do_action( 'wp_sudo_action_replayed', int $user_id, string $rule_id );
 //
 // This is NOT limited to the post-reauthentication path: it also fires from the
 // already-active-session resume paths, where no credential is presented and the
-// reason is no_credential_this_request. Do not treat those as filler — with no
-// password step involved, that is the branch the confused-deputy attack lands on
-// when the lured victim already holds a sudo session. Fires at most once per
+// reason is no_credential_this_request. That reason is the one worth alerting on
+// and the easiest to dismiss as noise: it is the footprint of a lure that landed
+// on a session-holder and was REFUSED. may_replay_bound_stash() rejects on a
+// missing credential before any other check, so nothing executed — it is not a
+// live hole — but the attempt is visible nowhere else. Fires at most once per
 // stash (the stash is consumed before the hook runs).
 do_action( 'wp_sudo_replay_refused', int $user_id, string $rule_id, string $reason );
 
@@ -855,11 +857,12 @@ Record mapping:
 - **Context:** `wp_sudo`
 - **Action:** derived from hook (`activated`, `deactivated`,
   `reauth_failed`, `lockout`, `gated`, `blocked`, `allowed`,
-  `passed`, `replayed`, `policy_preset_applied`, `capability_tampered`)
+  `passed`, `replayed`, `replay_refused`, `policy_preset_applied`,
+  `capability_tampered`)
 - **Args/meta:** always includes `source=wp-sudo` and `hook`, plus hook
   fields such as `user_id`, `rule_id`, `surface`, `attempts`, `ip`, `expires`,
-  `duration`, `preset_key`, `previous`, `current`, and `is_network` where
-  applicable.
+  `duration`, `preset_key`, `previous`, `current`, `reason` (the refusal reason
+  on `replay_refused`), and `is_network` where applicable.
 
 The bridge supports late Stream availability (mu-plugin loads before
 regular plugins) by deferring registration to `plugins_loaded` when

--- a/docs/developer-reference.md
+++ b/docs/developer-reference.md
@@ -607,6 +607,15 @@ do_action( 'wp_sudo_action_allowed', int $user_id, string $rule_id, string $surf
 do_action( 'wp_sudo_action_passed', int $user_id, string $rule_id, string $surface ); // Active session (v3.0.0).
 do_action( 'wp_sudo_action_replayed', int $user_id, string $rule_id );
 
+// Fires when a stashed action was NOT replayed after reauthentication (#322).
+// The counterpart to the above: without it the fail-closed path is silent, so a
+// reauthentication completed in a browser that did not start the action leaves no
+// audit trail and looks identical to nothing happening. $reason is one of
+// no_credential_this_request, redacted_fields, replay_blocked, incomplete_target,
+// no_binding_minted, no_proof_presented, proof_mismatch, url_altered,
+// insecure_replay_url.
+do_action( 'wp_sudo_replay_refused', int $user_id, string $rule_id, string $reason );
+
 // Admin-escalation guard (v4.1.0, opt-in via the wp_sudo_guard_escalation filter,
 // default OFF). High-severity, distinct from wp_sudo_action_blocked so external
 // alerting can subscribe to escalation specifically. Fires when a NEWLY granted

--- a/docs/developer-reference.md
+++ b/docs/developer-reference.md
@@ -607,13 +607,20 @@ do_action( 'wp_sudo_action_allowed', int $user_id, string $rule_id, string $surf
 do_action( 'wp_sudo_action_passed', int $user_id, string $rule_id, string $surface ); // Active session (v3.0.0).
 do_action( 'wp_sudo_action_replayed', int $user_id, string $rule_id );
 
-// Fires when a stashed action was NOT replayed after reauthentication (#322).
-// The counterpart to the above: without it the fail-closed path is silent, so a
+// Fires when a stashed action was discarded instead of replayed (#322). The
+// counterpart to the above: without it the fail-closed path is silent, so a
 // reauthentication completed in a browser that did not start the action leaves no
 // audit trail and looks identical to nothing happening. $reason is one of
 // no_credential_this_request, redacted_fields, replay_blocked, incomplete_target,
 // no_binding_minted, no_proof_presented, proof_mismatch, url_altered,
 // insecure_replay_url.
+//
+// This is NOT limited to the post-reauthentication path: it also fires from the
+// already-active-session resume paths, where no credential is presented and the
+// reason is no_credential_this_request. Do not treat those as filler — with no
+// password step involved, that is the branch the confused-deputy attack lands on
+// when the lured victim already holds a sudo session. Fires at most once per
+// stash (the stash is consumed before the hook runs).
 do_action( 'wp_sudo_replay_refused', int $user_id, string $rule_id, string $reason );
 
 // Admin-escalation guard (v4.1.0, opt-in via the wp_sudo_guard_escalation filter,
@@ -826,6 +833,7 @@ Event mapping:
 | `wp_sudo_capability_revoked` | `1900016` |
 | `wp_sudo_gated_actions_missing_builtin_rules` | `1900017` |
 | `wp_sudo_rule_regex_error` | `1900018` |
+| `wp_sudo_replay_refused` | `1900019` |
 
 `wp_sudo_recovery_mode_active` fires on every recovery-mode page load by
 design; the bridge throttles it to one event per user per hour (mirroring

--- a/includes/class-challenge.php
+++ b/includes/class-challenge.php
@@ -1311,9 +1311,14 @@ class Challenge {
 		 * `complete_active_session_request()` and `render_resume_page()`, where no
 		 * credential is presented and the reason is `no_credential_this_request`. A
 		 * consumer that assumes every fire follows a password step will misread
-		 * those. They are not filler: when a lured victim already holds a sudo
-		 * session there is no password step, so the #322 confused-deputy attack
-		 * lands on exactly that branch.
+		 * those.
+		 *
+		 * That reason is the highest-value one to alert on, and the easiest to
+		 * mistake for noise: it is the footprint of a lure that landed on a
+		 * session-holder and was refused. `may_replay_bound_stash()` rejects on
+		 * `! $credential_verified` before any other check, so NOTHING EXECUTED —
+		 * do not read this as a live hole and loosen that guard. But the attempt
+		 * is visible nowhere else.
 		 *
 		 * Fires at most once per stash — the stash is consumed (deleted) above
 		 * before this point, and a subsequent request finds nothing to refuse.

--- a/includes/class-challenge.php
+++ b/includes/class-challenge.php
@@ -1300,16 +1300,27 @@ class Challenge {
 		$this->clear_binding_cookie();
 
 		/**
-		 * Fires when a stashed action was NOT replayed after reauthentication.
+		 * Fires when a stashed action was discarded instead of replayed.
 		 *
 		 * The counterpart to `wp_sudo_action_replayed`. Without it the fail-closed
 		 * path is silent, so the case this whole mechanism exists to stop — someone
 		 * completing a reauthentication in a browser that did not start the action —
 		 * leaves no audit trail at all, and looks identical to nothing happening.
 		 *
+		 * NOT limited to the post-reauthentication path. This method also runs from
+		 * `complete_active_session_request()` and `render_resume_page()`, where no
+		 * credential is presented and the reason is `no_credential_this_request`. A
+		 * consumer that assumes every fire follows a password step will misread
+		 * those. They are not filler: when a lured victim already holds a sudo
+		 * session there is no password step, so the #322 confused-deputy attack
+		 * lands on exactly that branch.
+		 *
+		 * Fires at most once per stash — the stash is consumed (deleted) above
+		 * before this point, and a subsequent request finds nothing to refuse.
+		 *
 		 * @since 4.9.0
 		 *
-		 * @param int    $user_id The user who reauthenticated.
+		 * @param int    $user_id The user whose stashed action was discarded.
 		 * @param string $rule_id The rule ID that was gated.
 		 * @param string $reason  Why the replay was refused: no_credential_this_request,
 		 *                        redacted_fields, replay_blocked, incomplete_target,

--- a/includes/class-challenge.php
+++ b/includes/class-challenge.php
@@ -1104,19 +1104,24 @@ class Challenge {
 	 *
 	 * @param array<string, mixed> $stash               The stash data.
 	 * @param bool                 $credential_verified Whether a password/2FA was verified on THIS request.
+	 * @param string               $reason              Set to the refusal reason when this returns false,
+	 *                                                  so the caller can emit an auditable event.
 	 * @return bool
 	 */
-	private function may_replay_bound_stash( array $stash, bool $credential_verified ): bool {
+	private function may_replay_bound_stash( array $stash, bool $credential_verified, string &$reason = '' ): bool {
+		$reason = '';
 		// Only the post-credential paths. The already-active resume paths involve no
 		// password step at all and auto-submit on page load, so the cookie would be
 		// the only control between "victim opens a link" and "stashed POST executes".
 		if ( ! $credential_verified ) {
+			$reason = 'no_credential_this_request';
 			return false;
 		}
 
 		// Never replay a stash whose body was redacted or explicitly not replayable —
 		// it would submit a form with secret fields silently missing.
 		if ( ! empty( $stash['redacted_fields_omitted'] ) || ! empty( $stash['post_replay_blocked'] ) ) {
+			$reason = ! empty( $stash['redacted_fields_omitted'] ) ? 'redacted_fields' : 'replay_blocked';
 			return false;
 		}
 
@@ -1125,6 +1130,7 @@ class Challenge {
 		// the rest hidden) or when the payload carries an effect field the target does
 		// not name. Consent to a partial description is not consent to the whole effect.
 		if ( empty( $stash['target_complete'] ) ) {
+			$reason = 'incomplete_target';
 			return false;
 		}
 
@@ -1159,6 +1165,7 @@ class Challenge {
 		$expected = isset( $stash['binding_hash'] ) && is_string( $stash['binding_hash'] ) ? $stash['binding_hash'] : '';
 
 		if ( '' === $expected ) {
+			$reason = 'no_binding_minted';
 			return false;
 		}
 
@@ -1166,10 +1173,16 @@ class Challenge {
 		$presented = isset( $_COOKIE[ Request_Stash::BINDING_COOKIE ] ) ? sanitize_text_field( wp_unslash( (string) $_COOKIE[ Request_Stash::BINDING_COOKIE ] ) ) : '';
 
 		if ( '' === $presented ) {
+			$reason = 'no_proof_presented';
 			return false;
 		}
 
-		return hash_equals( $expected, hash( 'sha256', $presented ) );
+		if ( ! hash_equals( $expected, hash( 'sha256', $presented ) ) ) {
+			$reason = 'proof_mismatch';
+			return false;
+		}
+
+		return true;
 	}
 
 	/**
@@ -1227,7 +1240,9 @@ class Challenge {
 		// Consume the stash (one-time use).
 		$this->stash->delete( $stash_key, $user_id );
 
-		if ( $this->may_replay_bound_stash( $stash, $credential_verified ) ) {
+		$refusal_reason = '';
+
+		if ( $this->may_replay_bound_stash( $stash, $credential_verified, $refusal_reason ) ) {
 			$safe_url = wp_validate_redirect( $stash['url'], '' );
 
 			// Refuse rather than re-target: if validation altered the URL (e.g. a
@@ -1243,7 +1258,10 @@ class Challenge {
 			// Secure auth cookies. Fail closed instead of rewriting the URL.
 			$is_https = 0 === strpos( strtolower( (string) $stash['url'] ), 'https://' );
 
+			$refusal_reason = $is_https ? 'url_altered' : 'insecure_replay_url';
+
 			if ( '' !== $safe_url && $safe_url === $stash['url'] && $is_https ) {
+				$refusal_reason = '';
 				$this->clear_binding_cookie();
 
 				/**
@@ -1280,6 +1298,25 @@ class Challenge {
 		}
 
 		$this->clear_binding_cookie();
+
+		/**
+		 * Fires when a stashed action was NOT replayed after reauthentication.
+		 *
+		 * The counterpart to `wp_sudo_action_replayed`. Without it the fail-closed
+		 * path is silent, so the case this whole mechanism exists to stop — someone
+		 * completing a reauthentication in a browser that did not start the action —
+		 * leaves no audit trail at all, and looks identical to nothing happening.
+		 *
+		 * @since 4.9.0
+		 *
+		 * @param int    $user_id The user who reauthenticated.
+		 * @param string $rule_id The rule ID that was gated.
+		 * @param string $reason  Why the replay was refused: no_credential_this_request,
+		 *                        redacted_fields, replay_blocked, incomplete_target,
+		 *                        no_binding_minted, no_proof_presented, proof_mismatch,
+		 *                        url_altered, or insecure_replay_url.
+		 */
+		do_action( 'wp_sudo_replay_refused', $user_id, $stash['rule_id'] ?? '', $refusal_reason );
 
 		/*
 		 * #322 — fail closed, with a soft landing. The stashed action is NEVER

--- a/includes/class-dashboard-widget.php
+++ b/includes/class-dashboard-widget.php
@@ -323,6 +323,7 @@ class Dashboard_Widget {
 			'action_allowed'     => __( 'Allowed', 'wp-sudo' ),
 			'action_passed'      => __( 'Passed', 'wp-sudo' ),
 			'action_replayed'    => __( 'Replayed', 'wp-sudo' ),
+			'replay_refused'     => __( 'Not replayed', 'wp-sudo' ),
 			'recovery_mode'      => __( 'Break-glass', 'wp-sudo' ),
 			'escalation_blocked' => __( 'Escalation', 'wp-sudo' ),
 			'session_revoked'    => __( 'Revoked', 'wp-sudo' ),
@@ -1201,6 +1202,13 @@ class Dashboard_Widget {
 	background: #e7f0ff;
 	border-color: #c2d5fb;
 	color: #2e5fa9;
+}
+/* Amber, not the replayed blue: a refusal is the fail-closed outcome, and #322
+makes telling the two apart at a glance the point of logging it at all. */
+#wp_sudo_activity .wp-sudo-event-pill-replay-refused {
+	background: #fdf3e4;
+	border-color: #f0dcb8;
+	color: #8a5a1b;
 }
 #wp_sudo_activity .wp-sudo-event-pill-escalation-blocked {
 	background: #fbeeee;

--- a/includes/class-dashboard-widget.php
+++ b/includes/class-dashboard-widget.php
@@ -413,6 +413,7 @@ class Dashboard_Widget {
 		echo esc_html__( 'Passed', 'wp-sudo' );
 		echo '</option>';
 		echo '<option value="action_replayed">' . esc_html__( 'Replayed', 'wp-sudo' ) . '</option>';
+		echo '<option value="replay_refused">' . esc_html__( 'Not replayed', 'wp-sudo' ) . '</option>';
 		echo '</select>';
 
 		// Surface dropdown.

--- a/includes/class-event-recorder.php
+++ b/includes/class-event-recorder.php
@@ -22,6 +22,7 @@ namespace WP_Sudo;
  * - wp_sudo_action_allowed (policy: non-interactive request permitted)
  * - wp_sudo_action_passed (feature: gated action succeeds during active session)
  * - wp_sudo_action_replayed (flow: stashed request replayed after reauth)
+ * - wp_sudo_replay_refused (security: stashed request discarded, with reason)
  * - wp_sudo_recovery_mode_active (security: break-glass access, sampled hourly)
  * - wp_sudo_session_revoked (security: operator revoked sudo session(s) via UI)
  *

--- a/includes/class-event-recorder.php
+++ b/includes/class-event-recorder.php
@@ -42,6 +42,7 @@ class Event_Recorder {
 		'wp_sudo_action_allowed'       => 3, // user_id, rule_id, surface.
 		'wp_sudo_action_passed'        => 3, // user_id, rule_id, surface.
 		'wp_sudo_action_replayed'      => 2, // user_id, rule_id.
+		'wp_sudo_replay_refused'       => 3, // user_id, rule_id, reason (#322 fail-closed counterpart).
 		'wp_sudo_recovery_mode_active' => 1, // user_id.
 		'wp_sudo_session_revoked'      => 4, // target_user_id, revoker_user_id, reason, site_id.
 		'wp_sudo_role_drift_detected'  => 1, // report (high-severity role/cap drift audit alarm).
@@ -348,6 +349,54 @@ class Event_Recorder {
 				'event'   => 'action_replayed',
 				'rule_id' => $rule_id,
 				'surface' => '',
+			)
+		);
+	}
+
+	/**
+	 * Handle wp_sudo_replay_refused event.
+	 *
+	 * Fired when a stashed request was NOT replayed — the #322 fail-closed
+	 * counterpart to `action_replayed`. Without this row the refusal is silent
+	 * and indistinguishable from nothing having happened.
+	 *
+	 * EVERY reason is recorded, including `no_credential_this_request`. That one
+	 * is not routine noise to be filtered: it is the branch the confused-deputy
+	 * attack lands on when the lured victim already holds a sudo session, so no
+	 * password step occurs. Volume is bounded because
+	 * `build_replay_response_data()` consumes (deletes) the stash before firing:
+	 * one refusal per gated interception at most. Every such interception
+	 * already writes an `action_gated` row, so this adds at most one row per row
+	 * the recorder was writing anyway.
+	 *
+	 * The reason lands in `surface` rather than only `context` because
+	 * Event_Store::recent_for_dashboard() selects DASHBOARD_SELECT_COLUMNS,
+	 * which omits `context` — a context-only reason would be invisible in the
+	 * activity widget. (Event_Store::recent() selects `*`, so context IS
+	 * readable there; the widget is the constraint.) As with `session_revoked`,
+	 * the widget's Surface column therefore shows a reason tag rather than a
+	 * request surface.
+	 *
+	 * The reason is mirrored into `context` as headroom, not as a current
+	 * rescue: `surface` is clamped to 30 characters and the longest reason
+	 * (`no_credential_this_request`) is 26, so nothing truncates today. The
+	 * mirror keeps a longer future reason recoverable.
+	 *
+	 * @since 4.9.0
+	 *
+	 * @param int    $user_id User whose stashed action was discarded.
+	 * @param string $rule_id Action Registry rule ID.
+	 * @param string $reason  Why the replay was refused.
+	 * @return void
+	 */
+	public static function on_replay_refused( int $user_id, string $rule_id, string $reason ): void {
+		self::enqueue(
+			array(
+				'user_id' => $user_id,
+				'event'   => 'replay_refused',
+				'rule_id' => $rule_id,
+				'surface' => $reason,
+				'context' => array( 'reason' => $reason ),
 			)
 		);
 	}

--- a/languages/wp-sudo.pot
+++ b/languages/wp-sudo.pot
@@ -529,8 +529,8 @@ msgid "Controls non-cookie-auth REST requests (Application Passwords, Bearer tok
 msgstr ""
 
 #: includes/class-admin.php:731
-#: includes/class-dashboard-widget.php:425
-#: includes/class-dashboard-widget.php:800
+#: includes/class-dashboard-widget.php:426
+#: includes/class-dashboard-widget.php:801
 #: includes/class-site-health.php:227
 msgid "WP-CLI"
 msgstr ""
@@ -540,8 +540,8 @@ msgid "Disabled blocks all WP-CLI commands. Limited blocks only gated operations
 msgstr ""
 
 #: includes/class-admin.php:744
-#: includes/class-dashboard-widget.php:426
-#: includes/class-dashboard-widget.php:801
+#: includes/class-dashboard-widget.php:427
+#: includes/class-dashboard-widget.php:802
 #: includes/class-site-health.php:228
 msgid "Cron"
 msgstr ""
@@ -551,8 +551,8 @@ msgid "Disabled stops all cron execution (WP-Cron and server-level cron). Limite
 msgstr ""
 
 #: includes/class-admin.php:757
-#: includes/class-dashboard-widget.php:427
-#: includes/class-dashboard-widget.php:802
+#: includes/class-dashboard-widget.php:428
+#: includes/class-dashboard-widget.php:803
 #: includes/class-site-health.php:229
 msgid "XML-RPC"
 msgstr ""
@@ -734,7 +734,7 @@ msgstr ""
 
 #: includes/class-admin.php:2008
 #: includes/class-admin.php:2284
-#: includes/class-dashboard-widget.php:459
+#: includes/class-dashboard-widget.php:460
 msgid "Action"
 msgstr ""
 
@@ -743,24 +743,24 @@ msgid "Surfaces"
 msgstr ""
 
 #: includes/class-admin.php:2020
-#: includes/class-dashboard-widget.php:421
+#: includes/class-dashboard-widget.php:422
 msgid "Admin"
 msgstr ""
 
 #: includes/class-admin.php:2023
-#: includes/class-dashboard-widget.php:422
+#: includes/class-dashboard-widget.php:423
 msgid "AJAX"
 msgstr ""
 
 #: includes/class-admin.php:2026
-#: includes/class-dashboard-widget.php:423
+#: includes/class-dashboard-widget.php:424
 msgid "REST"
 msgstr ""
 
 #: includes/class-admin.php:2044
 #: includes/class-admin.php:2046
-#: includes/class-dashboard-widget.php:428
-#: includes/class-dashboard-widget.php:807
+#: includes/class-dashboard-widget.php:429
+#: includes/class-dashboard-widget.php:808
 msgid "GraphQL"
 msgstr ""
 
@@ -787,7 +787,7 @@ msgstr ""
 #: includes/class-admin.php:2084
 #: includes/class-admin.php:2161
 #: includes/class-admin.php:2283
-#: includes/class-dashboard-widget.php:457
+#: includes/class-dashboard-widget.php:458
 msgid "User"
 msgstr ""
 
@@ -885,8 +885,8 @@ msgid "See how Sudo would evaluate a representative request without executing it
 msgstr ""
 
 #: includes/class-admin.php:2594
-#: includes/class-dashboard-widget.php:460
-#: includes/class-dashboard-widget.php:794
+#: includes/class-dashboard-widget.php:461
+#: includes/class-dashboard-widget.php:795
 msgid "Surface"
 msgstr ""
 
@@ -1104,7 +1104,7 @@ msgstr ""
 #: includes/class-admin.php:2968
 #: includes/class-admin.php:3512
 #: includes/class-admin.php:3516
-#: includes/class-dashboard-widget.php:865
+#: includes/class-dashboard-widget.php:866
 msgid "Custom"
 msgstr ""
 
@@ -1503,6 +1503,7 @@ msgid "Replayed"
 msgstr ""
 
 #: includes/class-dashboard-widget.php:326
+#: includes/class-dashboard-widget.php:416
 msgid "Not replayed"
 msgstr ""
 
@@ -1550,125 +1551,125 @@ msgstr ""
 msgid "All Sessions"
 msgstr ""
 
-#: includes/class-dashboard-widget.php:419
+#: includes/class-dashboard-widget.php:420
 msgid "Filter events by request surface"
 msgstr ""
 
-#: includes/class-dashboard-widget.php:420
+#: includes/class-dashboard-widget.php:421
 msgid "All Surfaces"
 msgstr ""
 
-#: includes/class-dashboard-widget.php:424
+#: includes/class-dashboard-widget.php:425
 msgid "App Pass"
 msgstr ""
 
-#: includes/class-dashboard-widget.php:429
+#: includes/class-dashboard-widget.php:430
 msgid "Public API"
 msgstr ""
 
-#: includes/class-dashboard-widget.php:438
+#: includes/class-dashboard-widget.php:439
 msgid "Passed events are currently hidden by a code-level policy override."
 msgstr ""
 
-#: includes/class-dashboard-widget.php:445
+#: includes/class-dashboard-widget.php:446
 msgid "No recent activity"
 msgstr ""
 
-#: includes/class-dashboard-widget.php:452
+#: includes/class-dashboard-widget.php:453
 msgid "Recent event history"
 msgstr ""
 
-#: includes/class-dashboard-widget.php:454
+#: includes/class-dashboard-widget.php:455
 msgid "Recent sudo session events"
 msgstr ""
 
-#: includes/class-dashboard-widget.php:456
+#: includes/class-dashboard-widget.php:457
 msgid "Sort by Time"
 msgstr ""
 
-#: includes/class-dashboard-widget.php:456
+#: includes/class-dashboard-widget.php:457
 msgid "Time"
 msgstr ""
 
-#: includes/class-dashboard-widget.php:457
+#: includes/class-dashboard-widget.php:458
 msgid "Sort by User"
 msgstr ""
 
-#: includes/class-dashboard-widget.php:458
+#: includes/class-dashboard-widget.php:459
 msgid "Sort by Event"
 msgstr ""
 
-#: includes/class-dashboard-widget.php:458
+#: includes/class-dashboard-widget.php:459
 msgid "Event"
 msgstr ""
 
-#: includes/class-dashboard-widget.php:459
+#: includes/class-dashboard-widget.php:460
 msgid "Sort by Action"
 msgstr ""
 
-#: includes/class-dashboard-widget.php:460
+#: includes/class-dashboard-widget.php:461
 msgid "Sort by Surface"
 msgstr ""
 
 #. translators: %d is the deleted user's numeric ID.
-#: includes/class-dashboard-widget.php:477
+#: includes/class-dashboard-widget.php:478
 #, php-format
 msgid "Deleted user (#%d)"
 msgstr ""
 
-#: includes/class-dashboard-widget.php:518
+#: includes/class-dashboard-widget.php:519
 msgid "Critical"
 msgstr ""
 
 #. translators: %s is the technical action ID (for example options.wp_sudo).
-#: includes/class-dashboard-widget.php:522
+#: includes/class-dashboard-widget.php:523
 #, php-format
 msgid "Technical action ID: %s"
 msgstr ""
 
-#: includes/class-dashboard-widget.php:786
+#: includes/class-dashboard-widget.php:787
 msgid "Policy Summary"
 msgstr ""
 
-#: includes/class-dashboard-widget.php:787
+#: includes/class-dashboard-widget.php:788
 msgid "Mode:"
 msgstr ""
 
-#: includes/class-dashboard-widget.php:790
+#: includes/class-dashboard-widget.php:791
 msgid "Policy details"
 msgstr ""
 
-#: includes/class-dashboard-widget.php:792
+#: includes/class-dashboard-widget.php:793
 msgid "Entry-point surface policies"
 msgstr ""
 
-#: includes/class-dashboard-widget.php:795
+#: includes/class-dashboard-widget.php:796
 msgid "Policy"
 msgstr ""
 
-#: includes/class-dashboard-widget.php:799
+#: includes/class-dashboard-widget.php:800
 msgid "App Passwords"
 msgstr ""
 
-#: includes/class-dashboard-widget.php:902
+#: includes/class-dashboard-widget.php:903
 msgid "No matching events"
 msgstr ""
 
-#: includes/class-dashboard-widget.php:903
+#: includes/class-dashboard-widget.php:904
 msgid "Event filters updated."
 msgstr ""
 
 #. translators: 1: sort column label (for example, Time), 2: direction (ascending/descending).
-#: includes/class-dashboard-widget.php:905
+#: includes/class-dashboard-widget.php:906
 #, php-format
 msgid "Sorted by %1$s (%2$s)."
 msgstr ""
 
-#: includes/class-dashboard-widget.php:906
+#: includes/class-dashboard-widget.php:907
 msgid "ascending"
 msgstr ""
 
-#: includes/class-dashboard-widget.php:907
+#: includes/class-dashboard-widget.php:908
 msgid "descending"
 msgstr ""
 

--- a/languages/wp-sudo.pot
+++ b/languages/wp-sudo.pot
@@ -529,8 +529,8 @@ msgid "Controls non-cookie-auth REST requests (Application Passwords, Bearer tok
 msgstr ""
 
 #: includes/class-admin.php:731
-#: includes/class-dashboard-widget.php:424
-#: includes/class-dashboard-widget.php:799
+#: includes/class-dashboard-widget.php:425
+#: includes/class-dashboard-widget.php:800
 #: includes/class-site-health.php:227
 msgid "WP-CLI"
 msgstr ""
@@ -540,8 +540,8 @@ msgid "Disabled blocks all WP-CLI commands. Limited blocks only gated operations
 msgstr ""
 
 #: includes/class-admin.php:744
-#: includes/class-dashboard-widget.php:425
-#: includes/class-dashboard-widget.php:800
+#: includes/class-dashboard-widget.php:426
+#: includes/class-dashboard-widget.php:801
 #: includes/class-site-health.php:228
 msgid "Cron"
 msgstr ""
@@ -551,8 +551,8 @@ msgid "Disabled stops all cron execution (WP-Cron and server-level cron). Limite
 msgstr ""
 
 #: includes/class-admin.php:757
-#: includes/class-dashboard-widget.php:426
-#: includes/class-dashboard-widget.php:801
+#: includes/class-dashboard-widget.php:427
+#: includes/class-dashboard-widget.php:802
 #: includes/class-site-health.php:229
 msgid "XML-RPC"
 msgstr ""
@@ -734,7 +734,7 @@ msgstr ""
 
 #: includes/class-admin.php:2008
 #: includes/class-admin.php:2284
-#: includes/class-dashboard-widget.php:458
+#: includes/class-dashboard-widget.php:459
 msgid "Action"
 msgstr ""
 
@@ -743,24 +743,24 @@ msgid "Surfaces"
 msgstr ""
 
 #: includes/class-admin.php:2020
-#: includes/class-dashboard-widget.php:420
+#: includes/class-dashboard-widget.php:421
 msgid "Admin"
 msgstr ""
 
 #: includes/class-admin.php:2023
-#: includes/class-dashboard-widget.php:421
+#: includes/class-dashboard-widget.php:422
 msgid "AJAX"
 msgstr ""
 
 #: includes/class-admin.php:2026
-#: includes/class-dashboard-widget.php:422
+#: includes/class-dashboard-widget.php:423
 msgid "REST"
 msgstr ""
 
 #: includes/class-admin.php:2044
 #: includes/class-admin.php:2046
-#: includes/class-dashboard-widget.php:427
-#: includes/class-dashboard-widget.php:806
+#: includes/class-dashboard-widget.php:428
+#: includes/class-dashboard-widget.php:807
 msgid "GraphQL"
 msgstr ""
 
@@ -787,7 +787,7 @@ msgstr ""
 #: includes/class-admin.php:2084
 #: includes/class-admin.php:2161
 #: includes/class-admin.php:2283
-#: includes/class-dashboard-widget.php:456
+#: includes/class-dashboard-widget.php:457
 msgid "User"
 msgstr ""
 
@@ -885,8 +885,8 @@ msgid "See how Sudo would evaluate a representative request without executing it
 msgstr ""
 
 #: includes/class-admin.php:2594
-#: includes/class-dashboard-widget.php:459
-#: includes/class-dashboard-widget.php:793
+#: includes/class-dashboard-widget.php:460
+#: includes/class-dashboard-widget.php:794
 msgid "Surface"
 msgstr ""
 
@@ -1104,7 +1104,7 @@ msgstr ""
 #: includes/class-admin.php:2968
 #: includes/class-admin.php:3512
 #: includes/class-admin.php:3516
-#: includes/class-dashboard-widget.php:864
+#: includes/class-dashboard-widget.php:865
 msgid "Custom"
 msgstr ""
 
@@ -1473,198 +1473,202 @@ msgid "View all sudo-active users (%d) →"
 msgstr ""
 
 #: includes/class-dashboard-widget.php:320
-#: includes/class-dashboard-widget.php:407
+#: includes/class-dashboard-widget.php:408
 msgid "Lockout"
 msgstr ""
 
 #: includes/class-dashboard-widget.php:321
-#: includes/class-dashboard-widget.php:408
+#: includes/class-dashboard-widget.php:409
 msgid "Gated"
 msgstr ""
 
 #: includes/class-dashboard-widget.php:322
-#: includes/class-dashboard-widget.php:409
+#: includes/class-dashboard-widget.php:410
 msgid "Blocked"
 msgstr ""
 
 #: includes/class-dashboard-widget.php:323
-#: includes/class-dashboard-widget.php:410
+#: includes/class-dashboard-widget.php:411
 msgid "Allowed"
 msgstr ""
 
 #: includes/class-dashboard-widget.php:324
-#: includes/class-dashboard-widget.php:412
+#: includes/class-dashboard-widget.php:413
 msgid "Passed"
 msgstr ""
 
 #: includes/class-dashboard-widget.php:325
-#: includes/class-dashboard-widget.php:414
+#: includes/class-dashboard-widget.php:415
 msgid "Replayed"
 msgstr ""
 
 #: includes/class-dashboard-widget.php:326
-msgid "Break-glass"
+msgid "Not replayed"
 msgstr ""
 
 #: includes/class-dashboard-widget.php:327
-msgid "Escalation"
+msgid "Break-glass"
 msgstr ""
 
 #: includes/class-dashboard-widget.php:328
+msgid "Escalation"
+msgstr ""
+
+#: includes/class-dashboard-widget.php:329
 msgid "Revoked"
 msgstr ""
 
-#: includes/class-dashboard-widget.php:392
+#: includes/class-dashboard-widget.php:393
 msgid "Recent Events"
 msgstr ""
 
-#: includes/class-dashboard-widget.php:395
+#: includes/class-dashboard-widget.php:396
 msgid "Recent events filters"
 msgstr ""
 
-#: includes/class-dashboard-widget.php:398
+#: includes/class-dashboard-widget.php:399
 msgid "Filter events by time range"
 msgstr ""
 
-#: includes/class-dashboard-widget.php:399
+#: includes/class-dashboard-widget.php:400
 msgid "All Time"
 msgstr ""
 
-#: includes/class-dashboard-widget.php:400
+#: includes/class-dashboard-widget.php:401
 msgid "Last 24 Hours"
 msgstr ""
 
-#: includes/class-dashboard-widget.php:401
+#: includes/class-dashboard-widget.php:402
 msgid "Last 7 Days"
 msgstr ""
 
-#: includes/class-dashboard-widget.php:405
+#: includes/class-dashboard-widget.php:406
 msgid "Filter events by session event type"
 msgstr ""
 
-#: includes/class-dashboard-widget.php:406
+#: includes/class-dashboard-widget.php:407
 msgid "All Sessions"
 msgstr ""
 
-#: includes/class-dashboard-widget.php:418
+#: includes/class-dashboard-widget.php:419
 msgid "Filter events by request surface"
 msgstr ""
 
-#: includes/class-dashboard-widget.php:419
+#: includes/class-dashboard-widget.php:420
 msgid "All Surfaces"
 msgstr ""
 
-#: includes/class-dashboard-widget.php:423
+#: includes/class-dashboard-widget.php:424
 msgid "App Pass"
 msgstr ""
 
-#: includes/class-dashboard-widget.php:428
+#: includes/class-dashboard-widget.php:429
 msgid "Public API"
 msgstr ""
 
-#: includes/class-dashboard-widget.php:437
+#: includes/class-dashboard-widget.php:438
 msgid "Passed events are currently hidden by a code-level policy override."
 msgstr ""
 
-#: includes/class-dashboard-widget.php:444
+#: includes/class-dashboard-widget.php:445
 msgid "No recent activity"
 msgstr ""
 
-#: includes/class-dashboard-widget.php:451
+#: includes/class-dashboard-widget.php:452
 msgid "Recent event history"
 msgstr ""
 
-#: includes/class-dashboard-widget.php:453
+#: includes/class-dashboard-widget.php:454
 msgid "Recent sudo session events"
 msgstr ""
 
-#: includes/class-dashboard-widget.php:455
+#: includes/class-dashboard-widget.php:456
 msgid "Sort by Time"
 msgstr ""
 
-#: includes/class-dashboard-widget.php:455
+#: includes/class-dashboard-widget.php:456
 msgid "Time"
 msgstr ""
 
-#: includes/class-dashboard-widget.php:456
+#: includes/class-dashboard-widget.php:457
 msgid "Sort by User"
 msgstr ""
 
-#: includes/class-dashboard-widget.php:457
+#: includes/class-dashboard-widget.php:458
 msgid "Sort by Event"
 msgstr ""
 
-#: includes/class-dashboard-widget.php:457
+#: includes/class-dashboard-widget.php:458
 msgid "Event"
 msgstr ""
 
-#: includes/class-dashboard-widget.php:458
+#: includes/class-dashboard-widget.php:459
 msgid "Sort by Action"
 msgstr ""
 
-#: includes/class-dashboard-widget.php:459
+#: includes/class-dashboard-widget.php:460
 msgid "Sort by Surface"
 msgstr ""
 
 #. translators: %d is the deleted user's numeric ID.
-#: includes/class-dashboard-widget.php:476
+#: includes/class-dashboard-widget.php:477
 #, php-format
 msgid "Deleted user (#%d)"
 msgstr ""
 
-#: includes/class-dashboard-widget.php:517
+#: includes/class-dashboard-widget.php:518
 msgid "Critical"
 msgstr ""
 
 #. translators: %s is the technical action ID (for example options.wp_sudo).
-#: includes/class-dashboard-widget.php:521
+#: includes/class-dashboard-widget.php:522
 #, php-format
 msgid "Technical action ID: %s"
 msgstr ""
 
-#: includes/class-dashboard-widget.php:785
+#: includes/class-dashboard-widget.php:786
 msgid "Policy Summary"
 msgstr ""
 
-#: includes/class-dashboard-widget.php:786
+#: includes/class-dashboard-widget.php:787
 msgid "Mode:"
 msgstr ""
 
-#: includes/class-dashboard-widget.php:789
+#: includes/class-dashboard-widget.php:790
 msgid "Policy details"
 msgstr ""
 
-#: includes/class-dashboard-widget.php:791
+#: includes/class-dashboard-widget.php:792
 msgid "Entry-point surface policies"
 msgstr ""
 
-#: includes/class-dashboard-widget.php:794
+#: includes/class-dashboard-widget.php:795
 msgid "Policy"
 msgstr ""
 
-#: includes/class-dashboard-widget.php:798
+#: includes/class-dashboard-widget.php:799
 msgid "App Passwords"
 msgstr ""
 
-#: includes/class-dashboard-widget.php:901
+#: includes/class-dashboard-widget.php:902
 msgid "No matching events"
 msgstr ""
 
-#: includes/class-dashboard-widget.php:902
+#: includes/class-dashboard-widget.php:903
 msgid "Event filters updated."
 msgstr ""
 
 #. translators: 1: sort column label (for example, Time), 2: direction (ascending/descending).
-#: includes/class-dashboard-widget.php:904
+#: includes/class-dashboard-widget.php:905
 #, php-format
 msgid "Sorted by %1$s (%2$s)."
 msgstr ""
 
-#: includes/class-dashboard-widget.php:905
+#: includes/class-dashboard-widget.php:906
 msgid "ascending"
 msgstr ""
 
-#: includes/class-dashboard-widget.php:906
+#: includes/class-dashboard-widget.php:907
 msgid "descending"
 msgstr ""
 

--- a/tests/Integration/GateLoggingTest.php
+++ b/tests/Integration/GateLoggingTest.php
@@ -216,6 +216,54 @@ class GateLoggingTest extends TestCase {
 	}
 
 	// ─────────────────────────────────────────────────────────────────────
+	// wp_sudo_replay_refused hook → 'replay_refused' event
+	// ─────────────────────────────────────────────────────────────────────
+
+	/**
+	 * Firing wp_sudo_replay_refused logs an event whose reason is retrievable.
+	 *
+	 * Asserts the reason in the `surface` column specifically. Event_Store::recent()
+	 * selects `*`, so a context-only reason would still be readable through this
+	 * call — what it would NOT survive is the activity widget, whose
+	 * recent_for_dashboard() SELECT omits `context` entirely. Asserting `surface`
+	 * here is what pins the reason to the column the widget can actually read.
+	 */
+	public function test_replay_refused_hook_logs_event_with_retrievable_reason(): void {
+		$user = $this->make_admin();
+		wp_set_current_user( $user->ID );
+
+		do_action( 'wp_sudo_replay_refused', $user->ID, 'user.delete', 'proof_mismatch' );
+
+		$events = Event_Store::recent( 10, 'replay_refused' );
+		$this->assertNotEmpty( $events, 'Event_Store should contain replay_refused event.' );
+
+		$event = $events[0];
+		$this->assertSame( 'replay_refused', $event['event'] );
+		$this->assertSame( (string) $user->ID, $event['user_id'] );
+		$this->assertSame( 'user.delete', $event['rule_id'] );
+		$this->assertSame( 'proof_mismatch', $event['surface'], 'the refusal reason must survive to the queryable column.' );
+	}
+
+	/**
+	 * The no-credential refusal is recorded, not filtered out.
+	 *
+	 * That reason arises on the already-active-session resume paths, which look
+	 * routine but are the branch the #322 confused-deputy attack lands on when
+	 * the lured victim already holds a sudo session — no password step occurs.
+	 * Dropping it as noise would blind the audit trail to the worst case.
+	 */
+	public function test_replay_refused_records_the_no_credential_reason(): void {
+		$user = $this->make_admin();
+		wp_set_current_user( $user->ID );
+
+		do_action( 'wp_sudo_replay_refused', $user->ID, 'plugin.activate', 'no_credential_this_request' );
+
+		$events = Event_Store::recent( 10, 'replay_refused' );
+		$this->assertNotEmpty( $events, 'the no-credential refusal must not be filtered out.' );
+		$this->assertSame( 'no_credential_this_request', $events[0]['surface'] );
+	}
+
+	// ─────────────────────────────────────────────────────────────────────
 	// Event_Store::count_since() verification
 	// ─────────────────────────────────────────────────────────────────────
 

--- a/tests/Unit/ChallengeTest.php
+++ b/tests/Unit/ChallengeTest.php
@@ -1888,6 +1888,60 @@ class ChallengeTest extends TestCase
 	}
 
 	/**
+	 * #322: a refused replay must be AUDITABLE.
+	 *
+	 * The fail-closed path fired no hook at all, so the case this mechanism exists to
+	 * stop — a reauthentication completed in a browser that did not start the action —
+	 * was indistinguishable from nothing happening. Bridges (WSAL/Stream) saw silence.
+	 */
+	public function test_refused_replay_fires_audit_hook_with_reason(): void
+	{
+		unset($_COOKIE[\WP_Sudo\Request_Stash::BINDING_COOKIE]);
+
+		$this->stash->shouldReceive('get')->once()->andReturn($this->boundPostStash('attacker-secret'));
+		$this->stash->shouldReceive('delete')->once();
+		$this->stubReplayEnv();
+
+		$captured = null;
+		Actions\expectDone('wp_sudo_replay_refused')
+			->once()
+			->whenHappen(function ($user_id, $rule_id, $reason) use (&$captured) {
+				$captured = array($user_id, $rule_id, $reason);
+			});
+
+		$data = $this->invokeReplay('planted-key', true);
+
+		$this->assertArrayNotHasKey('replay', $data);
+		$this->assertSame(42, $captured[0]);
+		$this->assertSame(
+			'no_proof_presented',
+			$captured[2],
+			'The audit event must say WHY the replay was refused, not merely that it was.'
+		);
+	}
+
+	/**
+	 * #322: a successful bound replay must NOT fire the refusal hook.
+	 */
+	public function test_successful_bound_replay_does_not_fire_refused_hook(): void
+	{
+		$secret = 'super-secret-proof';
+		$_COOKIE[\WP_Sudo\Request_Stash::BINDING_COOKIE] = $secret;
+
+		$this->stash->shouldReceive('get')->once()->andReturn($this->boundPostStash($secret));
+		$this->stash->shouldReceive('delete')->once();
+		$this->stubReplayEnv();
+
+		Actions\expectDone('wp_sudo_replay_refused')->never();
+
+		$data = $this->invokeReplay('bound-key', true);
+
+		$this->assertTrue($data['replay'] ?? false);
+
+		unset($_COOKIE[\WP_Sudo\Request_Stash::BINDING_COOKIE]);
+	}
+
+	/**
 	 * #322 v2: the legitimate same-browser flow replays again (UX restored).
 	 */
 	public function test_bound_stash_replays_after_credential_verified(): void

--- a/tests/Unit/DashboardWidgetTest.php
+++ b/tests/Unit/DashboardWidgetTest.php
@@ -1588,6 +1588,34 @@ class DashboardWidgetTest extends TestCase {
 		$this->restoreWpdb();
 	}
 
+	/**
+	 * Test the refused-replay event has a human label and a styled pill.
+	 *
+	 * Writing a new `event` value into Event_Store is not self-contained: the
+	 * widget renders `$event_labels[ $event_type ] ?? $event_type`, so a missing
+	 * entry prints the raw `replay_refused` slug, and a missing pill rule renders
+	 * it unstyled next to eight styled siblings.
+	 *
+	 * @return void
+	 */
+	public function testReplayRefusedHasLabelAndPillStyle(): void {
+		Functions\when( '__' )->returnArg( 1 );
+
+		$method = new \ReflectionMethod( Dashboard_Widget::class, 'event_labels' );
+		@$method->setAccessible( true ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- Deprecated no-op on PHP 8.1+; suite-wide pattern for 8.0/8.5 parity.
+		$labels = $method->invoke( null );
+
+		$this->assertArrayHasKey( 'replay_refused', $labels );
+		$this->assertNotSame( 'replay_refused', $labels['replay_refused'], 'must be a human label, not the raw slug.' );
+
+		$source = (string) file_get_contents( dirname( __DIR__, 2 ) . '/includes/class-dashboard-widget.php' );
+		$this->assertStringContainsString(
+			'#wp_sudo_activity .wp-sudo-event-pill-replay-refused',
+			$source,
+			'the pill class the renderer derives from the event type has no CSS rule.'
+		);
+	}
+
 	// ─── Policy summary section tests ────────────────────────────────────
 
 	/**

--- a/tests/Unit/DashboardWidgetTest.php
+++ b/tests/Unit/DashboardWidgetTest.php
@@ -1614,6 +1614,16 @@ class DashboardWidgetTest extends TestCase {
 			$source,
 			'the pill class the renderer derives from the event type has no CSS rule.'
 		);
+
+		// The event-type <option> list is a SEPARATE inventory from event_labels():
+		// filterRows() only accepts values exposed by that select, so a refused
+		// replay would render in the table but could not be isolated from mixed
+		// activity — the one query an operator investigating a lure would run.
+		$this->assertStringContainsString(
+			'<option value="replay_refused">',
+			$source,
+			'refused replays are not selectable in the event-type filter.'
+		);
 	}
 
 	// ─── Policy summary section tests ────────────────────────────────────

--- a/tests/Unit/EventRecorderTest.php
+++ b/tests/Unit/EventRecorderTest.php
@@ -205,6 +205,10 @@ class EventRecorderTest extends TestCase {
 			->once()
 			->with( array( Event_Recorder::class, 'on_session_revoked' ), 10, 4 );
 
+		Actions\expectAdded( 'wp_sudo_replay_refused' )
+			->once()
+			->with( array( Event_Recorder::class, 'on_replay_refused' ), 10, 3 );
+
 		new Event_Recorder();
 	}
 
@@ -255,6 +259,7 @@ class EventRecorderTest extends TestCase {
 			'wp_sudo_action_allowed'       => 3,
 			'wp_sudo_action_passed'        => 3,
 			'wp_sudo_action_replayed'      => 2,
+			'wp_sudo_replay_refused'       => 3,
 			'wp_sudo_recovery_mode_active' => 1,
 			'wp_sudo_session_revoked'      => 4,
 			'wp_sudo_role_drift_detected'  => 1,
@@ -307,6 +312,7 @@ class EventRecorderTest extends TestCase {
 			'wp_sudo_action_allowed'       => 3,
 			'wp_sudo_action_passed'        => 3,
 			'wp_sudo_action_replayed'      => 2,
+			'wp_sudo_replay_refused'       => 3,
 			'wp_sudo_recovery_mode_active' => 1,
 			'wp_sudo_session_revoked'      => 4,
 			'wp_sudo_role_drift_detected'  => 1,
@@ -517,6 +523,58 @@ class EventRecorderTest extends TestCase {
 		$context = is_string( $data['context'] ) ? json_decode( $data['context'], true ) : $data['context'];
 		$this->assertIsArray( $context );
 		$this->assertSame( 7, $context['revoked_by'] );
+
+		$this->restoreWpdb();
+	}
+
+	/**
+	 * Test on_replay_refused() records the refusal reason in the surface column.
+	 *
+	 * The reason follows on_session_revoked()'s precedent and lands in `surface`
+	 * rather than only in context. See Event_Recorder::on_replay_refused() for
+	 * why: the activity widget's SELECT omits the context column.
+	 *
+	 * @return void
+	 */
+	public function testOnReplayRefusedRecordsReasonAsSurface(): void {
+		$this->setUpFakeWpdb();
+
+		Event_Recorder::on_replay_refused( 42, 'user.delete', 'proof_mismatch' );
+
+		$this->assertCount( 1, $this->fake_wpdb->inserts );
+
+		$data = $this->fake_wpdb->inserts[0]['data'];
+		$this->assertSame( 42, $data['user_id'] );
+		$this->assertSame( 'replay_refused', $data['event'] );
+		$this->assertSame( 'user.delete', $data['rule_id'] );
+		$this->assertSame( 'proof_mismatch', $data['surface'] );
+
+		$context = is_string( $data['context'] ) ? json_decode( $data['context'], true ) : $data['context'];
+		$this->assertIsArray( $context );
+		$this->assertSame( 'proof_mismatch', $context['reason'] );
+
+		$this->restoreWpdb();
+	}
+
+	/**
+	 * Test the no-credential refusal is recorded like any other.
+	 *
+	 * `no_credential_this_request` is NOT routine noise to be filtered out: it is
+	 * the branch the #322 confused-deputy attack lands on when the lured victim
+	 * already holds a sudo session, so no password step occurs. Dropping or
+	 * throttling it would blind the audit trail to the most dangerous case. The
+	 * stash is consumed (deleted) before the hook fires, so a refusal is bounded
+	 * to one per gated interception — each of which already writes a row.
+	 *
+	 * @return void
+	 */
+	public function testOnReplayRefusedRecordsTheNoCredentialReason(): void {
+		$this->setUpFakeWpdb();
+
+		Event_Recorder::on_replay_refused( 9, 'plugin.activate', 'no_credential_this_request' );
+
+		$this->assertCount( 1, $this->fake_wpdb->inserts, 'the no-credential refusal must not be filtered out.' );
+		$this->assertSame( 'no_credential_this_request', $this->fake_wpdb->inserts[0]['data']['surface'] );
 
 		$this->restoreWpdb();
 	}

--- a/tests/Unit/StreamBridgeTest.php
+++ b/tests/Unit/StreamBridgeTest.php
@@ -82,6 +82,7 @@ class StreamBridgeTest extends TestCase {
 			'wp_sudo_action_allowed',
 			'wp_sudo_action_passed',
 			'wp_sudo_action_replayed',
+			'wp_sudo_replay_refused',
 			'wp_sudo_capability_tampered',
 			'wp_sudo_policy_preset_applied',
 		);
@@ -218,6 +219,46 @@ class StreamBridgeTest extends TestCase {
 		$this->assertSame( 'wp_sudo_action_passed', $event['args']['hook'] ?? null );
 		$this->assertSame( 'plugin.activate', $event['args']['rule_id'] ?? null );
 		$this->assertSame( 'admin', $event['args']['surface'] ?? null );
+
+		\Brain\Monkey\tearDown();
+	}
+
+	/**
+	 * Test a refused replay reaches Stream with its reason.
+	 *
+	 * Without this the #322 fail-closed path is invisible to Stream: a
+	 * reauthentication completed in a browser that did not start the action
+	 * looks identical to nothing having happened.
+	 */
+	public function test_03d_bridge_maps_replay_refused_payload_to_stream_log(): void {
+		\Brain\Monkey\setUp();
+		$this->define_stream_stub();
+
+		$GLOBALS['wp_sudo_stream_test_instance'] = (object) array(
+			'log' => new \WP_Sudo_Stream_Test_Log(),
+		);
+
+		$callbacks = array();
+		Functions\when( 'add_action' )->alias(
+			static function ( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ) use ( &$callbacks ): bool {
+				$callbacks[ $hook ] = $callback;
+				return true;
+			}
+		);
+
+		include __DIR__ . '/../../bridges/wp-sudo-stream-bridge.php';
+
+		$this->assertArrayHasKey( 'wp_sudo_replay_refused', $callbacks );
+		$callbacks['wp_sudo_replay_refused']( 42, 'user.delete', 'proof_mismatch' );
+
+		$this->assertNotEmpty( \WP_Sudo_Stream_Test_Log::$events );
+
+		$event = \WP_Sudo_Stream_Test_Log::$events[0];
+		$this->assertSame( 'replay_refused', $event['action'] ?? null );
+		$this->assertSame( 42, $event['user_id'] ?? null );
+		$this->assertSame( 'wp_sudo_replay_refused', $event['args']['hook'] ?? null );
+		$this->assertSame( 'user.delete', $event['args']['rule_id'] ?? null );
+		$this->assertSame( 'proof_mismatch', $event['args']['reason'] ?? null );
 
 		\Brain\Monkey\tearDown();
 	}

--- a/tests/Unit/WsalSensorBridgeTest.php
+++ b/tests/Unit/WsalSensorBridgeTest.php
@@ -69,6 +69,7 @@ class WsalSensorBridgeTest extends TestCase {
 			'wp_sudo_action_allowed',
 			'wp_sudo_action_passed',
 			'wp_sudo_action_replayed',
+			'wp_sudo_replay_refused',
 			'wp_sudo_capability_tampered',
 			'wp_sudo_policy_preset_applied',
 		);
@@ -107,6 +108,40 @@ class WsalSensorBridgeTest extends TestCase {
 		$this->assertSame( 42, $event[1]['user_id'] ?? null );
 		$this->assertSame( 'plugin.activate', $event[1]['rule_id'] ?? null );
 		$this->assertSame( 'cli', $event[1]['surface'] ?? null );
+	}
+
+	/**
+	 * Test a refused replay maps to its own WSAL event carrying the reason.
+	 *
+	 * Distinct event_id from wp_sudo_action_replayed (1900009) so alerting can
+	 * subscribe to a refusal — the #322 fail-closed signal — separately from a
+	 * successful replay.
+	 */
+	public function test_03b_bridge_maps_replay_refused_with_reason(): void {
+		$this->define_wsal_alert_manager_stub();
+
+		$callbacks = array();
+		Functions\when( 'add_action' )->alias(
+			static function ( string $hook, callable $callback ) use ( &$callbacks ): bool {
+				$callbacks[ $hook ] = $callback;
+				return true;
+			}
+		);
+
+		include __DIR__ . '/../../bridges/wp-sudo-wsal-sensor.php';
+
+		$this->assertArrayHasKey( 'wp_sudo_replay_refused', $callbacks );
+
+		$callbacks['wp_sudo_replay_refused']( 42, 'user.delete', 'proof_mismatch' );
+
+		$this->assertNotEmpty( \WSAL\Controllers\Alert_Manager::$events );
+
+		$event = \WSAL\Controllers\Alert_Manager::$events[0];
+		$this->assertSame( 1900019, $event[0] );
+		$this->assertSame( 'wp_sudo_replay_refused', $event[1]['hook'] ?? null );
+		$this->assertSame( 42, $event[1]['user_id'] ?? null );
+		$this->assertSame( 'user.delete', $event[1]['rule_id'] ?? null );
+		$this->assertSame( 'proof_mismatch', $event[1]['reason'] ?? null );
 	}
 
 	/**


### PR DESCRIPTION
## The fail-closed path is silent

`wp_sudo_action_replayed` sits **inside** the bound-replay branch, so the case #322 exists to stop — a reauthentication completed in a browser that did not start the action — fired **no hook at all**. WSAL and Stream bridges saw silence on exactly the event worth recording, and a refused replay was indistinguishable from nothing happening.

Verified before writing: the only `do_action` in `build_replay_response_data()` is the replayed one.

## Change

Adds `wp_sudo_replay_refused( int $user_id, string $rule_id, string $reason )`, the counterpart to `wp_sudo_action_replayed`. The reason is **threaded out of `may_replay_bound_stash()`** rather than inferred at the call site, so the event says *why*:

`no_credential_this_request`, `redacted_fields`, `replay_blocked`, `incomplete_target`, `no_binding_minted`, `no_proof_presented`, `proof_mismatch`, `url_altered`, `insecure_replay_url`.

The last two come from the fall-through **inside** the bound branch (URL altered by `wp_validate_redirect`, or a non-HTTPS action URL under `FORCE_SSL_ADMIN`), which previously left no trace either.

## Why now

Raised by the Coordination session's #322 review. It matters more given their other finding: `Sec-Fetch-Site: same-origin` is satisfied by an ordinary link on the site's **own front end** into `/wp-admin/` — so a cross-browser lure needs no script execution in wp-admin, and until now was completely silent.

## Tests

Two, both asserting behaviour rather than existence: a refused replay fires the hook **with the correct reason**, and a successful bound replay does **not** fire it.

`composer test` 1,228 · lint · phpstan · psalm · verify:i18n · verify:metrics all pass. Documented in `developer-reference.md` beside its counterpart; audit-hook count 21 → 22 (the metrics gate caught that, not me).

🤖 Generated with [Claude Code](https://claude.com/claude-code)