### PR TITLE
fix(upgrader): forbid routines keyed at or below the 5.0.0 stamp (#393)

### DIFF
--- a/docs/current-metrics.md
+++ b/docs/current-metrics.md
@@ -9,8 +9,8 @@ Verification environment: local workspace, PHP 8.x
 
 | Metric | Value | Verification |
 |---|---:|---|
-| Unit tests | 1,226 tests | `composer test:unit` |
-| Unit assertions | 3,611 assertions | `composer test:unit` |
+| Unit tests | 1,227 tests | `composer test:unit` |
+| Unit assertions | 3,619 assertions | `composer test:unit` |
 | Integration tests in suite | 238 test methods | `rg -c "function test" tests/Integration/*.php | awk -F: '{sum+=$2} END{print sum}'` |
 | Unit test files | 38 | `ls tests/Unit/*.php | wc -l` |
 | Integration test files | 31 | `ls tests/Integration/*.php | wc -l` |
@@ -19,11 +19,11 @@ Verification environment: local workspace, PHP 8.x
 
 | Metric | Value | Verification |
 |---|---:|---|
-| Production PHP lines (`includes/`, `wp-sudo.php`, `uninstall.php`, `mu-plugin/`, `bridges/`) | 20,656 | `find ./includes ./wp-sudo.php ./uninstall.php ./mu-plugin ./bridges -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
-| Tests PHP lines (`tests/`) | 42,821 | `find ./tests -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
-| Production + tests PHP lines | 63,477 | sum of the two rows above |
-| Test-to-production ratio | 2.07:1 | `42821 / 20656` |
-| Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`, `.claude/`) | 65752 | `find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/vendor_test/*" ! -path "*/.tmp/*" ! -path "*/.git/*" ! -path "*/.claude/*" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Production PHP lines (`includes/`, `wp-sudo.php`, `uninstall.php`, `mu-plugin/`, `bridges/`) | 20,667 | `find ./includes ./wp-sudo.php ./uninstall.php ./mu-plugin ./bridges -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Tests PHP lines (`tests/`) | 42,858 | `find ./tests -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Production + tests PHP lines | 63,525 | sum of the two rows above |
+| Test-to-production ratio | 2.07:1 | `42858 / 20667` |
+| Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`, `.claude/`) | 65,800 | `find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/vendor_test/*" ! -path "*/.tmp/*" ! -path "*/.git/*" ! -path "*/.claude/*" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
 
 ## Footprint & Performance
 

--- a/includes/class-upgrader.php
+++ b/includes/class-upgrader.php
@@ -29,6 +29,17 @@ if ( ! defined( 'ABSPATH' ) ) {
  *    that introduces the change.
  * 2. Add the version string to the UPGRADES array, mapping it to the method name.
  * 3. The method will run exactly once for sites upgrading from an older version.
+ *
+ * ⚠️ 4. **Key it ABOVE 5.0.0.** `main` briefly carried version 5.0.0 before rolling
+ *    back to 4.9.0 (#391), so developer and staging installs that loaded it have
+ *    `wp_sudo_db_version` stamped 5.0.0. Because maybe_upgrade()'s guard is `>=`:
+ *      - a routine keyed below 5.0.0 never runs there while the runtime is <= 5.0.0;
+ *      - a routine keyed at *exactly* 5.0.0 never runs at all, not even once 5.0.0
+ *        genuinely ships, because stored == runtime still returns early.
+ *    Enforced by UpgraderTest::test_no_upgrade_routine_is_keyed_at_or_below_the_poisoned_stamp().
+ *    This is the same fix as upgrade_3_3_0()'s HISTORY note — re-key above every
+ *    stamp in the wild rather than rewriting stamps, which would reverse the
+ *    downgrade contract test_skips_when_version_is_newer() asserts. See #393.
  */
 class Upgrader {
 

--- a/poc/install-package-gate/README.md
+++ b/poc/install-package-gate/README.md
@@ -94,12 +94,32 @@ This slice implements a **reusable 15-minute window**. The spec has since moved 
 
 §11 item 3 ("flat freshness vs. scope-bound windows") is now **closed** — *"with no reusable window there is nothing to scope."* So what this slice does is not the spec's v1 recommendation; it is a **superseded** model that happens to be enough to demonstrate the seam.
 
-Concretely, the slice is missing:
+**What this slice is evidence about, and what it is not.** The spec is normative for *mechanism*; this slice is evidence about *behaviour*. It exercises a session-scoped proof with a TTL — the model that was current when it was written — and demonstrates two things that do not depend on which proof model is used:
 
-- **Per-action digest binding and single use.** Within its TTL the proof authorises *any* package write, so a session-riding attacker could substitute a different install ([#308](https://github.com/dknauss/Sudo/issues/308), and §5.1's redemption contract).
-- **An HMAC-signed record.** `has_proof()` trusts a transient. §4.2 requires the MAC to cover the proof hash, and a cache-bypassing read on the enforcement path, precisely because that storage is poisonable ([#310](https://github.com/dknauss/Sudo/issues/310)).
+- a copied login cookie cannot inherit a proof issued to another browser, and
+- `install_package()` fires after `unpack_package()`, so it is too late on its own.
 
-Both are tracked for alignment. The seam findings above — that the veto exists, and that `install_package()` fires too late — are independent of the proof model and stand regardless.
+Both hold under per-action step-up too. Neither is a claim that the TTL model is the right one.
+
+Concretely, the slice does **not** implement:
+
+- **Per-action digest binding and single use**, which §5.1 now requires. (Do not read the older #308 here as an open gap — it is **closed**, resolved by construction when §4.2 moved to per-action step-up: with no reusable window there is nothing to scope.)
+- **An HMAC-signed record.** `has_proof()` trusts a transient. §4.2 requires the MAC to cover the proof hash and a cache-bypassing read on the enforcement path, because that storage is poisonable ([#310](https://github.com/dknauss/Sudo/issues/310)).
+
+Reconciling the slice to per-action proofs is worthwhile but is not a prerequisite for either finding above.
+
+## Two traps this slice walked into, for whoever writes the next one
+
+**Drive the entry point, not the sink.** The first version of these tests called `install_package()` directly. That proves the check works *when reached* and says nothing about *whether it is reached* — which is exactly how the `unpack_package()` ordering above went unnoticed until a reviewer read `run()`. A gate test that invokes the gate is not a test of the gate's placement. Drive `run()`, or the admin request, or the REST route.
+
+**`git diff A B` does not answer "what would merging do."** It is a two-tree diff: files present on `A` and absent on `B` are reported as deletions, which reads exactly like `B` will delete them. It will not — a merge applies `B`'s diff *relative to its merge base*, so commits added to `A` afterwards survive. Ask the real question with:
+
+```bash
+git merge-tree $(git merge-base <branch> origin/main) <branch> origin/main   # paths from main show as `their`
+git diff $(git merge-base <branch> origin/main) <branch> -- <path>          # empty ⇒ branch never touched it
+```
+
+This cost a false alarm that `poc/` was about to be deleted by a stale branch. It wasn't.
 
 ## Running it
 

--- a/tests/Unit/UpgraderTest.php
+++ b/tests/Unit/UpgraderTest.php
@@ -914,4 +914,41 @@ class UpgraderTest extends TestCase {
 		// No exception thrown, no assertion failure — the test passes if execution reaches here.
 		$this->assertTrue( true );
 	}
+
+	/**
+	 * No upgrade routine may be keyed at or below 5.0.0.
+	 *
+	 * `main` briefly carried 5.0.0 before rolling back to 4.9.0 (#391), so
+	 * developer and staging installs that loaded it have `wp_sudo_db_version`
+	 * stamped 5.0.0. maybe_upgrade()'s guard is `>=`, so on those installs:
+	 *
+	 *   - a routine keyed BELOW 5.0.0 never runs while the runtime is <= 5.0.0;
+	 *   - a routine keyed at EXACTLY 5.0.0 never runs at all — not even once
+	 *     5.0.0 genuinely ships, because stored == runtime still returns early.
+	 *
+	 * Keying above the highest stamp in the wild is how this repo fixed the same
+	 * class of bug before: upgrade_3_3_0()'s HISTORY docblock records a routine
+	 * keyed at 3.1.0 that never ran for sites stamped 3.1.1-3.1.3 and silently
+	 * locked admins out. The fix was re-keying, not rewriting stamps — rewriting
+	 * would reverse the downgrade contract test_skips_when_version_is_newer()
+	 * asserts. See #393.
+	 */
+	public function test_no_upgrade_routine_is_keyed_at_or_below_the_poisoned_stamp() : void {
+		$ref = new \ReflectionClass( Upgrader::class );
+		$upgrades = $ref->getConstant( 'UPGRADES' );
+
+		$this->assertNotEmpty( $upgrades, 'sanity: UPGRADES should not be empty' );
+
+		foreach ( array_keys( $upgrades ) as $version ) {
+			$this->assertTrue(
+				version_compare( (string) $version, '5.0.0', '>' ) || version_compare( (string) $version, '4.9.0', '<' ),
+				sprintf(
+					'Upgrade routine keyed at %s will never run on installs stamped 5.0.0 '
+					. '(main carried it briefly; the >= guard skips them forever). '
+					. 'Key it above 5.0.0. See #393.',
+					$version
+				)
+			);
+		}
+	}
 }


### PR DESCRIPTION
Closes #393.

## The fix is a keying rule, not a stamp rewrite

`main` briefly carried `5.0.0` before rolling back to `4.9.0` (#391), so dev/staging installs that loaded it have `wp_sudo_db_version` stamped `5.0.0`. Because `maybe_upgrade()`'s guard is `>=`:

- a routine keyed **below** 5.0.0 never runs there while the runtime is ≤ 5.0.0;
- a routine keyed at **exactly** 5.0.0 never runs **at all** — not even once 5.0.0 genuinely ships, because `stored == runtime` still returns early.

This repo already solved this class of bug once. `upgrade_3_3_0()`'s `HISTORY` docblock records a routine keyed at `3.1.0` that never ran for sites stamped `3.1.1`–`3.1.3` and silently locked admins out; the fix was **re-keying above every stamp in the wild**, not rewriting stamps.

So: a unit test asserting no `UPGRADES` key falls in the dead band, plus a note in the **"HOW TO ADD A NEW UPGRADE"** docblock — where the next person actually looks, rather than in an issue they will never open.

Mutation-verified: keys of `5.0.0` **and** `4.9.0` both red the test with the reason in the message.

`maybe_upgrade()` is untouched. The corrective-migration option stays rejected — it reverses the contract `test_skips_when_version_is_newer()` asserts, and that guard protects a real case (a genuine downgrade where newer schema is already in place).

## What this replaces — a remedy I published that was unsafe

An earlier revision of #393 told operators to run `wp option delete wp_sudo_db_version`, with a per-site `xargs` loop for multisite. **Both were wrong**, and the issue now carries a retraction:

- **Multisite is network-scoped.** `get_db_version()` uses `get_site_option()` when `is_multisite()` → `wp_sitemeta`. `wp option delete` never touches it. The loop deletes rows the Upgrader does not read, changes nothing, and looks like it worked.
- **Deleting replays everything from `0.0.0`**, re-firing `upgrade_2_0_0`'s unconditional `remove_role( 'site_manager' )` (destroys any role with that slug, whoever created it) and `upgrade_3_3_0`'s backfill, which grants four governance capabilities to **every administrator** when it finds zero holders — silent privilege escalation, in a security plugin, from a command we recommended.

The pre-implementation design review caught both **before** any code was written. That is the CLAUDE.md process doing exactly what it is for, and it is why this PR contains a keying rule instead of the Site Health test I originally proposed.

## PoC README

Two changes, both from other sessions' findings:

**Stop citing a closed issue.** #308 closed as resolved-by-construction when §4.2 moved to per-action step-up. Per the Docs session, the README now states what the slice is *evidence about* — a copied login cookie cannot inherit a proof, and `install_package()` fires after `unpack_package()` — both of which hold under per-action step-up too. It no longer reads as endorsing the TTL model.

**Two traps recorded**, per Coordination:

- *Drive the entry point, not the sink.* The first version of these tests called `install_package()` directly, which proves the check works **when reached** and says nothing about **whether it is reached** — exactly how the unpack ordering went unnoticed until a reviewer read `run()`.
- *`git diff A B` is not a merge preview.* It reports main-only files as deletions. `git merge-tree $(git merge-base A B) A B` answers the real question. This cost a false alarm that `poc/` was about to be deleted by a stale branch.

## Gates

1227 tests / 3619 assertions; metrics in sync (six coupled rows updated); sources 31 citations; i18n POT in sync; phpcs; psalm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)