### PR TITLE
fix(process): clear the dangling registry reference #406 put on main

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -349,7 +349,15 @@ contract already existed on a third, unmerged branch. Both greps ran; both retur
 the conclusion was still wrong, because **the message had chosen the scope of the check**.
 
 The rule is therefore *verify the question, not the claim*: decide what would falsify the
-statement **before** running anything, and let that choose the command. This survives the
+statement **before** running anything, and let that choose the command.
+
+**The worst version of this is a command that answers confidently and wrongly.**
+`git branch -a --sort=-committerdate | head -20` is the reflex for "is anyone already working
+on this" — and it sorts by the date of the **commit a branch points at**, not the branch's
+creation. A branch cut minutes ago from an older commit sorts by that older date and falls
+off the list. It exits 0, prints a plausible answer, and omits exactly the case the command
+exists to catch. Prefer an explicit search — `git branch -a --list "*<issue>*"`, or
+`gh pr list` — and treat any "nothing found" from a sorted-and-truncated listing as unproven. This survives the
 common case where the claim is honest and merely narrow — which is most cases, and which a
 check aimed at dishonesty would miss entirely.
 
@@ -361,7 +369,8 @@ check aimed at dishonesty would miss entirely.
 - *"Does upstream never do Y?"* is **not** answerable by a `docs/upstream-sources.md` row.
   A must-contain snippet confirms a positive fact and cannot falsify an absence: if upstream
   added the call on an adjacent line, the row still passes while the claim silently becomes
-  false (see #388, and the note on `GB-CORE-UPDATE-SINK`).
+  false (see #388, and the "not machine-checked" note carried on the core-update row in
+  `docs/upstream-sources.md`).
 
 Both are the same error — treating "I looked and did not find it" as equivalent to "it is not
 there", when the looking was scoped by something other than the question. **Absence claims


### PR DESCRIPTION
**`composer verify:sources` is red on `main`** — `AGENTS.md` cites `GB-CORE-UPDATE-SINK`, but that row lives on the unmerged #378 branch, so `main` carries a reference with no row. Caught by the dangling-ID scan, which is exactly the guard for this.

Reported by the Coordination session, verified on a clean `main` at `ed4d902`.

**Fix:** describe the note instead of naming the ID. Adding the row here would duplicate #378's and conflict on merge, and the sentence never needed a specific citation — it illustrates a *class* of claim rather than resting on that row.

The irony is worth stating rather than stepping around: **the PR that introduced "verify the question, not the claim" is the one that broke the verification gate.** Same shape as the failure it documents — I checked the ID was correct, not that it resolved in the tree I was committing to.

**Also adds a better worked example** (supplied by Coordination): `git branch -a --sort=-committerdate | head -20` sorts by the date of the **commit a branch points at**, not branch creation — so a branch cut minutes ago from an older commit sorts by that older date and drops off the list. It exits 0, prints a plausible answer, and omits precisely the case it's run to catch. A silent failure, which is worse than a loud one.

`verify-sources`: 33 citations, green. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)