### PR TITLE
docs(roadmap): 4.10 action-confirmation API, and correct two entries it supersedes

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,7 +1,7 @@
 ---
 status: current
-applies_to: 5.0.x
-last_verified: 2026-07-26
+applies_to: 4.9.x
+last_verified: 2026-07-27
 canonical_for: forward roadmap (Now / Next / Later / Non-goals)
 ---
 
@@ -10,7 +10,7 @@ canonical_for: forward roadmap (Now / Next / Later / Non-goals)
 Forward-looking only. Shipped work lives in [`CHANGELOG.md`](../CHANGELOG.md); open
 work is tracked as GitHub issues; design analyses live in their own docs. Current
 release state is canonical in [`release-status.md`](release-status.md). Near-term work
-is grouped in the [**v5.1.0** milestone](https://github.com/dknauss/Sudo/milestone/1);
+is grouped in the [**post-4.9.0** milestone](https://github.com/dknauss/Sudo/milestone/5);
 the full backlog is in the [issues](https://github.com/dknauss/Sudo/issues), labeled
 `priority: high` / `medium` / `low`.
 
@@ -23,11 +23,11 @@ the full backlog is in the [issues](https://github.com/dknauss/Sudo/issues), lab
   `wp sudo manifest diff` / Site Health / cron run. Walk the network (manifest sites,
   or all blogs via `switch_to_blog()`), keep the cache-bypass reads per-blog, and
   consider a `--site=<id|url>` scope flag with batching for large networks.
-  `priority: high`, in the [v5.1.0 milestone](https://github.com/dknauss/Sudo/milestone/1); documented MVP limitation until shipped.
+  `priority: high`, in the [post-4.9.0 milestone](https://github.com/dknauss/Sudo/milestone/5); documented MVP limitation until shipped.
 
 ## Next
 
-- **Cross-site (network-admin) session revocation** ([#239](https://github.com/dknauss/Sudo/issues/239), `priority: high`, v5.1.0) —
+- **Cross-site (network-admin) session revocation** ([#239](https://github.com/dknauss/Sudo/issues/239), `priority: high`, post-4.9.0) —
   network revoke-all / by-user / by-site for incident response, reusing
   `Sudo_Session::deactivate()`.
 - **Session-store architecture** — evaluate and likely implement a dedicated
@@ -46,7 +46,7 @@ the full backlog is in the [issues](https://github.com/dknauss/Sudo/issues), lab
 - **Multisite terminology + coverage pass** — remaining Core-Trac-alignment work:
   standardize "network administrator" vs. "super admin"; review network-level
   gated-action coverage. Maps to Trac [#20140](https://core.trac.wordpress.org/ticket/20140).
-- **Scoped single-user recovery form** ([#240](https://github.com/dknauss/Sudo/issues/240), `priority: high`, v5.1.0) —
+- **Scoped single-user recovery form** ([#240](https://github.com/dknauss/Sudo/issues/240), `priority: high`, post-4.9.0) —
   `define( 'WP_SUDO_RECOVERY_MODE', <user> )`, plus a `Site_Health::test_recovery_mode()`
   status; the open follow-up to the hardened break-glass (Phase R3).
 - **Test-scaffolding hardening** — blueprint rot-guard smoke lane (do first),
@@ -67,11 +67,121 @@ the full backlog is in the [issues](https://github.com/dknauss/Sudo/issues), lab
   cosmetic and self-heals (the server stays authoritative and re-challenges as needed).
   Distinct from the shipped in-editor reauth *modal* (Milestones A/B, v4.6/4.7).
 
+## 4.10 — Action-confirmation API (design)
+
+**The organising idea for 4.10, and a correction to how this project has framed the
+problem.** Everything below is design direction, not committed scope.
+
+### The defect class it closes
+
+`#429`, `#431`, `#436` and the settings-blanking path found in `#444` are not four
+bugs. They are four symptoms of one thing: **the gate discovers the action only after
+the request has been submitted.** By then the server holds an opaque already-sent
+request, and every option available to it is bad:
+
+| option | what it cost us |
+|---|---|
+| discard it | `#429` — the user lands on a screen with no form and the typed input is gone |
+| stash and auto-replay | the confused deputy `#322` exists to close |
+| reconstruct after reauth | the settings-blanking path — and for Settings-API pages this is **impossible**, not merely hard |
+
+That third row is the load-bearing evidence. `wp-admin/options.php` initialises
+`$value = null` and calls `update_option()` **unconditionally** for every option in
+`$allowed_options[$option_page]`, so a body carrying a subset does not save a subset —
+it blanks the remainder (`GB-OPTIONS-NULL-WRITE`). No allowlist narrower than the whole
+page can reproduce a save, and a wider one carries fields the confirmation cannot name.
+`options.critical` is therefore non-replayable as of `#444`. Reconstruction is not a
+tuning problem for that class of screen; it is unavailable.
+
+The deeper point is that intercept-after-submit makes **reauthentication stand in for
+authorization**. A password proves a person is present. It cannot prove they intended
+*this* action, because the action was chosen before the challenge began and was never
+shown to them. Only a deliberate final click on a named action supplies intent.
+
+### The flow
+
+```
+click → pause locally → server preflight → trusted reauth UI
+      → action-bound proof → user confirms → original request sent once
+```
+
+Properties that matter:
+
+- Intercept the click or submit **in the browser, before transmission**.
+- Identify the action and target from **server-defined metadata**, not from guessing at
+  URLs and field names. `Request_Stash::TARGET_PARAMS` is that guess, and `#431` is what
+  guessing costs: it named `default_role` on a Site Title change, and named *nothing* on
+  an administration-email takeover because core's field is `new_admin_email`.
+- Ask the server whether fresh authentication is required, rather than inferring it.
+- Reauthenticate through a **standard component**, so plugins integrate without
+  implementing authentication themselves.
+- Issue a **short-lived, single-use proof** bound to user, session, action, target and
+  the parameters that matter.
+- Show a final confirmation naming the concrete operation — "Upload plugin `acme.zip`".
+- Send the original request **once**, carrying that proof.
+- Re-enforce the proof at an **early server-side veto point**.
+
+Form contents never leave the page: passwords, uploads, selections and validation state
+stay in the document, so nothing sensitive is stored server-side awaiting replay.
+
+### Three layers, and only one of them is the boundary
+
+1. **Early server veto** — the non-bypassable enforcement layer. Unchanged in kind from
+   what ships today; this is what covers direct URLs, REST clients, legacy forms,
+   third-party admin pages and compromised scripts.
+2. **Preflight client** — the editor-like experience, as progressive enhancement.
+3. **Action-bound single-use proof** — what actually connects the reauthentication to
+   the operation the user approved.
+
+Layer 2 is UX and must never be mistaken for the boundary. Screens without integration
+fall back to **reauthenticate-then-resubmit**. Automatic replay is never the fallback.
+
+### Prevent-at-initiation is broader than the editor
+
+The plugin already ships one instance of this pattern with no JavaScript integration at
+all: `Gate::filter_plugin_action_links()` greys out gated links so the action cannot be
+started. That is the cheap rung, it works on ordinary admin pages, and it is why plugin
+activation was the one flow in this release that never lost anyone's work. The ladder is
+three rungs, not two: **prevent at initiation** where the surface is renderable,
+**preflight** where JavaScript owns the request, **server veto with an honest
+fail-closed landing** everywhere else.
+
+### The caveat that constrains the design
+
+An ordinary same-origin modal is **not intrinsically trustworthy against active
+admin-page XSS**. Malicious page script can inspect or imitate it, so password entry
+into a potentially compromised admin document cannot be treated as fully protected. The
+strongest form uses a browser-mediated credential (WebAuthn/passkeys) or a separately
+isolated authentication surface.
+
+This bears directly on a standing decline below: passkeys were declined in 2026-02-28 on
+**UX** grounds — OS biometric autofill already covered it. That reasoning does not
+answer an XSS-resistance argument, which is a security claim. The decline is not
+reversed here, but it must be re-decided on the new grounds rather than inherited.
+
+### Proposed demonstrator
+
+Implement it for **two** high-value operations only — plugin/theme upload, and
+file-editor save. Enough to establish the UX and the proof protocol; far short of
+modernising every `wp-admin` form. Scope creep here would repeat the mistake this
+release made in the small.
+
+### Related
+
+`#436` (multi-rule form described by one rule), `#445` (`options.critical` gates on
+presence rather than change), `#446` (REST aliases missing from `TARGET_PARAMS`), and
+the core proposal in
+[`core-sudo-gate-implementation-spec.md`](core-sudo-gate-implementation-spec.md) — whose
+confirm-then-redeem shape is the same idea at the core layer.
+
 ## Later (need design work)
 
-- **Client-side modal challenge** (GitHub-style inline reauth) — explicitly deferred:
-  design-heavy, no security gain over stash → challenge → replay. If built, re-evaluate
-  the password-first OS-autofill decision (see
+- **Client-side modal challenge** (GitHub-style inline reauth) — **rationale superseded,
+  see "4.10 — Action-confirmation API" above.** This entry previously read "no security
+  gain over stash → challenge → replay". That is no longer defensible: the replay path
+  carries a cost the in-page path does not, demonstrated in this release by a reachable
+  settings-blanking route and by reconstruction being impossible for Settings-API
+  screens. If built, re-evaluate the password-first OS-autofill decision (see
   [`security-model.md`](security-model.md#reauthentication-flow-password-first-design-rationale)).
 - **REST sudo-grant endpoint** (`POST /wp/v2/sudo`) for headless clients.
 - **Per-session / device sudo isolation** via `WP_Session_Tokens` — deferred:
@@ -106,9 +216,14 @@ the full backlog is in the [issues](https://github.com/dknauss/Sudo/issues), lab
 ## Non-goals / Declined
 
 - **Session extension without reauth** — undermines the time-bounded trust model.
-- **Passkey / WebAuthn as a standalone reauth factor** — declined 2026-02-28; OS
-  biometric autofill already covers the UX. (Key registration/deletion *gating* is a
-  separate concern, shipped via the WebAuthn bridge.)
+- **Passkey / WebAuthn as a standalone reauth factor** — declined 2026-02-28 on **UX**
+  grounds: OS biometric autofill already covers the experience. (Key
+  registration/deletion *gating* is a separate concern, shipped via the WebAuthn bridge.)
+  **Open to re-decision on different grounds:** the 4.10 preflight direction raises an
+  XSS-resistance argument — a same-origin modal cannot be trusted against active
+  admin-page script — which the 2026-02-28 reasoning never addressed. Still declined
+  until re-decided; recorded here so the decline is not inherited as though it answered
+  that question.
 - **`compatibility` governance mode** — removed in v4.0.0; not returning.
 - **`enforce_editor_unfiltered_html` relocation / REST early-exit micro-opts** — no
   measured benefit; relocation would add a front-end detection gap.


### PR DESCRIPTION
Records the organising idea for 4.10: bring the block editor's **pause-before-send** pattern into `wp-admin` as a progressively-enhanced action-confirmation API, rather than continuing to improve server-side stash and replay.

## Why this is a direction change, not a feature

`#429`, `#431`, `#436` and the settings-blanking path in `#444` are not four bugs. They are four symptoms of one thing: **the gate discovers the action only after the request has been submitted.** By then the server holds an opaque already-sent request, and all three options available to it failed in a specific way this release:

| option | what it cost |
|---|---|
| discard | #429 — user lands on a screen with no form, typed input gone |
| stash and auto-replay | the confused deputy #322 exists to close |
| reconstruct after reauth | the settings-blanking path — **impossible**, not merely hard |

That third row carries the argument. `wp-admin/options.php` initialises `$value = null` and calls `update_option()` unconditionally for every option in `$allowed_options[$option_page]`, so a partial body **blanks** the omitted ones (`GB-OPTIONS-NULL-WRITE`). No allowlist narrower than the whole page reproduces a save; a wider one carries fields the confirmation cannot name. Reconstruction is not a tuning problem for that class of screen — it is unavailable.

The deeper point: intercept-after-submit makes **reauthentication stand in for authorization**. A password proves presence. It cannot prove intent, because the action was chosen before the challenge began and was never shown to the user.

## Two entries corrected, not just added alongside

Leaving these would make the roadmap argue against its own new direction.

- **"Client-side modal challenge"** read *"no security gain over stash → challenge → replay."* No longer defensible — the replay path carries a cost the in-page path does not, demonstrated this release by a reachable settings-blanking route and by reconstruction being impossible for Settings-API screens.
- **Passkey/WebAuthn decline** was made on **UX** grounds (2026-02-28): biometric autofill covers the experience. The XSS-resistance argument here is a **security** claim that reasoning never addressed. **Not reversed** — flagged as needing re-decision on the new grounds rather than inheriting an answer to a different question.

## Stale release state fixed in the same file

`applies_to` said `5.0.x` against a `4.9.0` tree, and four links pointed at a **"v5.1.0" milestone that does not exist** (milestone 1 is titled `v5.0.0`) — leftovers from the version rollback. Now `4.9.x` and the real `post-4.9.0` milestone.

## Scope discipline

The proposed demonstrator is **two operations only** — plugin/theme upload and file-editor save. Enough to establish the UX and the proof protocol, far short of modernising every `wp-admin` form. Scoping it wider would repeat in the large the mistake this release made in the small.

Design direction only; nothing here is committed scope. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)