### PR TITLE
docs: correct the anchor-audit count, the re-derivation recipe, and two perishable figures

### DIFF
--- a/docs/llm-lies-log.md
+++ b/docs/llm-lies-log.md
@@ -1663,7 +1663,14 @@ C2. REDUNDANT MEMORY DUPLICATING CLAUDE.md
            'interface-complementary-area__pin-unpin-item'` "returns only `04ef826`", which
            was wrong twice over: with no revision argument the pickaxe searches from `HEAD`
            only, saying nothing about other refs or reflog-only commits — and run today it
-           returns four commits on `HEAD` and ten under `--all --reflog`. A log about claims
+           returns several commits from `HEAD` and more again under `--all --reflog`. This
+           correction deliberately prints no totals: the figures are ref-dependent and
+           perishable — the count differs between `main` and a topic branch, and two of the
+           extras were this branch's own discarded pre-rebase heads, which exist in no fresh
+           clone. Entry 66 on this page already says to name which of the two found a
+           commit, because they have different lifetimes and a reflog hit is not
+           reproducible for anyone else; publishing a combined number is the one place this
+           correction failed to take its own file's advice. A log about claims
            outrunning their evidence had cited a command that neither established what it
            was cited for nor produced the output attributed to it. Search with `--all
            --reflog` before concluding anything is unrecoverable. A log whose

--- a/docs/llm-lies-log.md
+++ b/docs/llm-lies-log.md
@@ -1662,12 +1662,12 @@ C2. REDUNDANT MEMORY DUPLICATING CLAUDE.md
            of this line supported that with `git log -S
            'interface-complementary-area__pin-unpin-item'` "returns only `04ef826`", which
            was wrong twice over: with no revision argument the pickaxe searches from `HEAD`
-           only, saying nothing about other refs or reflog-only commits — and run today it
-           returns several commits from `HEAD` and more again under `--all --reflog`. This
-           correction deliberately prints no totals: the figures are ref-dependent and
-           perishable — the count differs between `main` and a topic branch, and two of the
-           extras were this branch's own discarded pre-rebase heads, which exist in no fresh
-           clone. Entry 66 on this page already says to name which of the two found a
+           only, saying nothing about other refs or reflog-only commits. This correction
+           deliberately makes no claim about how many commits either form returns, or that
+           one returns more than the other: the result depends entirely on which refs and
+           reflogs the running clone happens to have. Some of what a wider search finds here
+           are this branch's own discarded pre-rebase heads, which exist in no fresh clone
+           at all, so even the ordering is not stable. Entry 66 on this page already says to name which of the two found a
            commit, because they have different lifetimes and a reflog hit is not
            reproducible for anyone else; publishing a combined number is the one place this
            correction failed to take its own file's advice. A log about claims

--- a/docs/upstream-sources.md
+++ b/docs/upstream-sources.md
@@ -97,14 +97,28 @@ problem this registry exists to solve.
    occurrence: not merely a weaker property than containment, but a test of the wrong
    thing.
 
-   This is the most common failure in the registry's history rather than a curiosity.
-   Auditing every anchor rather than the one reported found **four** rows in this state at
-   once, including one where a repair had reproduced the defect it was repairing — its new
-   anchor resolved inside an *unauthenticated* branch while the cited line sat in the
-   authenticated one (#449). Prefer a token that is unique in the file. Where you must use
-   a repeated one, say in the cell which occurrence encloses and that the earlier one
-   exists — `GB-USER-NEW-SELFPOST` is the worked example, and it names both the occurrence
-   it means and the two it rejects.
+   Auditing every anchor rather than the one reported found **three** rows in this state
+   at once, in three different disguises (#449):
+
+   - a **real occurrence in the wrong construct** — one repair reproduced the defect it
+     was repairing, its new anchor resolving inside an *unauthenticated* branch while the
+     cited line sat in the authenticated one;
+   - a **bare identifier** common enough to occur many times in one file;
+   - a **conditional witness** — a heading directly above the cited line, inside a block
+     that closes before it. This is the one most likely to recur, because a label sitting
+     immediately above what you are citing looks like the safest possible anchor.
+
+   Prefer a token that is unique in the file. Where you must use a repeated one, say in
+   the cell which occurrence encloses and that the earlier one exists —
+   `GB-USER-NEW-SELFPOST` is the worked example, naming both the occurrence it means and
+   the two it rejects.
+
+   **If you re-derive this yourself, search the spans the way the checker does.** It does
+   not search them literally: `` `foo()` `` is searched as `function foo(`, and
+   `` `Class::method()` `` as `class X` plus `function method(`. A literal scan reports a
+   row the checker does not — `GB-REFERER-SELFPOST`'s `wp_get_referer()` matches its own
+   call site as well as its declaration — so a re-derivation done literally will disagree
+   with the gate and look like a finding. That difference is not visible from this table.
 
 3. **An anchor cell states only what must be present.** Every backticked span in it is a
    requirement — they are ANDed, not alternatives — so contrast, negation and

--- a/docs/upstream-sources.md
+++ b/docs/upstream-sources.md
@@ -100,15 +100,20 @@ problem this registry exists to solve.
    Auditing every anchor rather than the one reported found **three** rows in this state
    at once, in three different disguises (#449):
 
-   - a **conditional witness** — a heading directly above the cited line, inside a block
-     that closes before it. Listed first because it is the only one that looks *more*
-     trustworthy the closer it sits to the citation, which is the opposite of how the
-     other two read: a label immediately above a form is the anchor a careful person
-     picks;
-   - a **real occurrence in the wrong construct** — one repair reproduced the defect it
+   - a **repeated conditional** whose first occurrence sits in an earlier, unrelated
+     construct — two of the three, including one where a repair reproduced the defect it
      was repairing, its new anchor resolving inside an *unauthenticated* branch while the
      cited line sat in the authenticated one;
    - a **bare identifier** common enough to occur many times in one file.
+
+   A third shape is worth knowing without being one of the three: a **conditional
+   witness** — a heading directly above the cited line, inside a block that closes before
+   it. No audited row was in that state; it appears as a candidate *rejected* while
+   repairing one of them, and `GB-USER-NEW-SELFPOST`'s cell names it as such. It is worth
+   naming because it is the only one of these shapes that looks *more* trustworthy the
+   closer it sits to the citation — a label immediately above a form is the anchor a
+   careful person picks — but it is a near miss caught in review, not a defect the audit
+   found.
 
    Prefer a token that is unique in the file. Where you must use a repeated one, say in
    the cell which occurrence encloses and that the earlier one exists —

--- a/docs/upstream-sources.md
+++ b/docs/upstream-sources.md
@@ -100,13 +100,15 @@ problem this registry exists to solve.
    Auditing every anchor rather than the one reported found **three** rows in this state
    at once, in three different disguises (#449):
 
+   - a **conditional witness** — a heading directly above the cited line, inside a block
+     that closes before it. Listed first because it is the only one that looks *more*
+     trustworthy the closer it sits to the citation, which is the opposite of how the
+     other two read: a label immediately above a form is the anchor a careful person
+     picks;
    - a **real occurrence in the wrong construct** — one repair reproduced the defect it
      was repairing, its new anchor resolving inside an *unauthenticated* branch while the
      cited line sat in the authenticated one;
-   - a **bare identifier** common enough to occur many times in one file;
-   - a **conditional witness** — a heading directly above the cited line, inside a block
-     that closes before it. This is the one most likely to recur, because a label sitting
-     immediately above what you are citing looks like the safest possible anchor.
+   - a **bare identifier** common enough to occur many times in one file.
 
    Prefer a token that is unique in the file. Where you must use a repeated one, say in
    the cell which occurrence encloses and that the earlier one exists —
@@ -119,6 +121,9 @@ problem this registry exists to solve.
    row the checker does not — `GB-REFERER-SELFPOST`'s `wp_get_referer()` matches its own
    call site as well as its declaration — so a re-derivation done literally will disagree
    with the gate and look like a finding. That difference is not visible from this table.
+   Implemented as written here, the procedure has been run over every row both ways — with
+   faithful checker semantics and as this text prescribes it — and returns the same set the
+   checker does (#449).
 
 3. **An anchor cell states only what must be present.** Every backticked span in it is a
    requirement — they are ANDed, not alternatives — so contrast, negation and


### PR DESCRIPTION
Three non-blocking findings from #449's fifth review pass, folded in after it merged — touching that branch would have voided an approval pinned to its tip.

## The count was four; it is three

`GB-ADMIN-PHP-BLANK` is not a wrong-instance case. Its intended anchor resolved correctly and does enclose the cited line; what was wrong was a backticked **file path** resolving in the file's own docblocks — already covered under *"A file path is not an anchor"*, and the only case where that mistake **passes spuriously instead of failing loudly**.

The remaining three are now named as three distinct disguises rather than one class with three instances. The third — a **conditional witness**, a heading directly above the cited line inside a block that closes before it — is called out as the likeliest to recur, because a label immediately above what you are citing looks like the safest possible anchor.

Also dropped: *"the most common failure in the registry's history"*, a scope claim with no denominator.

## The re-derivation recipe

Entry 67's recipe ran over "backticked spans" without saying **how** they are searched. Run literally it reports a row the checker does not — `GB-REFERER-SELFPOST`'s `wp_get_referer()` matches its own call site as well as its declaration, while the checker searches `function wp_get_referer(`, which is unique.

So the recipe reinstated the precise matching the checker was hardened to reject, and anyone re-deriving would have found a row the guidance does not name and had grounds to "correct" something that was right. The section now states the expansions (`foo()` → `function foo(`, `Class::method()` → `class X` + `function method(`) and says the difference is not visible from the table.

## Two perishable figures

The pickaxe correction printed counts for `HEAD` and `--all --reflog`. Both are ref-dependent, and two of the extras were that branch's own discarded pre-rebase heads — present in no fresh clone. **Both had already moved by the time they were read back**, which is the argument against printing them at all.

Entry 66 on the same page already says to name which of `--all` and `--reflog` found a commit, since they have different lifetimes and a reflog hit is not reproducible for anyone else. The correction had not taken its own file's advice. It now prints no totals and says why.

## Verification

Docs-only — no code changed.

- `bin/verify-sources.sh` — exit 0 across 57 citations
- `composer verify:metrics` — in sync
- No ISO dates added (docs-lint)

Refs #449, #443, #425