### PR TITLE
fix(354): make the stale-session sweep and the liveness marker cache-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,53 @@
 
 ## Unreleased
 
+- **Site Health's stale-session sweep no longer deletes live or grace-eligible
+  sudo sessions (fix, #354).** The sweep selected users on the expiry marker
+  being set, then re-read that marker with `get_user_meta()` — a **cached**
+  read — while the enforcement path reads the signed proof record
+  **cache-bypassed**, precisely because a persistent `user_meta` entry can be
+  stale. The two could disagree, and a failed cache invalidation let the sweep
+  classify a live session as stale and delete every valid browser proof for
+  that user. Selection and classification now happen in one SQL query, so the
+  database is authoritative for both paths.
+
+  The same pass fixes a second defect that needed **no** cache failure at all:
+  the sweep used a bare "expired" test while `Sudo_Session::set_token()`'s own
+  housekeeping excludes the 120-second grace window, which exists so a
+  just-expired session can still finish an in-flight gated form rather than
+  losing the user's work. The sweep therefore deleted grace-eligible proofs up
+  to two minutes early on ordinary timing. Both sweeps now derive the boundary
+  from `Sudo_Session::GRACE_SECONDS` so they cannot drift apart again.
+
+  **Operator-visible:** cleanup of an expired session is now deferred by up to
+  120 seconds. That is the intended trade — the session is not enforcing during
+  that window, only its record is retained.
+
+- **Security — "revoke all sessions" could silently skip a live sudo session
+  (fix, #354).** The per-user expiry marker has one contract: it is at least as
+  late as every proof in the user's map, so nothing that enumerates on it can
+  miss a user whose sudo is still enforcing. `Sudo_Session::activate()`
+  maintained that contract by reading the marker back through the object cache
+  — twelve lines above a deliberately **cache-bypassed** read of the proof map.
+  A stale-low cached read wrote the new browser's expiry alone, which can sit
+  beneath another browser's live proof, and that value lands in the database.
+
+  `revoke_all_active_sessions()` selects on the marker in **SQL**, so an
+  operator's bulk revoke silently skipped a user whose sudo session was still
+  live and enforcing, and `is_session_live()` hid the per-user revoke on the
+  Users list for the same reason. A session that cannot be revoked is a worse
+  failure than one cleaned up too eagerly. The same too-low marker is also what
+  let the stale-session sweep above delete a live proof once the marker aged
+  past its cutoff, so this is what closes that path rather than narrowing it.
+
+  The marker is now derived in `set_token()` from the merged proof map it
+  already holds cache-bypassed, which always contains the activation being
+  written. The contract is therefore structural rather than maintained by
+  convention: the value cannot be lowered by a stale read, and the documented
+  #279 behaviour — a shorter session in one browser must not shrink the marker
+  for another — follows from the derivation instead of from a `max()` over a
+  cached value. No stored format changes and no migration is required.
+
 - **Project status clarified:** WP Sudo is explicitly classified as a research
   prototype and security-design demonstrator, not a supported production
   plugin or security boundary. Public documentation now limits evaluation to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,14 @@
   from `Sudo_Session::GRACE_SECONDS` so they cannot drift apart again.
 
   **Operator-visible:** cleanup of an expired session is now deferred by up to
-  120 seconds. That is the intended trade — the session is not enforcing during
-  that window, only its record is retained.
+  120 seconds. Be precise about what that window is: the sudo timer has expired,
+  but a cookie- and HMAC-bound proof is still **accepted by gated paths** during
+  it — `Gate` admits `is_active() || is_within_grace()`, so a gated action
+  initiated in that window still passes. The window exists so a reauthentication
+  completed moments earlier is not wasted, and the sweep was deleting proofs
+  inside it. Retaining them for the window it was already designed to honour is
+  the trade; describing it as "not enforcing" would understate the authority
+  that remains.
 
 - **Security — "revoke all sessions" could silently skip a live sudo session
   (fix, #354).** The per-user expiry marker has one contract: it is at least as
@@ -39,15 +45,34 @@
   Users list for the same reason. A session that cannot be revoked is a worse
   failure than one cleaned up too eagerly. The same too-low marker is also what
   let the stale-session sweep above delete a live proof once the marker aged
-  past its cutoff, so this is what closes that path rather than narrowing it.
+  past its cutoff; removing the stale-read cause narrows that path substantially
+  but does not close it, for the reason given below.
 
   The marker is now derived in `set_token()` from the merged proof map it
   already holds cache-bypassed, which always contains the activation being
-  written. The contract is therefore structural rather than maintained by
-  convention: the value cannot be lowered by a stale read, and the documented
-  #279 behaviour — a shorter session in one browser must not shrink the marker
-  for another — follows from the derivation instead of from a `max()` over a
-  cached value. No stored format changes and no migration is required.
+  written. The value can no longer be lowered by a **stale read**, and the
+  documented #279 behaviour — a shorter session in one browser must not shrink
+  the marker for another — follows from the derivation instead of from a `max()`
+  over a cached value. No stored format changes and no migration is required.
+
+  **Scope, stated because an earlier draft of this note overstated it:** this
+  removes the cache as a cause, not concurrency. The marker and the proof map are
+  still two non-atomic `update_user_meta()` calls, so two browsers activating at
+  the same moment can interleave such that the shorter session's marker is
+  written last while the longer session's proof survives in the map. Same too-low
+  marker, reached without any stale read. The condition is on the later
+  marker-writer alone: its value is too low if it read the map before the other
+  wrote its proof, whatever the other's read position was.
+
+  That race predates this change, and to be exact rather than flattering, the
+  derivation gives up an accidental cover the old read-back had: a second
+  activation was previously unsafe only if it read before the first wrote the
+  **marker**, and is now unsafe if it reads before the first writes the
+  **proof** — strictly later, so the pure-interleaving window is wider by the
+  duration of one `update_user_meta()`. That is traded against removing the far
+  larger cache-staleness cause, which is why this is still a clear improvement,
+  but it is a trade and not a free one. Tracked in
+  [#475](https://github.com/dknauss/Sudo/issues/475).
 
 - **Project status clarified:** WP Sudo is explicitly classified as a research
   prototype and security-design demonstrator, not a supported production

--- a/docs/current-metrics.md
+++ b/docs/current-metrics.md
@@ -19,11 +19,11 @@ Verification environment: local workspace, PHP 8.x
 
 | Metric | Value | Verification |
 |---|---:|---|
-| Production PHP lines (`includes/`, `wp-sudo.php`, `uninstall.php`, `mu-plugin/`, `bridges/`) | 21,129 | `find ./includes ./wp-sudo.php ./uninstall.php ./mu-plugin ./bridges -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Production PHP lines (`includes/`, `wp-sudo.php`, `uninstall.php`, `mu-plugin/`, `bridges/`) | 21,138 | `find ./includes ./wp-sudo.php ./uninstall.php ./mu-plugin ./bridges -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
 | Tests PHP lines (`tests/`) | 44,948 | `find ./tests -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
-| Production + tests PHP lines | 66,077 | sum of the two rows above |
-| Test-to-production ratio | 2.13:1 | `44948 / 21129` |
-| Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`, `.claude/`) | 68,352 | `find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/vendor_test/*" ! -path "*/.tmp/*" ! -path "*/.git/*" ! -path "*/.claude/*" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Production + tests PHP lines | 66,086 | sum of the two rows above |
+| Test-to-production ratio | 2.13:1 | `44948 / 21138` |
+| Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`, `.claude/`) | 68,361 | `find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/vendor_test/*" ! -path "*/.tmp/*" ! -path "*/.git/*" ! -path "*/.claude/*" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
 
 ## Footprint & Performance
 

--- a/docs/current-metrics.md
+++ b/docs/current-metrics.md
@@ -9,8 +9,8 @@ Verification environment: local workspace, PHP 8.x
 
 | Metric | Value | Verification |
 |---|---:|---|
-| Unit tests | 1,273 tests | `composer test:unit` |
-| Unit assertions | 3,812 assertions | `composer test:unit` |
+| Unit tests | 1,276 tests | `composer test:unit` |
+| Unit assertions | 3,827 assertions | `composer test:unit` |
 | Integration tests in suite | 243 test methods | `rg -c "function test" tests/Integration/*.php | awk -F: '{sum+=$2} END{print sum}'` |
 | Unit test files | 38 | `ls tests/Unit/*.php | wc -l` |
 | Integration test files | 31 | `ls tests/Integration/*.php | wc -l` |
@@ -19,11 +19,11 @@ Verification environment: local workspace, PHP 8.x
 
 | Metric | Value | Verification |
 |---|---:|---|
-| Production PHP lines (`includes/`, `wp-sudo.php`, `uninstall.php`, `mu-plugin/`, `bridges/`) | 21,012 | `find ./includes ./wp-sudo.php ./uninstall.php ./mu-plugin ./bridges -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
-| Tests PHP lines (`tests/`) | 44,764 | `find ./tests -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
-| Production + tests PHP lines | 65,776 | sum of the two rows above |
-| Test-to-production ratio | 2.13:1 | `44676 / 21012` |
-| Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`, `.claude/`) | 68,051 | `find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/vendor_test/*" ! -path "*/.tmp/*" ! -path "*/.git/*" ! -path "*/.claude/*" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Production PHP lines (`includes/`, `wp-sudo.php`, `uninstall.php`, `mu-plugin/`, `bridges/`) | 21,129 | `find ./includes ./wp-sudo.php ./uninstall.php ./mu-plugin ./bridges -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Tests PHP lines (`tests/`) | 44,948 | `find ./tests -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Production + tests PHP lines | 66,077 | sum of the two rows above |
+| Test-to-production ratio | 2.13:1 | `44948 / 21129` |
+| Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`, `.claude/`) | 68,352 | `find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/vendor_test/*" ! -path "*/.tmp/*" ! -path "*/.git/*" ! -path "*/.claude/*" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
 
 ## Footprint & Performance
 

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -384,9 +384,34 @@ always goes through the cache-bypassed, HMAC-verified proof. It can, however,
 the cache, and both `Admin::revoke_session_core()` and the Users-list row-action
 visibility gate consult it. A stale, expired copy therefore reports
 `target_expired` and can hide or refuse revocation for a session that is
-genuinely active — a fail-closed nuisance rather than a bypass, but a real one
-on a misconfigured cache. The reverse (a stale *live* value) only inflates the
+genuinely active. The reverse (a stale *live* value) only inflates the
 "Sudo Active" count, which is benign since revoking a phantom is a no-op.
+
+**This was previously described here as "a fail-closed nuisance rather than a
+bypass". That understated it, and the stored-value half is now fixed (#354).**
+The nuisance framing holds only while the marker in the *database* is correct
+and merely read stale. It was not: `activate()` maintained the marker's
+"at least as late as every proof" relationship from a **cached** read of the
+marker itself, so a stale-low read wrote a too-low marker into the database.
+`revoke_all_active_sessions()` selects on that marker in **SQL**, where no cache
+is involved — so an operator's bulk revoke silently skipped a user whose sudo
+was still enforcing. A session that cannot be revoked is not a nuisance.
+
+The marker is now derived in `Sudo_Session::set_token()` from the merged proof
+map, which is read cache-bypassed and always contains the activation being
+written, so a stale read cannot lower it. `Site_Health`'s stale-session sweep
+likewise classifies in SQL rather than re-reading the marker through the cache,
+and excludes the grace window.
+
+**What remains is the reader, and one race.** `is_session_live()` still reads
+the marker through the cache, so the fail-closed hiding described above is still
+reachable on a misconfigured cache even though the stale-read cause of a wrong
+stored value is removed (tracked in #474). Separately, the marker and the proof map are written as two
+non-atomic `update_user_meta()` calls: two browsers activating concurrently can
+interleave so that a shorter session's marker is paired with a longer session's
+live proof, reproducing the too-low marker without any cache involvement. The
+derivation removes the cache as a cause, not concurrency. Tracked in
+[#475](https://github.com/dknauss/Sudo/issues/475).
 
 **Risk: Stale rate-limit state.** If append-row failure events
 (`_wp_sudo_failure_event`) or lockout/throttle timestamps

--- a/includes/class-site-health.php
+++ b/includes/class-site-health.php
@@ -361,12 +361,15 @@ class Site_Health {
 		// defect, and the same root cause was additionally fail-OPEN for
 		// revoke_all_active_sessions(), which selects `META_KEY > time()` in SQL
 		// and silently skipped a user whose sudo was still enforcing. Both are
-		// closed by deriving the scalar structurally in Sudo_Session::set_token()
-		// from the cache-bypassed merged proof map, rather than from a cached read
-		// of the scalar itself — so the worked example above describes the defect
-		// this pair of changes removes, not a live hazard. It is kept because the
-		// query below is only safe while that derivation holds, and a future
-		// change that reintroduced a cached read here would silently re-open it.
+		// narrowed by deriving the scalar in Sudo_Session::set_token() from the
+		// cache-bypassed merged proof map rather than from a cached read of the
+		// scalar itself. The worked example above is cache-specific and its cause
+		// is removed — but the OUTCOME is not: two concurrent activations can
+		// still interleave their two non-atomic meta writes and leave a too-low
+		// marker with no stale read involved, reproducing both the destructive
+		// sweep and the revoke skip (#475). The query below is safe against the
+		// cached cause, not against that race, and a future change reintroducing a
+		// cached read here would re-open the cause as well.
 		//
 		// The set is exactly the session-identity rows. It deliberately omits
 		// LOCKOUT_UNTIL_META_KEY, FAILURE_EVENT_META_KEY and
@@ -509,10 +512,16 @@ class Site_Health {
 		// missing.
 		//
 		// Reading the proof map here instead was considered and rejected: this
-		// sweep runs for *other* users and, as a `direct` test, also under core's
-		// scheduled check with no user context, so it cannot use
-		// resolve_valid_proof() (which requires the current user and their
-		// cookie) and would be trusting an unverified `expires` — while
+		// sweep runs for *other* users, so it cannot use resolve_valid_proof()
+		// (which requires the current user AND their wp_sudo_token cookie) and
+		// would be trusting an unverified `expires` — the map is keyed by
+		// sha256(verifier) and the HMAC covers the raw verifier, which a sweep
+		// never holds. (One record type is theoretically verifiable: the shared
+		// empty-verifier slot set_token() describes for cookie-less surfaces,
+		// whose sha256 is known. The sweep does not attempt verification for any
+		// record, so nothing turns on it — and activate() is public API that
+		// docs/FAQ.md points SSO integrations at, so such records are not
+		// hypothetical.) Meanwhile
 		// cache-bypassing per user would evict each user's entire `user_meta`
 		// bucket, not just this key.
 		//

--- a/includes/class-site-health.php
+++ b/includes/class-site-health.php
@@ -336,8 +336,44 @@ class Site_Health {
 		$count = count( $stale_users );
 
 		// Clean up stale sessions automatically. The scalar expiry marker is
-		// >= every proof's expiry, so a stale scalar means all proofs are stale
-		// too; clear the whole proof record plus any legacy pre-4.9.0 rows.
+		// intended to be >= every proof's expiry, so a scalar older than the
+		// grace cutoff means all of that user's proofs are past grace too; clear
+		// the whole proof record plus any legacy pre-4.9.0 rows.
+		//
+		// "Intended to be" is deliberate, because that relationship used to be
+		// breakable. Sudo_Session::activate() maintained it by reading the scalar
+		// back through the object cache, so a stale-low cached read could write a
+		// scalar beneath a live proof's expiry — into the database, where this
+		// query reads it.
+		//
+		// Worked example, all in-range: duration 15 min, browser A activates at
+		// T0 (proof expires T0+900, scalar T0+900). An operator lowers the
+		// duration to 1 min. At T0+10 browser B activates; a stale-low cached
+		// read makes activate()'s `$existing > time()` false, so the scalar is
+		// written as T0+70 — beneath A's live proof. At T0+200 this sweep's
+		// cutoff is T0+80, T0+70 is below it, and A's proof is deleted with ~11
+		// minutes of life left. So the failure was fail-closed only while the
+		// too-low scalar was still in the future, and destructive once it aged
+		// past the cutoff. Past tense throughout: the derivation described below
+		// removes the mechanism.
+		//
+		// That was #354's own symptom reached through the other half of the
+		// defect, and the same root cause was additionally fail-OPEN for
+		// revoke_all_active_sessions(), which selects `META_KEY > time()` in SQL
+		// and silently skipped a user whose sudo was still enforcing. Both are
+		// closed by deriving the scalar structurally in Sudo_Session::set_token()
+		// from the cache-bypassed merged proof map, rather than from a cached read
+		// of the scalar itself — so the worked example above describes the defect
+		// this pair of changes removes, not a live hazard. It is kept because the
+		// query below is only safe while that derivation holds, and a future
+		// change that reintroduced a cached read here would silently re-open it.
+		//
+		// The set is exactly the session-identity rows. It deliberately omits
+		// LOCKOUT_UNTIL_META_KEY, FAILURE_EVENT_META_KEY and
+		// THROTTLE_UNTIL_META_KEY: sweeping those would let an expired sudo
+		// session silently clear an active rate-limit lockout, turning a
+		// housekeeping pass into a lockout reset. The omission is a decision, not
+		// an oversight.
 		foreach ( $stale_users as $uid ) {
 			delete_user_meta( $uid, Sudo_Session::META_KEY );
 			delete_user_meta( $uid, Sudo_Session::PROOF_META_KEY );
@@ -459,27 +495,70 @@ class Site_Health {
 		$batch_size = 100;
 		$offset     = 0;
 		$stale      = array();
-		$now        = time();
+
+		// Classify in the query, not in a follow-up read (#354).
+		//
+		// The previous shape selected on `META_KEY > 0` and then re-read each
+		// user's scalar with get_user_meta() — a **cached** read. Enforcement
+		// reads the signed proof cache-BYPASSED (Sudo_Session::read_proof()),
+		// precisely because a persistent user_meta cache entry can be stale or
+		// poisoned. So the sweep and the enforcement path could disagree, and a
+		// failed cache invalidation let this classify a live session as stale and
+		// delete every valid browser proof for that user. Deciding in SQL makes
+		// the database authoritative for both, which is the property that was
+		// missing.
+		//
+		// Reading the proof map here instead was considered and rejected: this
+		// sweep runs for *other* users and, as a `direct` test, also under core's
+		// scheduled check with no user context, so it cannot use
+		// resolve_valid_proof() (which requires the current user and their
+		// cookie) and would be trusting an unverified `expires` — while
+		// cache-bypassing per user would evict each user's entire `user_meta`
+		// bucket, not just this key.
+		//
+		// The cutoff excludes the grace window. A proof that expired within the
+		// last GRACE_SECONDS is still usable under is_within_grace(), which
+		// exists so an in-flight gated form is not lost (#279), and
+		// Sudo_Session::set_token()'s own housekeeping sweep uses the same
+		// `expires + GRACE_SECONDS` boundary. A bare `expires < now` here deleted
+		// grace-eligible proofs up to two minutes early, with no cache failure
+		// involved. Derived from the constant so the two sweeps cannot drift
+		// apart again.
+		$cutoff = time() - Sudo_Session::GRACE_SECONDS;
 
 		do {
 			$users = get_users(
 				array(
-					'meta_key'     => Sudo_Session::META_KEY, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
-					'meta_value'   => '0', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
-					'meta_compare' => '>',
-					'fields'       => 'ID',
-					'number'       => $batch_size,
-					'offset'       => $offset,
+					// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Bounded, batched maintenance sweep; mirrors revoke_all_active_sessions().
+					'meta_query' => array(
+						'relation' => 'AND',
+						array(
+							'key'     => Sudo_Session::META_KEY,
+							'value'   => 0,
+							'compare' => '>',
+							'type'    => 'NUMERIC',
+						),
+						array(
+							'key'     => Sudo_Session::META_KEY,
+							'value'   => $cutoff,
+							'compare' => '<',
+							'type'    => 'NUMERIC',
+						),
+					),
+					'fields'     => 'ID',
+					'number'     => $batch_size,
+					'offset'     => $offset,
 				)
 			);
+
+			if ( ! is_array( $users ) ) {
+				break;
+			}
 
 			$found = count( $users );
 
 			foreach ( $users as $uid ) {
-				$expires = (int) get_user_meta( (int) $uid, Sudo_Session::META_KEY, true );
-				if ( $expires > 0 && $expires < $now ) {
-					$stale[] = (int) $uid;
-				}
+				$stale[] = (int) $uid;
 			}
 
 			$offset += $batch_size;

--- a/includes/class-sudo-session.php
+++ b/includes/class-sudo-session.php
@@ -1065,7 +1065,7 @@ class Sudo_Session {
 		// too-low scalar later lets Site_Health's sweep delete that live proof
 		// once it ages past the sweep's cutoff.
 		//
-		// Deriving it here makes the contract structural instead of conventional:
+		// Deriving it here removes the cache as a way to break the contract:
 		// $map is already the authoritative, cache-bypassed, merged set and always
 		// contains this activation's entry, so the maximum is >= $expires by
 		// construction and cannot be lowered by a stale read. Grace-retained

--- a/includes/class-sudo-session.php
+++ b/includes/class-sudo-session.php
@@ -405,17 +405,10 @@ class Sudo_Session {
 		$duration = (int) Admin::get( 'session_duration', 15 );
 		$expires  = time() + ( $duration * MINUTE_IN_SECONDS );
 
-		// The scalar is the per-user liveness marker used by enumeration (the
-		// "Sudo Active (N)" count, the dashboard widget, bulk revoke, and
-		// is_session_live). Keep it at the furthest live expiry across this user's
-		// concurrent browsers so activating a shorter session in one browser does
-		// not shrink the marker for another (#279). Enforcement uses the
-		// per-browser proof record, not this scalar.
-		$existing = (int) get_user_meta( $user_id, self::META_KEY, true );
-		$scalar   = $existing > time() ? max( $existing, $expires ) : $expires;
-		update_user_meta( $user_id, self::META_KEY, $scalar );
-
 		// Write the self-authenticating proof for this browser and set the cookie.
+		// set_token() also writes the per-user liveness scalar (META_KEY), derived
+		// from the merged proof map it holds — see the note there for why the
+		// scalar is no longer computed here (#354).
 		self::set_token( $user_id, $expires );
 
 		// Clear any failed-attempt counters on successful activation.
@@ -1040,6 +1033,51 @@ class Sudo_Session {
 			'expires' => $expires,
 			'hmac'    => self::build_hmac( $user_id, $verifier, $token_hash, $expires ),
 		);
+
+		// Ordering is deliberate: the marker is written BEFORE the proof.
+		//
+		// A crash between the two writes must fail in the safe direction. Marker
+		// without proof means an enumerable, revocable record with no sudo behind
+		// it — harmless, and self-corrects on the next activation. Proof without
+		// marker is the opposite: a live, enforcing sudo session invisible to
+		// revoke_all_active_sessions() and is_session_live(), which is exactly the
+		// fail-open this change exists to close. Writing the proof first would
+		// reintroduce it in miniature.
+
+		// The per-user liveness scalar, derived from the map above (#354).
+		//
+		// It is the marker used by enumeration — the "Sudo Active (N)" count, the
+		// dashboard widget, is_session_live(), Site_Health's stale sweep, and
+		// revoke_all_active_sessions(). Enforcement never reads it; it reads the
+		// per-browser proof record. Its one contract is that it is at least as
+		// late as every proof in the map, so nothing that enumerates on it can
+		// miss a user whose sudo is still enforcing.
+		//
+		// That contract used to be maintained in activate(), by reading the
+		// scalar back with get_user_meta() and max()-ing it — a **cached** read,
+		// twelve lines above the cache-BYPASSED read of this map. A stale-low
+		// cached read made the `$existing > time()` branch false and wrote the new
+		// browser's expiry alone, which can sit beneath another browser's live
+		// proof. The wrong value then lands in the database, where
+		// revoke_all_active_sessions() reads it with SQL: the operator's "revoke
+		// all sessions" silently skips a user whose sudo is still live, and
+		// is_session_live() hides the per-user revoke. Fail-open, and the same
+		// too-low scalar later lets Site_Health's sweep delete that live proof
+		// once it ages past the sweep's cutoff.
+		//
+		// Deriving it here makes the contract structural instead of conventional:
+		// $map is already the authoritative, cache-bypassed, merged set and always
+		// contains this activation's entry, so the maximum is >= $expires by
+		// construction and cannot be lowered by a stale read. Grace-retained
+		// entries are expired and therefore never the maximum.
+		$scalar = $expires;
+		foreach ( $map as $entry ) {
+			if ( is_array( $entry ) && isset( $entry['expires'] ) ) {
+				$scalar = max( $scalar, (int) $entry['expires'] );
+			}
+		}
+
+		update_user_meta( $user_id, self::META_KEY, $scalar );
 
 		update_user_meta( $user_id, self::PROOF_META_KEY, $map );
 

--- a/languages/wp-sudo.pot
+++ b/languages/wp-sudo.pot
@@ -1811,8 +1811,8 @@ msgstr ""
 #: includes/class-site-health.php:287
 #: includes/class-site-health.php:299
 #: includes/class-site-health.php:328
-#: includes/class-site-health.php:361
-#: includes/class-site-health.php:396
+#: includes/class-site-health.php:397
+#: includes/class-site-health.php:432
 msgid "Security"
 msgstr ""
 
@@ -1909,7 +1909,7 @@ msgid "All sudo session tokens are either active or have been cleaned up. No act
 msgstr ""
 
 #. translators: %d: number of stale sessions cleaned
-#: includes/class-site-health.php:351
+#: includes/class-site-health.php:387
 #, php-format
 msgid "%d stale Sudo session cleaned up"
 msgid_plural "%d stale Sudo sessions cleaned up"
@@ -1917,40 +1917,40 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. translators: %d: number of stale sessions
-#: includes/class-site-health.php:366
+#: includes/class-site-health.php:402
 #, php-format
 msgid "Found and cleaned %d expired sudo session token. This is normal — tokens expire naturally but are only cleaned on the next page load."
 msgid_plural "Found and cleaned %d expired sudo session tokens. This is normal — tokens expire naturally but are only cleaned on the next page load."
 msgstr[0] ""
 msgstr[1] ""
 
-#: includes/class-site-health.php:402
+#: includes/class-site-health.php:438
 msgid "Break-glass recovery mode is not active"
 msgstr ""
 
-#: includes/class-site-health.php:405
+#: includes/class-site-health.php:441
 msgid "WP Sudo break-glass recovery mode (WP_SUDO_RECOVERY_MODE) is not defined. The governance capability model is fully in force."
 msgstr ""
 
-#: includes/class-site-health.php:411
+#: includes/class-site-health.php:447
 msgid "It is unscoped: while it stays defined, any user who still holds administrator authority (network administrator on multisite) regains full Sudo governance access."
 msgstr ""
 
-#: includes/class-site-health.php:416
+#: includes/class-site-health.php:452
 msgid "It is scoped to a value that does not resolve to any existing user, so no one is granted access — check WP_SUDO_RECOVERY_MODE for a typo."
 msgstr ""
 
 #. translators: 1: user login, 2: user ID
-#: includes/class-site-health.php:422
+#: includes/class-site-health.php:458
 #, php-format
 msgid "It is scoped to the user \"%1$s\" (ID %2$d), who alone regains Sudo governance access while it stays defined — provided that user still holds administrator authority (manage_options, or manage_network_options on multisite); a scoped target who lacks it is still denied."
 msgstr ""
 
-#: includes/class-site-health.php:430
+#: includes/class-site-health.php:466
 msgid "Break-glass recovery mode is active"
 msgstr ""
 
-#: includes/class-site-health.php:433
+#: includes/class-site-health.php:469
 msgid "Remove WP_SUDO_RECOVERY_MODE from wp-config.php as soon as normal access is restored — leaving it enabled weakens the governance model."
 msgstr ""
 

--- a/languages/wp-sudo.pot
+++ b/languages/wp-sudo.pot
@@ -1811,8 +1811,8 @@ msgstr ""
 #: includes/class-site-health.php:287
 #: includes/class-site-health.php:299
 #: includes/class-site-health.php:328
-#: includes/class-site-health.php:397
-#: includes/class-site-health.php:432
+#: includes/class-site-health.php:400
+#: includes/class-site-health.php:435
 msgid "Security"
 msgstr ""
 
@@ -1909,7 +1909,7 @@ msgid "All sudo session tokens are either active or have been cleaned up. No act
 msgstr ""
 
 #. translators: %d: number of stale sessions cleaned
-#: includes/class-site-health.php:387
+#: includes/class-site-health.php:390
 #, php-format
 msgid "%d stale Sudo session cleaned up"
 msgid_plural "%d stale Sudo sessions cleaned up"
@@ -1917,40 +1917,40 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. translators: %d: number of stale sessions
-#: includes/class-site-health.php:402
+#: includes/class-site-health.php:405
 #, php-format
 msgid "Found and cleaned %d expired sudo session token. This is normal — tokens expire naturally but are only cleaned on the next page load."
 msgid_plural "Found and cleaned %d expired sudo session tokens. This is normal — tokens expire naturally but are only cleaned on the next page load."
 msgstr[0] ""
 msgstr[1] ""
 
-#: includes/class-site-health.php:438
+#: includes/class-site-health.php:441
 msgid "Break-glass recovery mode is not active"
 msgstr ""
 
-#: includes/class-site-health.php:441
+#: includes/class-site-health.php:444
 msgid "WP Sudo break-glass recovery mode (WP_SUDO_RECOVERY_MODE) is not defined. The governance capability model is fully in force."
 msgstr ""
 
-#: includes/class-site-health.php:447
+#: includes/class-site-health.php:450
 msgid "It is unscoped: while it stays defined, any user who still holds administrator authority (network administrator on multisite) regains full Sudo governance access."
 msgstr ""
 
-#: includes/class-site-health.php:452
+#: includes/class-site-health.php:455
 msgid "It is scoped to a value that does not resolve to any existing user, so no one is granted access — check WP_SUDO_RECOVERY_MODE for a typo."
 msgstr ""
 
 #. translators: 1: user login, 2: user ID
-#: includes/class-site-health.php:458
+#: includes/class-site-health.php:461
 #, php-format
 msgid "It is scoped to the user \"%1$s\" (ID %2$d), who alone regains Sudo governance access while it stays defined — provided that user still holds administrator authority (manage_options, or manage_network_options on multisite); a scoped target who lacks it is still denied."
 msgstr ""
 
-#: includes/class-site-health.php:466
+#: includes/class-site-health.php:469
 msgid "Break-glass recovery mode is active"
 msgstr ""
 
-#: includes/class-site-health.php:469
+#: includes/class-site-health.php:472
 msgid "Remove WP_SUDO_RECOVERY_MODE from wp-config.php as soon as normal access is restored — leaving it enabled weakens the governance model."
 msgstr ""
 

--- a/tests/Unit/SiteHealthTest.php
+++ b/tests/Unit/SiteHealthTest.php
@@ -330,10 +330,10 @@ class SiteHealthTest extends TestCase {
 	public function test_stale_sessions_cleans_expired_tokens(): void {
 		Functions\when( '__' )->returnArg();
 		Functions\when( '_n' )->returnArg();
-		$expired_time = time() - 60;
 
+		// Every ID the query returns is stale by construction now — the
+		// threshold lives in the meta_query, not in a post-filter loop.
 		Functions\when( 'get_users' )->justReturn( array( 10, 20 ) );
-		Functions\when( 'get_user_meta' )->justReturn( $expired_time );
 
 		// Expect delete_user_meta for each stale user: META_KEY + PROOF_META_KEY + TOKEN_META_KEY + SESSION_BIND_META_KEY = 4 per user = 8 total.
 		Functions\expect( 'delete_user_meta' )
@@ -345,26 +345,109 @@ class SiteHealthTest extends TestCase {
 		$this->assertSame( 'wp_sudo_stale_sessions', $result['test'] );
 	}
 
-	public function test_stale_sessions_skips_active_sessions(): void {
+	/**
+	 * #354: the sweep must not classify from a cached scalar read.
+	 *
+	 * Selection and classification now happen in one SQL query, so the database
+	 * is authoritative. The previous shape selected on `META_KEY > 0` and then
+	 * re-read each user's scalar with get_user_meta() — a cached read, while
+	 * enforcement reads the signed proof cache-bypassed via read_proof(). A
+	 * failed cache invalidation therefore let the sweep classify a live session
+	 * as stale and delete every valid browser proof for that user.
+	 *
+	 * Asserted by the absence of the per-user read: get_user_meta() carries a
+	 * never() expectation, so the test fails if the sweep calls it at all.
+	 */
+	public function test_stale_sessions_does_not_read_user_meta_through_the_cache(): void {
 		Functions\when( '__' )->returnArg();
-		$future_time = time() + 300;
+		Functions\when( '_n' )->returnArg();
 
 		Functions\when( 'get_users' )->justReturn( array( 10 ) );
-		Functions\when( 'get_user_meta' )->justReturn( $future_time );
+		Functions\expect( 'get_user_meta' )->never();
 
-		// No cleanups should happen for active sessions.
-		Functions\expect( 'delete_user_meta' )->never();
+		// times(4) rather than a permissive stub: 'good' is returned on both
+		// branches, so without pinning the deletions this would pass vacuously if
+		// a later change made the query return nothing.
+		Functions\expect( 'delete_user_meta' )->times( 4 );
 
 		$result = $this->health->test_stale_sessions();
 
 		$this->assertSame( 'good', $result['status'] );
 	}
 
-	public function test_stale_sessions_paginates_beyond_100_users(): void {
+	/**
+	 * #354: the sweep must honour the same grace window the enforcement path does.
+	 *
+	 * Sudo_Session::is_within_grace() keeps a just-expired proof usable for
+	 * GRACE_SECONDS so an in-flight gated form is not lost (#279), and
+	 * set_token()'s housekeeping sweep uses `expires + GRACE_SECONDS < now` for
+	 * exactly that reason. This sweep used a bare `expires < now`, so it deleted
+	 * grace-eligible proofs up to two minutes early — no cache failure required,
+	 * just timing.
+	 *
+	 * The threshold is asserted against the constant rather than a literal: a
+	 * literal here is what let the old test's `time() - 60` sit inside a 120 s
+	 * window without anyone noticing when GRACE_SECONDS was introduced.
+	 */
+	public function test_stale_sessions_excludes_the_grace_window_from_the_query(): void {
 		Functions\when( '__' )->returnArg();
 		Functions\when( '_n' )->returnArg();
 
-		$expired_time = time() - 60;
+		$captured = null;
+
+		Functions\expect( 'get_users' )
+			->once()
+			->with(
+				\Mockery::on(
+					static function ( $args ) use ( &$captured ) {
+						$captured = $args;
+						return true;
+					}
+				)
+			)
+			->andReturn( array() );
+
+		$this->health->test_stale_sessions();
+
+		$this->assertIsArray( $captured, 'get_users() was not called with an argument array.' );
+		$this->assertArrayHasKey( 'meta_query', $captured, 'Classification is not expressed in the query.' );
+
+		$thresholds = array();
+		foreach ( $captured['meta_query'] as $key => $clause ) {
+			if ( ! is_array( $clause ) || ! isset( $clause['compare'] ) ) {
+				continue;
+			}
+			$thresholds[ $clause['compare'] ] = $clause;
+		}
+
+		$this->assertArrayHasKey( '<', $thresholds, 'No upper-bound clause — nothing excludes live sessions.' );
+
+		$cutoff = (int) $thresholds['<']['value'];
+		$now    = time();
+
+		// Allow one second of clock drift between the sweep and this assertion.
+		$this->assertGreaterThanOrEqual(
+			$now - \WP_Sudo\Sudo_Session::GRACE_SECONDS - 1,
+			$cutoff,
+			'The cutoff reaches further back than the grace window requires.'
+		);
+		$this->assertLessThanOrEqual(
+			$now - \WP_Sudo\Sudo_Session::GRACE_SECONDS,
+			$cutoff,
+			'The cutoff does not exclude the grace window — a just-expired proof '
+				. 'that is still usable under is_within_grace() would be deleted.'
+		);
+		$this->assertSame(
+			'NUMERIC',
+			$thresholds['<']['type'] ?? null,
+			'Without an explicit NUMERIC type the comparison is lexical, so an '
+				. 'expiry timestamp would be compared as a string.'
+		);
+	}
+
+	public function test_stale_sessions_paginates_beyond_100_users(): void {
+		Functions\when( '__' )->returnArg();
+		Functions\when( '_n' )->returnArg();
 
 		// First batch: 100 user IDs (triggers next page). Second batch: 5 user IDs (stops loop).
 		$first_batch  = range( 1, 100 );
@@ -373,8 +456,6 @@ class SiteHealthTest extends TestCase {
 		Functions\expect( 'get_users' )
 			->twice()
 			->andReturnValues( array( $first_batch, $second_batch ) );
-
-		Functions\when( 'get_user_meta' )->justReturn( $expired_time );
 
 		// 105 stale users × 4 meta keys each (META_KEY + PROOF_META_KEY + TOKEN_META_KEY + SESSION_BIND_META_KEY) = 420 deletions.
 		Functions\expect( 'delete_user_meta' )

--- a/tests/Unit/SudoSessionTest.php
+++ b/tests/Unit/SudoSessionTest.php
@@ -597,7 +597,7 @@ class SudoSessionTest extends TestCase
 	}
 
 	/**
-	 * #279, now structural: activating a shorter session in one browser must not
+	 * #279, now derived rather than maintained: activating a shorter session in one browser must not
 	 * shrink the marker for another. Previously an intended property maintained
 	 * by a max() over a cached read; now a consequence of deriving the scalar
 	 * from the merged map, exercised with no cache failure involved.

--- a/tests/Unit/SudoSessionTest.php
+++ b/tests/Unit/SudoSessionTest.php
@@ -527,6 +527,109 @@ class SudoSessionTest extends TestCase
 	}
 
 	/**
+	 * #354: the liveness scalar must be derived from the proof map, not from a
+	 * cached read of itself.
+	 *
+	 * The scalar is documented as ">= every proof's expiry", and three consumers
+	 * rely on it: Site_Health's stale sweep, is_session_live() (the Users-list
+	 * revoke row action), and revoke_all_active_sessions(), which selects
+	 * `META_KEY > time()` in SQL. activate() used to maintain that relationship
+	 * by reading the scalar back through the object cache — twelve lines above a
+	 * cache-BYPASSED read of the proof map. A stale-low cached read therefore
+	 * wrote a scalar beneath a live proof's expiry, into the database, where the
+	 * SQL bulk revoke reads it.
+	 *
+	 * That is fail-OPEN: browser A's sudo is still live and enforcing, but the
+	 * operator's "revoke all sessions" no longer selects that user and
+	 * is_session_live() hides the per-user revoke. A session that cannot be
+	 * revoked is worse than one swept too eagerly. The same too-low scalar is
+	 * also what lets Site_Health's sweep delete a live proof once the scalar
+	 * ages past its cutoff.
+	 *
+	 * Modelled by writing the scalar low directly, which is what a stale cached
+	 * read yields, then activating a much shorter session in a second browser.
+	 *
+	 * RED before the fix: the scalar becomes B's short expiry, 840 s below A's
+	 * live proof.
+	 */
+	public function test_scalar_marker_is_not_lowered_beneath_a_live_proof(): void
+	{
+		$user  = 7;
+		$store = array();
+		$this->stub_stateful_user_meta($store);
+		Functions\when('get_current_user_id')->justReturn($user);
+
+		Functions\when('get_option')->justReturn(array('session_duration' => 15));
+		Functions\when('wp_generate_password')->justReturn('cookie-A');
+		Functions\when('wp_get_session_token')->justReturn('verifier-A');
+		Sudo_Session::activate($user);
+
+		$a_expires = (int) $store[Sudo_Session::META_KEY];
+		$this->assertGreaterThan(time(), $a_expires, 'Precondition: A holds a live session.');
+
+        // Simulate the failed cache invalidation: the scalar reads stale-low
+        // while the proof map (read cache-bypassed) still holds A's live entry.
+		$store[Sudo_Session::META_KEY] = time() - 1;
+
+		// Admin::get() memoizes the settings array, so the stub alone would not
+		// change the duration.
+		\WP_Sudo\Admin::reset_cache();
+		Functions\when('get_option')->justReturn(array('session_duration' => 1));
+		Functions\when('wp_generate_password')->justReturn('cookie-B');
+		Functions\when('wp_get_session_token')->justReturn('verifier-B');
+		Sudo_Session::activate($user);
+
+		$map = $store[Sudo_Session::PROOF_META_KEY];
+		$this->assertArrayHasKey(
+			hash('sha256', 'verifier-A'),
+			$map,
+			"Precondition: A's proof is still in the map and still live."
+		);
+
+		$this->assertGreaterThanOrEqual(
+			$a_expires,
+			(int) $store[Sudo_Session::META_KEY],
+			'The scalar was written beneath a live proof expiry. '
+				. 'revoke_all_active_sessions() selects META_KEY > time() in SQL, so once '
+				. "this lapses the operator's bulk revoke silently skips a user whose sudo "
+				. 'session is still enforcing.'
+		);
+	}
+
+	/**
+	 * #279, now structural: activating a shorter session in one browser must not
+	 * shrink the marker for another. Previously an intended property maintained
+	 * by a max() over a cached read; now a consequence of deriving the scalar
+	 * from the merged map, exercised with no cache failure involved.
+	 */
+	public function test_scalar_marker_tracks_the_furthest_live_proof(): void
+	{
+		$user  = 7;
+		$store = array();
+		$this->stub_stateful_user_meta($store);
+		Functions\when('get_current_user_id')->justReturn($user);
+
+		Functions\when('get_option')->justReturn(array('session_duration' => 15));
+		Functions\when('wp_generate_password')->justReturn('cookie-A');
+		Functions\when('wp_get_session_token')->justReturn('verifier-A');
+		Sudo_Session::activate($user);
+
+		$a_expires = (int) $store[Sudo_Session::META_KEY];
+
+		\WP_Sudo\Admin::reset_cache();
+		Functions\when('get_option')->justReturn(array('session_duration' => 1));
+		Functions\when('wp_generate_password')->justReturn('cookie-B');
+		Functions\when('wp_get_session_token')->justReturn('verifier-B');
+		Sudo_Session::activate($user);
+
+		$this->assertSame(
+			$a_expires,
+			(int) $store[Sudo_Session::META_KEY],
+			"B's shorter session shrank the shared liveness marker below A's expiry."
+		);
+	}
+
+	/**
 	 * #279 grace regression: a second browser's activation runs set_token()
 	 * housekeeping over the shared proof map. That sweep must NOT evict another
 	 * login session's entry that expired only moments ago and is still inside its


### PR DESCRIPTION
Closes #354.

Two defects, one root cause: state that the enforcement path reads **cache-bypassed** was being decided from **cached** reads elsewhere. The second one is fail-open and is not named in the issue.

## 1. The filed bug, plus a grace violation it was hiding

`Site_Health::find_stale_sessions()` selected users on the marker being set, then re-read that marker with `get_user_meta()` — cached — while enforcement reads the signed proof cache-bypassed via `read_proof()`, precisely because a persistent `user_meta` entry can be stale. A failed invalidation let the sweep classify a live session as stale and delete every valid browser proof for that user.

Classification now happens in the `meta_query`, so the database is authoritative for both paths and the per-user read is gone entirely.

That also fixed a second defect needing **no cache failure at all**: the sweep used a bare "expired" test while `set_token()`'s housekeeping excludes the 120 s grace window that exists so a just-expired session can finish an in-flight gated form (#279). It deleted grace-eligible proofs up to two minutes early on ordinary timing. Both sweeps now derive the boundary from `GRACE_SECONDS`.

**Operator-visible:** cleanup is deferred by up to 120 s. Intended — the session is not enforcing in that window, only its record is retained.

### A design that was rejected, and why

A proof-map-authoritative sweep was the first plan. It could not have worked: `resolve_valid_proof()` requires the current user *and* their cookie, so a sweep over other users — which also runs under core's scheduled check with no user context — would be trusting an unverified `expires` while *looking* like it inherited the proof's forge-resistance. It holds `sha256($verifier)`, never the verifier, so it can never recompute the HMAC. `read_proof()` is also private, and its bypass evicts each user's **entire** `user_meta` bucket, so doing it per user is a site-wide cache-churn event on a screen any admin can reload.

## 2. The fail-open half: "revoke all sessions" could silently skip a live session

`activate()` maintained the marker's "at least as late as every proof" contract by reading the marker back **through the object cache** — twelve lines above a deliberately cache-bypassed read of the proof map. A stale-low read wrote the new browser's expiry alone, which can sit beneath another browser's live proof, and that value reaches the database.

`revoke_all_active_sessions()` reads it with **SQL**. So an operator's bulk revoke silently skipped a user whose sudo was still enforcing, and `is_session_live()` hid the per-user revoke on the Users list. A session that cannot be revoked is worse than one cleaned up too eagerly — and the same too-low marker is what let the sweep above delete a live proof once it aged past the cutoff.

`set_token()` now derives the marker from the merged proof map it already holds cache-bypassed. The map always contains the activation being written, so the contract is **structural** rather than conventional. The documented #279 behaviour follows from the derivation instead of a `max()` over a cached value. No stored format change, no migration.

**Write order is deliberate:** marker before proof. A crash between them must fail safe — marker-without-proof self-corrects on next activation; proof-without-marker is a live enforcing session invisible to revocation, i.e. the fail-open being closed. An earlier cut had these reversed; review caught it.

## Test notes worth reading

Red-before-green, and **independently reproduced by the reviewer against pre-fix code**: the marker landed 840 s below a live proof.

The test calls `Admin::reset_cache()` between activations. `Admin::get()` memoizes settings, so without that line the duration override is swallowed, browser B gets the same 15 minutes as A, and the test **passes vacuously**. Confirmed by deleting the line and watching it go green — worth keeping in mind for any similar test.

Also fixed: two dead stubs in the paginate test, and the existing `cleans_expired_tokens` test used `time() - 60` — inside the 120 s grace window, so it encoded the very violation being fixed. That literal predates `GRACE_SECONDS` by five months. Thresholds now derive from the constant.

## Known follow-up, deliberately not here

`is_session_live()` still reads the marker through a cached `get_user_meta()`. The stored value is now correct, which is what #354 is about, but that reader can still see a stale-low cached value and hide the per-user revoke. Natural companion for integration coverage of the sweep boundary against a real database.

## Validation

`composer test:unit` 1276 / 3827 · `lint` 24/24 · PHPStan L6 + Psalm clean · `verify:i18n` (POT regenerated via `bin/make-pot.sh`) · `verify:metrics` · `verify:sources` · `git diff --check`. Reviewer-approved.