### PR TITLE
fix(427): bind reviewer approval to the staged tree, and install the gate

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -70,6 +70,49 @@ echo "🔍 Pre-Commit Validation"
 echo "=============================="
 echo ""
 
+# ── Step 0: Dependency root ──────────────────────────────────────────────────
+# Confirm vendor/ belongs to THIS worktree before trusting any test result.
+#
+# The mechanism is PHP's __DIR__, not baked paths. vendor/composer/autoload_psr4.php
+# computes `$vendorDir = dirname(__DIR__); $baseDir = dirname($vendorDir);` — no
+# absolute path is written into it (`grep -c '/Users/'` returns 0). But __DIR__
+# resolves symlinks, so including the autoloader through a symlinked vendor/ makes
+# $baseDir land in the *other* checkout, and PSR-4 then loads every class from
+# there. The suite runs green against source you did not change, and edits to this
+# worktree's includes/ are invisible to it.
+#
+# Observed twice on 2026-07-27: a guard test written to fail against an injected
+# defect passed, because the defect was injected here and the class was loaded
+# from there — and again when a reviewer reproducing that result hit the same trap.
+#
+# Because the paths are runtime-relative, `cp -r vendor` from another checkout is
+# harmless; only a symlink breaks it. That is exactly what this check catches, so
+# it is deliberately narrow rather than a blanket ban on sharing dependencies.
+if [ -e "$REPO_ROOT/vendor" ]; then
+  ROOT_REAL=$(cd "$REPO_ROOT" && pwd -P)
+  VENDOR_REAL=$(cd "$REPO_ROOT/vendor" 2>/dev/null && pwd -P || echo "")
+
+  case "$VENDOR_REAL" in
+    "$ROOT_REAL"/*)
+      : # vendor/ is inside this worktree — results are about this code.
+      ;;
+    *)
+      echo -e "${RED}❌ BLOCKED: vendor/ does not belong to this worktree${NC}"
+      echo "   worktree: $ROOT_REAL"
+      echo "   vendor:   ${VENDOR_REAL:-<unresolvable>}"
+      echo ""
+      echo "   PHP resolves symlinks in __DIR__, so Composer's autoloader would"
+      echo "   compute its base directory in that other tree and load every class"
+      echo "   from there — tests pass without exercising your changes."
+      echo "   Run 'composer install' in this worktree (a copy is fine, a symlink"
+      echo "   is not)."
+      exit 1
+      ;;
+  esac
+  echo -e "${GREEN}✅ vendor/ resolves inside this worktree${NC}"
+  echo ""
+fi
+
 # ── Step 1: Reviewer approval ────────────────────────────────────────────────
 echo "1️⃣  Checking reviewer agent approval..."
 
@@ -82,16 +125,57 @@ elif [ "$NON_TEXT_FILES" -eq 0 ]; then
   # Consume any leftover approval flag so it cannot be reused by a later code commit.
   rm -f "$APPROVAL_FILE"
 elif [ -f "$APPROVAL_FILE" ]; then
-  APPROVAL_TIME=$(cat "$APPROVAL_FILE")
+  APPROVAL_TIME=$(sed -n '1p' "$APPROVAL_FILE")
+  APPROVAL_TREE=$(sed -n '2p' "$APPROVAL_FILE")
   CURRENT_TIME=$(date +%s)
   TIME_DIFF=$((CURRENT_TIME - APPROVAL_TIME))
 
-  if [ "$TIME_DIFF" -lt "$REVIEWER_APPROVAL_TIMEOUT" ]; then
-    echo -e "${GREEN}✅ Reviewer agent approved (${TIME_DIFF}s ago)${NC}"
+  # Content binding. A timestamp alone answers "was something approved
+  # recently", never "was THIS approved" — so any edit between approval and
+  # commit rode in unreviewed, and the flag looked perfectly valid. Bind to the
+  # index instead: `git write-tree` is the id of the exact staged content, so
+  # touching any staged file invalidates the approval. It is stricter than
+  # hashing `git diff --cached`, which is sensitive to diff config and says
+  # nothing about files staged after review.
+  #
+  # write-tree does not move HEAD or touch the worktree. It does rewrite
+  # .git/index — git persists the cache-tree extension — but alters no staged
+  # content, and `git status` is unchanged. It fails on unmerged entries, which
+  # is why the merge path above never reaches here.
+  #
+  # The binding also survives the staging shortcuts, because git hands the hook a
+  # temporary index via GIT_INDEX_FILE: under `git commit -a` and under
+  # `git commit <pathspec>`, write-tree here sees the tree that will ACTUALLY be
+  # committed, not the pre-existing index. Both fail closed against a stale
+  # approval. Verified 2026-07-27.
+  STAGED_TREE=$(git write-tree 2>/dev/null || echo "")
+
+  if [ -z "$APPROVAL_TREE" ]; then
+    echo -e "${RED}❌ BLOCKED: Approval flag has no content binding${NC}"
+    echo "   This flag records only a timestamp, so it cannot prove it approved"
+    echo "   the code you are committing. Re-approve with:"
+    echo "       bash bin/reviewer-approve.sh"
+    rm -f "$APPROVAL_FILE"
+    exit 1
+  elif [ -z "$STAGED_TREE" ]; then
+    echo -e "${RED}❌ BLOCKED: Could not read the staged tree${NC}"
+    echo "   git write-tree failed — unmerged index entries?"
+    exit 1
+  elif [ "$APPROVAL_TREE" != "$STAGED_TREE" ]; then
+    echo -e "${RED}❌ BLOCKED: Staged content changed since approval${NC}"
+    echo "   approved tree: $APPROVAL_TREE"
+    echo "   staged tree:   $STAGED_TREE"
+    echo "   The reviewer approved different bytes than you are committing."
+    echo "   Re-run the reviewer against the current staged tree."
+    rm -f "$APPROVAL_FILE"
+    exit 1
+  elif [ "$TIME_DIFF" -lt "$REVIEWER_APPROVAL_TIMEOUT" ]; then
+    echo -e "${GREEN}✅ Reviewer agent approved (${TIME_DIFF}s ago, tree ${STAGED_TREE})${NC}"
     rm "$APPROVAL_FILE"
   else
     echo -e "${RED}❌ BLOCKED: Reviewer approval expired (${TIME_DIFF}s old, max ${REVIEWER_APPROVAL_TIMEOUT}s)${NC}"
     echo "   Spawn reviewer agent again and get a fresh approval."
+    rm -f "$APPROVAL_FILE"
     exit 1
   fi
 else

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -92,11 +92,15 @@ if [ -e "$REPO_ROOT/vendor" ]; then
   ROOT_REAL=$(cd "$REPO_ROOT" && pwd -P)
   VENDOR_REAL=$(cd "$REPO_ROOT/vendor" 2>/dev/null && pwd -P || echo "")
 
-  case "$VENDOR_REAL" in
-    "$ROOT_REAL"/*)
-      : # vendor/ is inside this worktree — results are about this code.
-      ;;
-    *)
+  # Exact match, not a prefix. A prefix test passes for a checkout NESTED under
+  # this one — and this repo nests them: `git worktree list` shows checkouts under
+  # .claude/worktrees/. A vendor symlink pointing at one of those resolves to
+  # $ROOT_REAL/.claude/worktrees/<x>/vendor, which satisfies "$ROOT_REAL"/* while
+  # loading every class from that other checkout. The prefix form would therefore
+  # have passed in precisely the layout this check exists to protect.
+  if [ "$VENDOR_REAL" = "$ROOT_REAL/vendor" ]; then
+    : # vendor/ is this worktree's own — results are about this code.
+  else
       echo -e "${RED}❌ BLOCKED: vendor/ does not belong to this worktree${NC}"
       echo "   worktree: $ROOT_REAL"
       echo "   vendor:   ${VENDOR_REAL:-<unresolvable>}"
@@ -107,9 +111,8 @@ if [ -e "$REPO_ROOT/vendor" ]; then
       echo "   Run 'composer install' in this worktree (a copy is fine, a symlink"
       echo "   is not)."
       exit 1
-      ;;
-  esac
-  echo -e "${GREEN}✅ vendor/ resolves inside this worktree${NC}"
+  fi
+  echo -e "${GREEN}✅ vendor/ is this worktree's own${NC}"
   echo ""
 fi
 

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -3,7 +3,11 @@
 # Source: https://github.com/jazzsequence/claude-code-reviewer
 #
 # Reads configuration from .reviewer-config.sh in the project root.
-# Copy to .git/hooks/pre-commit and chmod +x, or use install.sh.
+#
+# Enable with `git config core.hooksPath .githooks` (see CONTRIBUTING.md).
+# Upstream suggests copying this file into .git/hooks/ instead; do not — this
+# fork has diverged from upstream and a copy goes stale, silently reverting the
+# merge-commit and docs-only exemptions below.
 
 set -e
 

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -116,6 +116,42 @@ if [ -e "$REPO_ROOT/vendor" ]; then
   echo ""
 fi
 
+# ── Step 0b: Staged content must be what gets validated ─────────────────────
+# The approval binds to the staged tree, but every validation command below —
+# tests, lint, build — reads the WORKING TREE. When a staged file also has
+# unstaged modifications those are two different things, so a broken staged
+# implementation with an unstaged fix validates green and commits broken. The
+# binding would faithfully record approval of the broken tree.
+#
+# Rather than paper over the gap, refuse: for a code commit, a staged file must
+# have no unstaged modifications, so that what is validated and what is approved
+# and what is committed are all the same bytes.
+if [ "$USER_COMMIT" != "1" ] && [ "$NON_TEXT_FILES" -gt 0 ]; then
+  # Intersect via sort/uniq, NOT a shell loop. `for f in $(git diff --name-only)`
+  # word-splits on IFS and glob-expands, and git does not quote spaces in that
+  # output — this repository tracks ".planning/research/Threat Landscape/…", so a
+  # staged path with a space silently escaped the check while an unrelated dirty
+  # file got named in its place. Git quotes newline paths identically in both
+  # lists, so they intersect correctly here too.
+  BOTH=$( { git diff --cached --name-only; git diff --name-only; } | sort | uniq -d )
+
+  if [ -n "$BOTH" ]; then
+    echo -e "${RED}❌ BLOCKED: staged files also have unstaged changes${NC}"
+    printf '%s\n' "$BOTH" | sed 's/^/   /'
+    echo ""
+    echo "   Tests, lint and build read the working tree; the approval binds to the"
+    echo "   index. While those differ, a green validation says nothing about the"
+    echo "   bytes being committed."
+    echo ""
+    echo "   Stage the rest:   git add <file>"
+    echo "   Or set it aside:  git stash push --keep-index"
+    echo ""
+    echo "   Plain 'git stash' would also stash what you staged, leaving nothing to"
+    echo "   commit; --keep-index is the flag that keeps the reviewed bytes in place."
+    exit 1
+  fi
+fi
+
 # ── Step 1: Reviewer approval ────────────────────────────────────────────────
 echo "1️⃣  Checking reviewer agent approval..."
 
@@ -172,8 +208,23 @@ elif [ -f "$APPROVAL_FILE" ]; then
     echo "   Re-run the reviewer against the current staged tree."
     rm -f "$APPROVAL_FILE"
     exit 1
+  elif [ "$TIME_DIFF" -lt 0 ]; then
+    # A future timestamp means the clock moved backward since approval (restored
+    # VM snapshot, NTP correction) or the flag was hand-written. An upper-bound
+    # test alone would treat that as valid indefinitely, until the clock caught
+    # up, so it is rejected outright rather than clamped.
+    echo -e "${RED}❌ BLOCKED: Approval timestamp is in the future (${TIME_DIFF}s)${NC}"
+    echo "   The clock moved backward since approval, or the flag was written by hand."
+    rm -f "$APPROVAL_FILE"
+    exit 1
   elif [ "$TIME_DIFF" -lt "$REVIEWER_APPROVAL_TIMEOUT" ]; then
     echo -e "${GREEN}✅ Reviewer agent approved (${TIME_DIFF}s ago, tree ${STAGED_TREE})${NC}"
+    # Consumed here rather than after validation, deliberately. Any failure worth
+    # fixing changes the tree, which invalidates the flag through the binding
+    # anyway, so late consumption would only help a flaky test passing on retry
+    # against an identical tree — where re-review is cheap. Early consumption is
+    # strictly safer: a Ctrl-C during the validation window cannot leave a live
+    # token behind.
     rm "$APPROVAL_FILE"
   else
     echo -e "${RED}❌ BLOCKED: Reviewer approval expired (${TIME_DIFF}s old, max ${REVIEWER_APPROVAL_TIMEOUT}s)${NC}"
@@ -305,6 +356,25 @@ if [ "$USER_COMMIT" != "1" ] && [ "$NON_TEXT_FILES" -gt 0 ]; then
 fi
 
 echo "=============================="
+# ── Final: the tree must still be the approved one ───────────────────────────
+# Re-check, because everything above takes time and the index is shared. Git
+# commits whatever the index holds when it returns, not what it held when Step 1
+# ran — so a lint --fix that stages its own output, or a concurrent session
+# running `git add` in this checkout during the validation window, would commit a
+# tree nobody approved while the flag was already consumed. Several sessions work
+# this repository at once, so that window is real rather than theoretical.
+if [ "$USER_COMMIT" != "1" ] && [ -n "$APPROVAL_TREE" ]; then
+  FINAL_TREE=$(git write-tree 2>/dev/null || echo "")
+
+  if [ "$FINAL_TREE" != "$APPROVAL_TREE" ]; then
+    echo -e "${RED}❌ BLOCKED: staged tree changed during validation${NC}"
+    echo "   approved: $APPROVAL_TREE"
+    echo "   now:      ${FINAL_TREE:-<unreadable>}"
+    echo "   Something staged content while the checks were running. Re-review."
+    exit 1
+  fi
+fi
+
 echo -e "${GREEN}✅ COMMIT ALLOWED${NC}"
 echo ""
 exit 0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,12 +108,31 @@ No build step. No production dependencies — only dev dependencies (PHPUnit 9.6
 
 ### Worktree dependency isolation
 
-Every Git worktree must run its own `composer install`. **Never symlink or share
-`vendor/` between worktrees.** Composer generates absolute paths in
-`vendor/composer/autoload_classmap.php`; a shared directory can therefore load
-`WP_Sudo\*` production classes from another checkout while tests appear to run
-normally. This has produced a real false-green guard verification in this
-project.
+Every Git worktree must run its own `composer install`. **Never symlink
+`vendor/` between worktrees.**
+
+The mechanism is PHP, not Composer. Composer generates **no** absolute paths —
+`vendor/composer/autoload_classmap.php` and `autoload_psr4.php` both open with
+`$vendorDir = dirname(__DIR__); $baseDir = dirname($vendorDir);` and emit entries
+as `$baseDir . '/includes/…'`. Verify at any time:
+
+```bash
+grep -c '/Users/' vendor/composer/autoload_classmap.php   # 0
+```
+
+What breaks isolation is that PHP resolves symlinks in `__DIR__`. Loading the
+autoloader *through* a symlinked `vendor/` therefore computes `$baseDir` in the
+checkout the symlink points at, and every `WP_Sudo\*` production class loads
+from there while tests appear to run normally. This has produced a real
+false-green guard verification in this project — twice in one day, the second
+time to a reviewer reproducing the first.
+
+The distinction is operative, not pedantic: because the paths are derived at
+runtime, a **`cp -r` of another worktree's `vendor/` is harmless**, and only a
+symlink breaks it. The earlier wording here ("Composer generates absolute paths")
+would lead a maintainer to ban copying too, or to distrust the narrow check in
+`.githooks/pre-commit` that blocks exactly the symlink case. Recorded as
+[`llm-lies-log.md`](docs/llm-lies-log.md) #71.
 
 Before trusting tests in a worktree, verify both the directory and the resolved
 production class:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,13 +28,22 @@ When reviewing for commit approval:
 
 4. **If all checks PASS** — write the approval flag and respond APPROVED:
    ```
-   Bash({ command: "date +%s" })           ← get Unix timestamp
-   Write({
-     file_path: "<PROJECT_ROOT>/reviewer-approved",
-     content: "<timestamp>"
-   })
+   Bash({ command: "bash bin/reviewer-approve.sh" })
    ```
    Then respond: **"✅ APPROVED. Approval flag written."**
+
+   Do **not** write the file with the Write tool. The flag binds to the id of the
+   **staged tree**, so the script has to read the index; a hand-written timestamp
+   is rejected by the hook rather than silently honoured (#427). The script also
+   refuses when nothing is staged, which catches reviewing the working tree
+   instead of what will actually be committed — the two differ, and the hook
+   compares against the index.
+
+   **Review the staged tree, not the working tree.** `git show :<path>` reads the
+   staged blob; `git diff --cached` is the change being approved. A report that
+   describes edits which were never staged has approved nothing, and the tree
+   binding will not catch that — it pins *which* bytes were approved, not whether
+   you read them.
 
 5. **If any check FAILS** — respond REJECTED:
    **"❌ BLOCKED: [list specific issues with actionable fixes]"**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,22 @@ Example prompt:
 
 ### Reviewer approval flag
 
-The **reviewer agent** writes `reviewer-approved` using the Write tool after deciding APPROVE.
+The **reviewer agent** writes the flag after deciding APPROVE, by running:
+
+```bash
+bash bin/reviewer-approve.sh
+```
+
+Not with the Write tool. The flag is now two lines — a timestamp and the id of
+the **staged tree** (`git write-tree`) — and the hook rejects a flag whose tree
+does not match what is being committed. A hand-written timestamp is rejected
+outright rather than silently accepted, because a degraded binding that still
+looks like enforcement is worse than none (#427).
+
+This closes a real hole: the old flag proved only that *something* was approved
+recently, never that **this** was approved, so any edit between approval and
+commit rode in unreviewed behind a valid-looking flag.
+
 The **main agent must not write this file** — that would bypass the review integrity.
 
 ### When to skip

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,10 +14,15 @@ composer install
 ```
 
 When using a Git worktree, run `composer install` separately inside every
-worktree. Do not symlink or share `vendor/`: Composer's generated classmap uses
-absolute paths and can silently load WP Sudo production classes from a different
-checkout, producing false-green tests. Confirm the active mapping before
-trusting a worktree test run:
+worktree, and do **not** symlink `vendor/`. Composer writes no absolute paths —
+both `autoload_classmap.php` and `autoload_psr4.php` derive them at runtime from
+`$baseDir = dirname(dirname(__DIR__))` — but PHP resolves symlinks in `__DIR__`,
+so loading the autoloader through a symlinked `vendor/` puts `$baseDir` in the
+*other* checkout and silently loads WP Sudo production classes from there. The
+tests then pass without exercising your changes: green, but about the wrong code.
+A `cp -r` of another checkout's `vendor/` is therefore harmless; only a symlink
+breaks it, and the pre-commit hook blocks exactly that case. Confirm the active
+mapping before trusting a worktree test run:
 
 ```bash
 test -d vendor && test ! -L vendor
@@ -67,13 +72,29 @@ For your own (non-AI) commits, bypass the hook with `USER_COMMIT=1`:
 USER_COMMIT=1 git commit -m "message"
 ```
 
-The approval flag is single-use and expires after 30 minutes
+The approval flag is single-use, bound to content, and expires after 30 minutes
 (`REVIEWER_APPROVAL_TIMEOUT` in `.reviewer-config.sh`); the hook deletes it once
-consumed, and an expired flag blocks rather than passes. One caveat when several
-agent sessions share **one checkout**: the flag lives at the repository root, so
-an approval written by one session can be consumed by another session's commit
-inside that window. Separate worktrees do not have this problem — each resolves
-its own root.
+consumed, and an expired flag blocks rather than passes.
+
+**Content binding (#427).** The flag records the id of the staged tree
+(`git write-tree`) alongside the timestamp, and the hook refuses to commit if the
+staged tree has changed since approval. A timestamp alone only answers "was
+something approved recently" — never "was *this* approved" — so an edit made
+after approval used to ride in unreviewed behind a flag that still looked valid.
+Write the flag with `bash bin/reviewer-approve.sh`, never by hand: a
+timestamp-only flag is rejected rather than silently accepted.
+
+This narrows, but does not remove, the shared-checkout caveat: when several agent
+sessions share **one checkout**, an approval written by one session can still be
+consumed by another — but only if that session commits the *identical* staged
+tree. Separate worktrees avoid it entirely, since each resolves its own root.
+
+**A branch without `.githooks/` is ungated, silently.** `core.hooksPath` is set once
+per clone and shared by every worktree, but it is a *relative* path, so each worktree
+resolves it against its own checkout. A branch cut before `.githooks/pre-commit`
+existed therefore runs no hook at all — no warning, exit 0. There is no
+`.git/hooks/pre-commit` fallback. Rebase such a branch onto `main` before relying on
+the gate.
 
 ## Running Tests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,10 +61,21 @@ git add --chmod=+x .githooks/<hook-name>
 ```
 
 Git runs a hook only if the file is executable. Under `core.hooksPath` a
-non-executable hook is skipped **silently** — no hook, no warning, no error, and
-the repository looks correctly configured. `.githooks/pre-commit` is mode 100755;
-a new file committed at the default 100644 would appear installed and never run.
-Check with `git ls-files -s .githooks/`.
+non-executable hook is **skipped**, and git says so once:
+
+```
+hint: The '.githooks/pre-commit' hook was ignored because it's not set as executable.
+```
+
+That hint depends on `advice.ignoredHook`, which defaults on but is commonly
+disabled in shared setups — and a hint above a successful commit is easy to read
+past, so the repository can look correctly configured while nothing runs.
+`.githooks/pre-commit` is mode 100755; a new file committed at the default 100644
+would appear installed and never fire. Check with `git ls-files -s .githooks/`.
+
+(An earlier version of this paragraph said the skip was silent with "no warning,
+no error". Verified false on git 2.50.1: the hint above is emitted with default
+advice settings.)
 
 For your own (non-AI) commits, bypass the hook with `USER_COMMIT=1`:
 
@@ -88,6 +99,37 @@ This narrows, but does not remove, the shared-checkout caveat: when several agen
 sessions share **one checkout**, an approval written by one session can still be
 consumed by another — but only if that session commits the *identical* staged
 tree. Separate worktrees avoid it entirely, since each resolves its own root.
+
+**A staged file may not also have unstaged changes.** For a code commit the hook
+refuses when any staged path is also dirty in the working tree, and names the
+paths. The reason is that the approval binds to the **index** while every check —
+tests, lint, PHPStan — reads the **working tree**. While those differ a green
+validation says nothing about the bytes being committed: a broken staged
+implementation with an unstaged fix would validate green and commit broken, and
+the approval would faithfully record the broken tree.
+
+This does block a `git add -p` workflow that leaves the rest of a file dirty.
+Two compliant paths:
+
+```bash
+git add <file>                    # include the rest
+git stash push --keep-index       # set the rest aside, keep what you staged
+```
+
+Use `--keep-index`. A plain `git stash` also stashes the staged change, leaving
+nothing to commit.
+
+**The staged tree is re-checked after validation, not only before.** Validation
+takes tens of seconds and the index is shared — several sessions work this
+repository at once — so a `lint --fix` staging its own output, or another
+session's `git add`, could otherwise commit a tree nobody approved while the flag
+was already consumed. The hook compares `git write-tree` again as its last act
+and refuses on a mismatch.
+
+The flag is consumed at the *start* of validation rather than the end,
+deliberately: any failure worth fixing changes the tree, which invalidates the
+approval through the binding anyway, and early consumption means an interrupted
+run cannot leave a live token behind.
 
 **A branch without `.githooks/` is ungated, silently.** `core.hooksPath` is set once
 per clone and shared by every worktree, but it is a *relative* path, so each worktree

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,18 +26,54 @@ php -r '$m = require "vendor/composer/autoload_classmap.php"; $expected = realpa
 
 ### Git hooks
 
-Install the pre-commit hook to enforce reviewer agent approval before every AI-generated commit:
+Point git at the versioned hooks directory to enforce reviewer agent approval
+before every AI-generated commit:
 
 ```bash
-cp .githooks/pre-commit .git/hooks/pre-commit
-chmod +x .git/hooks/pre-commit
+git config core.hooksPath .githooks
 ```
+
+Run it once per clone. Git cannot enable hooks automatically — they execute
+arbitrary code, so a fresh clone never runs them until someone opts in. Nothing
+in CI verifies you have done this; see [#427](https://github.com/dknauss/Sudo/issues/427).
+
+This replaces the older `cp .githooks/pre-commit .git/hooks/pre-commit`. Prefer
+`core.hooksPath` for two reasons:
+
+- **`cp` takes a snapshot.** `.githooks/pre-commit` is maintained — it has since
+  gained a merge-commit exemption and a docs-only approval skip. A copy made
+  before those keeps blocking merges and docs commits, which is the fastest way
+  to train everyone to pass `--no-verify`.
+- **`core.hooksPath` covers every worktree.** It resolves through the common git
+  directory, so one setting applies to all of them. A copy into `.git/hooks`
+  reaches them too, but only until it goes stale — and `git worktree` checkouts
+  are how most work in this repo happens.
+
+**If you add a hook to `.githooks/`, commit it executable:**
+
+```bash
+git add --chmod=+x .githooks/<hook-name>
+```
+
+Git runs a hook only if the file is executable. Under `core.hooksPath` a
+non-executable hook is skipped **silently** — no hook, no warning, no error, and
+the repository looks correctly configured. `.githooks/pre-commit` is mode 100755;
+a new file committed at the default 100644 would appear installed and never run.
+Check with `git ls-files -s .githooks/`.
 
 For your own (non-AI) commits, bypass the hook with `USER_COMMIT=1`:
 
 ```bash
 USER_COMMIT=1 git commit -m "message"
 ```
+
+The approval flag is single-use and expires after 30 minutes
+(`REVIEWER_APPROVAL_TIMEOUT` in `.reviewer-config.sh`); the hook deletes it once
+consumed, and an expired flag blocks rather than passes. One caveat when several
+agent sessions share **one checkout**: the flag lives at the repository root, so
+an approval written by one session can be consumed by another session's commit
+inside that window. Separate worktrees do not have this problem — each resolves
+its own root.
 
 ## Running Tests
 

--- a/bin/reviewer-approve.sh
+++ b/bin/reviewer-approve.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+#
+# Write the reviewer approval flag, bound to the exact staged content.
+#
+# Run this from the reviewer agent AFTER deciding APPROVE, instead of writing
+# `reviewer-approved` by hand. The flag is two lines — a unix timestamp and the
+# id of the staged tree — and the pre-commit hook rejects a flag whose tree does
+# not match what is being committed.
+#
+# The binding is the point. A timestamp answers "was something approved
+# recently"; it cannot answer "was THIS approved". Any edit between approval and
+# commit previously rode in unreviewed behind a flag that still looked valid.
+#
+# Writing the file by hand with a bare timestamp is now rejected, deliberately:
+# a silently-degraded binding would be worse than none, because it would read as
+# enforcement.
+#
+# Usage:  bash bin/reviewer-approve.sh
+# Exit:   0 written, 1 refused (with the reason on stderr)
+
+set -euo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+CONFIG_FILE="$REPO_ROOT/.reviewer-config.sh"
+
+REVIEWER_APPROVAL_FILE="reviewer-approved"
+if [ -f "$CONFIG_FILE" ]; then
+	# shellcheck source=/dev/null
+	source "$CONFIG_FILE"
+fi
+
+APPROVAL_FILE="$REPO_ROOT/$REVIEWER_APPROVAL_FILE"
+
+# Refuse to approve nothing. An empty index means the reviewer looked at the
+# working tree rather than at what would be committed — the two differ, and the
+# hook compares against the index.
+if git diff --cached --quiet; then
+	echo "refusing to approve: nothing is staged." >&2
+	echo "Stage the change first; the hook binds approval to the staged tree." >&2
+	exit 1
+fi
+
+# `git write-tree` is the id of the current index. It writes tree objects but
+# does not move HEAD, modify the worktree, or alter the index. It fails on
+# unmerged entries, which is the correct time to refuse.
+if ! STAGED_TREE=$(git write-tree 2>/dev/null); then
+	echo "refusing to approve: git write-tree failed (unmerged index entries?)." >&2
+	exit 1
+fi
+
+printf '%s\n%s\n' "$(date +%s)" "$STAGED_TREE" > "$APPROVAL_FILE"
+
+echo "Approval written for staged tree $STAGED_TREE"
+echo "Any change to the staged content invalidates it."

--- a/bin/reviewer-approve.sh
+++ b/bin/reviewer-approve.sh
@@ -40,9 +40,12 @@ if git diff --cached --quiet; then
 	exit 1
 fi
 
-# `git write-tree` is the id of the current index. It writes tree objects but
-# does not move HEAD, modify the worktree, or alter the index. It fails on
-# unmerged entries, which is the correct time to refuse.
+# `git write-tree` is the id of the current index. It does not move HEAD or touch
+# the worktree. It does rewrite `.git/index` when the cache-tree extension is
+# missing or stale — git persists that extension — but the staged content is
+# unchanged and `git status` is unaffected. Stated to match the hook's own note
+# rather than contradict it. Fails on unmerged entries, which is the correct time
+# to refuse.
 if ! STAGED_TREE=$(git write-tree 2>/dev/null); then
 	echo "refusing to approve: git write-tree failed (unmerged index entries?)." >&2
 	exit 1

--- a/docs/llm-lies-log.md
+++ b/docs/llm-lies-log.md
@@ -1936,3 +1936,45 @@ C2. REDUNDANT MEMORY DUPLICATING CLAUDE.md
    Fix:    Read the function. When a summary states a type, the summary is the thing to
            check, not the thing to cite — and when its own columns disagree, that
            disagreement is the signal to go to source, not a detail to route around.
+
+71. A MECHANISM INVENTED TO EXPLAIN A REAL FAILURE — the failure was real, the
+    check written for it was correct, and the reason given for both was false.
+   Claim:  In `.githooks/pre-commit`, its user-facing error message, and
+           `CONTRIBUTING.md` (three places): "Composer bakes absolute paths into
+           `vendor/composer/autoload_psr4.php`", so a symlinked `vendor/` makes
+           the PSR-4 map point at another checkout.
+   Reality: Composer writes **no** absolute paths. Both `autoload_psr4.php` and
+           `autoload_classmap.php` open with `$vendorDir = dirname(__DIR__);
+           $baseDir = dirname($vendorDir);` and emit entries as
+           `$baseDir . '/includes/class-gate.php'`.
+
+               $ grep -c '/Users/' vendor/composer/autoload_psr4.php     # 0
+               $ grep -c '/Users/' vendor/composer/autoload_classmap.php # 0
+
+           The real mechanism is PHP: `__DIR__` resolves symlinks, so including
+           the autoloader *through* a symlinked `vendor/` makes `$baseDir` land
+           in the real tree the symlink points at.
+   Source: `vendor/composer/autoload_psr4.php` and `autoload_classmap.php` in
+           this repo, read 2026-07-27.
+   Notes:  The underlying failure was real and independently reproduced twice the
+           same day — a guard test written to fail against an injected defect
+           passed, because the defect was injected in one worktree and the class
+           loaded from another; then a reviewer reproducing that result hit the
+           identical trap. Having *seen* the symptom made the explanation feel
+           established, and it was never checked.
+
+           Two things follow. First, a correct guard can rest on a false
+           rationale: the vendor-root check is right, but the stated reason would
+           lead a maintainer to widen it pointlessly — a `cp -r vendor` is
+           harmless under the true mechanism and fatal under the invented one.
+           Second, the claim propagated to three places before anyone read the
+           file, including a user-facing error message, because each copy was
+           written from the same unchecked belief rather than from the source.
+
+           Caught by an external reviewer running the one-line grep. The distance
+           between "I watched this fail twice" and "I know why it failed" is the
+           whole entry.
+   Fix:    A reproduced symptom licenses no claim about its cause. When writing
+           the *reason* into a comment, an error message, or docs, open the file
+           that would falsify it — especially when the symptom is already
+           convincing, which is when the check feels least necessary.


### PR DESCRIPTION
Closes #427.

Two commits. The first is Dan's pre-existing `docs/427-hooks-install` work, rebased onto main — documentation for installing via `core.hooksPath` instead of a `cp` that goes stale. I built on that branch rather than opening a parallel one. The second is the enforcement half.

## The gate could not run

`core.hooksPath` was unset and no `.git/hooks/pre-commit` existed, so `.githooks/pre-commit` never executed — anywhere, on any worktree, silently. Every "reviewer approved" this repo has recorded was an agent honouring a convention, not a control enforcing one.

Codex listed four requirements. **One was already implemented** — approval consumption, `rm "$APPROVAL_FILE"`, plus a leftover-clear on the docs-only path. The other three are here.

## 1. Approval is bound to content

The flag carried only a timestamp, which answers *"was something approved recently"* and never *"was **this** approved"*. Any edit between approval and commit rode in unreviewed behind a flag that still looked valid.

It now carries `git write-tree` — the id of the exact staged content — and the hook refuses when it differs. The index tree was chosen over hashing `git diff --cached` because it is insensitive to diff config **and** catches files staged *after* review. A bare-timestamp flag is rejected outright rather than accepted degraded: a binding that reads as enforcement while enforcing nothing is how this issue happened.

**The binding survives the staging shortcuts.** Git hands the hook a temporary index via `GIT_INDEX_FILE`, so under `git commit -a` and `git commit <pathspec>` the hook's `write-tree` sees the tree that will *actually* be committed. Both fail closed against a stale approval — verified in review, not assumed.

`bin/reviewer-approve.sh` writes the flag (staged `100755`). It refuses when nothing is staged, which catches reviewing the working tree instead of what will be committed.

## 2. Dependency-root check

Blocks a `vendor/` resolving outside the worktree. Not hypothetical — it happened twice on 2026-07-27: a guard test written to fail against an injected defect **passed**, because the defect was injected in one worktree and the class loaded from another; then a reviewer reproducing that result hit the identical trap.

**The mechanism is PHP, not Composer.** An earlier draft of this change claimed Composer bakes absolute paths into its autoloader, in three places *including a user-facing error message*. It does not — `grep -c '/Users/'` returns `0` for `autoload_psr4.php` and `autoload_classmap.php`, both of which derive `$baseDir` at runtime. `__DIR__` resolves symlinks, so loading the autoloader through a symlinked `vendor/` puts `$baseDir` in the other checkout. This matters for scope: `cp -r vendor` is harmless, only a symlink breaks it, so the check is deliberately narrow. Recorded as `llm-lies-log` #71.

## 3. Installed

`git config core.hooksPath .githooks` is set. A hazard the review surfaced by experiment is now documented: it is set once per clone and shared by every worktree, but resolves *relatively* against each worktree's checkout — so a branch cut before `.githooks/pre-commit` existed runs **no hook at all**, silently, exit 0, with no `.git/hooks` fallback.

`AGENTS.md` gains an instruction the mechanism cannot enforce: **review the staged tree, not the working tree.** The binding pins which bytes were approved, not whether anyone read them.

## Verified paths

Six, manually: empty index refused · bare-timestamp blocked and revoked · valid approval consumed on success · **post-approval re-stage blocked and revoked** · symlinked `vendor/` blocked · real install passes.

This PR's own commit was gated by the new hook and consumed a tree-bound flag, which is its first real use.

## Known gap, recorded rather than dropped

**The gate has no automated test.** The issue being fixed is "the gate went inert and nobody noticed" — an untested gate can go inert the same way, and the six paths above live only in a review transcript. Worth its own issue.

Also noted for opportunistic fix: `CONTRIBUTING.md` paraphrases the derivation as `dirname(dirname(__DIR__))` where the generated file uses two statements. Semantically identical; flagged only because #71 is an entry about paraphrasing source from memory.

## Validation

`composer test:unit` 1273 / 3812 · `lint` 24/24 · PHPStan clean · `bash -n` on both scripts · size gate 6 files / 244 insertions. Reviewer-approved against tree `2847d4f`.