### PR TITLE
docs(planning): correct REST network-context claim

### DIFF
--- a/.planning/post-4.1.0-dev-scopes.md
+++ b/.planning/post-4.1.0-dev-scopes.md
@@ -212,9 +212,10 @@ implementation.
 - Rule out **iframe** (SameSite/partitioned-cookie breaks sudo-cookie readback) → use
   same-document AJAX against the existing challenge handlers.
 - Re-mint the REST nonce on retry (apiFetch's nonce middleware already does this).
-- `challenge_url` has **no reliable network-admin context** under REST
-  (`is_network_admin()` is false) — client builds it from a localized base, or the
-  server emits a context-correct URL; don't naively reuse admin-path logic.
+- `challenge_url` has **no reliable network-admin context** under REST because
+  `is_network_admin()` reads mutable ambient state — client builds it from a
+  localized base, or the server emits a context-correct URL; don't naively reuse
+  admin-path logic.
 - The grace window (120 s) already covers "don't re-challenge"; retry should re-fire
   and let the gate re-evaluate, not gate the UI on a stale flag.
 - **`@wordpress/scripts` build step — DECISION: not needed for Phase 2 (build-free).**

--- a/.planning/post-4.1.0-dev-scopes.md
+++ b/.planning/post-4.1.0-dev-scopes.md
@@ -213,9 +213,11 @@ implementation.
   same-document AJAX against the existing challenge handlers.
 - Re-mint the REST nonce on retry (apiFetch's nonce middleware already does this).
 - `challenge_url` has **no reliable network-admin context** under REST because
-  `is_network_admin()` reads mutable ambient state — client builds it from a
-  localized base, or the server emits a context-correct URL; don't naively reuse
-  admin-path logic.
+  `is_network_admin()` reads mutable ambient state (`GB-IS-NETWORK-ADMIN`) — it
+  tests `$GLOBALS['current_screen']`, then the `WP_NETWORK_ADMIN` constant, then
+  falls through to `false`, and both pieces of state can be set by any
+  earlier-running plugin or hook. Client builds the URL from a localized base, or
+  the server emits a context-correct one; don't naively reuse admin-path logic.
 - The grace window (120 s) already covers "don't re-challenge"; retry should re-fire
   and let the gate re-evaluate, not gate the UI on a stale flag.
 - **`@wordpress/scripts` build step — DECISION: not needed for Phase 2 (build-free).**


### PR DESCRIPTION
## What changed

Replaces the unsupported claim that `is_network_admin()` is false under REST with the narrower verified statement that the function reads mutable ambient state.

## Why

The old sentence predicted a runtime value from core's normal bootstrap path even though earlier-running plugins or hooks can alter the globals the function reads. This is the same absence-claim defect retracted in #488. The planning conclusion remains unchanged: REST cannot derive a reliable network-admin URL context from that ambient value.

## Validation

- `composer test:unit` — 1,283 tests, 3,838 assertions
- `composer lint`
- `composer analyse`
- `composer verify:metrics`
- repository-wide stale-claim sweep

Closes #491