### PR TITLE
test(473): exercise reviewer gate end to end

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -288,7 +288,7 @@ else
   # Unit tests
   if [ -n "$REVIEWER_TEST_CMD" ]; then
     echo "   Running unit tests..."
-    if ! eval "$REVIEWER_TEST_CMD" 2>&1 | tail -6; then
+    if ! ( set -o pipefail; eval "$REVIEWER_TEST_CMD" 2>&1 | tail -6 ); then
       echo -e "${RED}❌ BLOCKED: Unit tests failed${NC}"
       exit 1
     fi
@@ -298,7 +298,7 @@ else
   # Linter
   if [ -n "$REVIEWER_LINT_CMD" ]; then
     echo "   Running linter..."
-    if ! eval "$REVIEWER_LINT_CMD" 2>&1 | tail -3; then
+    if ! ( set -o pipefail; eval "$REVIEWER_LINT_CMD" 2>&1 | tail -3 ); then
       echo -e "${RED}❌ BLOCKED: Linter failed${NC}"
       exit 1
     fi

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -312,6 +312,9 @@ jobs:
       - name: Install Composer dependencies
         run: composer install --no-interaction --prefer-dist
 
+      - name: Verify reviewer gate
+        run: composer test:reviewer-gate
+
       - name: Verify metrics file drift
         run: composer verify:metrics
 

--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,7 @@
         "test:poc": "phpunit -c poc/install-package-gate/phpunit.xml.dist",
         "test:integration": "bash bin/run-integration-tests.sh phpunit-integration.xml.dist",
         "test:coverage": "phpunit --configuration phpunit.xml.dist --coverage-clover coverage.xml --coverage-text",
+        "test:reviewer-gate": "bash tests/reviewer-gate/run.sh",
         "test:sources": "bash tests/verify-sources/run.sh",
         "verify:metrics": "bash bin/verify-metrics.sh",
         "verify:i18n": "bash bin/verify-i18n.sh",

--- a/tests/reviewer-gate/run.sh
+++ b/tests/reviewer-gate/run.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+#
+# Black-box regression tests for the staged-tree reviewer gate.
+
+set -u
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+TMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/wp-sudo-reviewer-gate.XXXXXX")
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+passed=0
+failed=0
+case_number=0
+output=""
+status=0
+
+pass() {
+	passed=$((passed + 1))
+}
+
+fail() {
+	printf 'not ok %d - %s\n' "$case_number" "$1"
+	printf '%s\n' "$output" | sed 's/^/  /'
+	failed=$((failed + 1))
+}
+
+expect_status() {
+	local expected=$1
+	local description=$2
+
+	case_number=$((case_number + 1))
+	if [ "$status" -eq "$expected" ]; then
+		printf 'ok %d - %s\n' "$case_number" "$description"
+		pass
+	else
+		fail "$description (expected status $expected, got $status)"
+	fi
+}
+
+expect_output() {
+	local needle=$1
+	local description=$2
+
+	case_number=$((case_number + 1))
+	if printf '%s\n' "$output" | grep -qF -- "$needle"; then
+		printf 'ok %d - %s\n' "$case_number" "$description"
+		pass
+	else
+		fail "$description (missing: $needle)"
+	fi
+}
+
+new_repo() {
+	local name=$1
+	local repo="$TMP_ROOT/$name"
+
+	mkdir -p "$repo/.githooks" "$repo/bin"
+	cp "$ROOT/.githooks/pre-commit" "$repo/.githooks/pre-commit"
+	cp "$ROOT/bin/reviewer-approve.sh" "$repo/bin/reviewer-approve.sh"
+	chmod +x "$repo/.githooks/pre-commit" "$repo/bin/reviewer-approve.sh"
+
+	git -C "$repo" init -q
+	git -C "$repo" config user.name "Reviewer Gate Test"
+	git -C "$repo" config user.email "reviewer-gate@example.invalid"
+	printf 'reviewer-approved\n' > "$repo/.gitignore"
+	printf 'seed\n' > "$repo/README.md"
+	git -C "$repo" add .gitignore README.md .githooks/pre-commit bin/reviewer-approve.sh
+	git -C "$repo" commit -qm "test: seed repository"
+
+	cat > "$repo/.reviewer-config.sh" <<'EOF'
+REVIEWER_TEST_CMD=":"
+REVIEWER_LINT_CMD=":"
+REVIEWER_BUILD_CMD=":"
+REVIEWER_E2E_CMD=""
+REVIEWER_MAX_FILES=1
+REVIEWER_MAX_INSERTIONS=20
+REVIEWER_APPROVAL_TIMEOUT=1800
+REVIEWER_APPROVAL_FILE="reviewer-approved"
+REVIEWER_TEXT_ONLY_PATTERN='\.(md|txt|rst)$'
+REVIEWER_EXCLUDED_FILES='^package-lock\.json$'
+EOF
+
+	printf '%s\n' "$repo"
+}
+
+run_in() {
+	local repo=$1
+	shift
+
+	set +e
+	output=$(cd "$repo" && "$@" 2>&1)
+	status=$?
+	set -e
+}
+
+set -e
+
+mode=$(git -C "$ROOT" ls-files -s .githooks/pre-commit | awk '{print $1}')
+status=0
+output="index mode: $mode"
+[ "$mode" = "100755" ] || status=1
+expect_status 0 "pre-commit hook is executable in the index"
+
+repo=$(new_repo empty-index)
+run_in "$repo" bash bin/reviewer-approve.sh
+expect_status 1 "approval refuses an empty index"
+expect_output "nothing is staged" "empty-index refusal explains the problem"
+
+repo=$(new_repo valid-approval)
+printf '<?php\n' > "$repo/change.php"
+git -C "$repo" add change.php
+run_in "$repo" bash bin/reviewer-approve.sh
+expect_status 0 "approval binds to a staged tree"
+run_in "$repo" bash .githooks/pre-commit
+expect_status 0 "matching staged-tree approval passes the hook"
+status=0
+output="approval flag still exists"
+[ ! -e "$repo/reviewer-approved" ] || status=1
+expect_status 0 "successful hook consumes the approval flag"
+
+repo=$(new_repo changed-tree)
+printf '<?php\n' > "$repo/change.php"
+git -C "$repo" add change.php
+(cd "$repo" && bash bin/reviewer-approve.sh >/dev/null)
+printf '<?php\n// changed\n' > "$repo/change.php"
+git -C "$repo" add change.php
+run_in "$repo" bash .githooks/pre-commit
+expect_status 1 "restaging changed content invalidates approval"
+expect_output "Staged content changed since approval" "tree mismatch is reported"
+
+repo=$(new_repo legacy-flag)
+printf '<?php\n' > "$repo/change.php"
+git -C "$repo" add change.php
+date +%s > "$repo/reviewer-approved"
+run_in "$repo" bash .githooks/pre-commit
+expect_status 1 "legacy timestamp-only approval is rejected"
+expect_output "no content binding" "legacy flag failure names the missing binding"
+
+repo=$(new_repo docs-only)
+printf 'docs\n' > "$repo/change.md"
+git -C "$repo" add change.md
+printf 'stale\nflag\n' > "$repo/reviewer-approved"
+run_in "$repo" bash .githooks/pre-commit
+expect_status 0 "docs-only staged content skips reviewer approval"
+status=0
+output="approval flag still exists"
+[ ! -e "$repo/reviewer-approved" ] || status=1
+expect_status 0 "docs-only path clears a leftover approval flag"
+
+repo=$(new_repo user-bypass)
+printf '<?php\n' > "$repo/change.php"
+git -C "$repo" add change.php
+run_in "$repo" env USER_COMMIT=1 bash .githooks/pre-commit
+expect_status 0 "USER_COMMIT bypass remains available"
+expect_output "User commit bypass enabled" "bypass is visible in hook output"
+
+repo=$(new_repo vendor-symlink)
+mkdir -p "$TMP_ROOT/foreign-vendor"
+ln -s "$TMP_ROOT/foreign-vendor" "$repo/vendor"
+printf '<?php\n' > "$repo/change.php"
+git -C "$repo" add change.php
+run_in "$repo" env USER_COMMIT=1 bash .githooks/pre-commit
+expect_status 1 "foreign vendor symlink is rejected"
+expect_output "vendor/ does not belong to this worktree" "vendor failure explains the isolation breach"
+
+repo=$(new_repo merge-size)
+printf '<?php\n' > "$repo/one.php"
+printf '<?php\n' > "$repo/two.php"
+git -C "$repo" add one.php two.php
+(cd "$repo" && bash bin/reviewer-approve.sh >/dev/null)
+git -C "$repo" rev-parse HEAD > "$repo/.git/MERGE_HEAD"
+run_in "$repo" bash .githooks/pre-commit
+expect_status 0 "merge path skips only the AI size limit"
+expect_output "Merge commit" "merge-size exemption is reported"
+expect_output "Reviewer agent approved" "merge path still requires staged-tree approval"
+
+printf '\nreviewer-gate tests: %d passed, %d failed\n' "$passed" "$failed"
+[ "$failed" -eq 0 ]

--- a/tests/reviewer-gate/run.sh
+++ b/tests/reviewer-gate/run.sh
@@ -62,6 +62,7 @@ new_repo() {
 	git -C "$repo" init -q
 	git -C "$repo" config user.name "Reviewer Gate Test"
 	git -C "$repo" config user.email "reviewer-gate@example.invalid"
+	git -C "$repo" config commit.gpgSign false
 	printf 'reviewer-approved\n' > "$repo/.gitignore"
 	printf 'seed\n' > "$repo/README.md"
 	git -C "$repo" add .gitignore README.md .githooks/pre-commit bin/reviewer-approve.sh
@@ -128,6 +129,15 @@ run_in "$repo" bash .githooks/pre-commit
 expect_status 1 "restaging changed content invalidates approval"
 expect_output "Staged content changed since approval" "tree mismatch is reported"
 
+repo=$(new_repo unstaged-change)
+printf '<?php\n' > "$repo/change.php"
+git -C "$repo" add change.php
+(cd "$repo" && bash bin/reviewer-approve.sh >/dev/null)
+printf '<?php\n// unstaged\n' > "$repo/change.php"
+run_in "$repo" bash .githooks/pre-commit
+expect_status 1 "unstaged changes to a staged file are rejected"
+expect_output "staged files also have unstaged changes" "unstaged-change failure explains the mismatch"
+
 repo=$(new_repo legacy-flag)
 printf '<?php\n' > "$repo/change.php"
 git -C "$repo" add change.php
@@ -154,9 +164,16 @@ run_in "$repo" env USER_COMMIT=1 bash .githooks/pre-commit
 expect_status 0 "USER_COMMIT bypass remains available"
 expect_output "User commit bypass enabled" "bypass is visible in hook output"
 
+repo=$(new_repo missing-approval)
+printf '<?php\n' > "$repo/change.php"
+git -C "$repo" add change.php
+run_in "$repo" bash .githooks/pre-commit
+expect_status 1 "code without reviewer approval is rejected"
+expect_output "No reviewer agent approval found" "missing approval is reported"
+
 repo=$(new_repo vendor-symlink)
-mkdir -p "$TMP_ROOT/foreign-vendor"
-ln -s "$TMP_ROOT/foreign-vendor" "$repo/vendor"
+mkdir -p "$repo/nested-checkout/vendor"
+ln -s "$repo/nested-checkout/vendor" "$repo/vendor"
 printf '<?php\n' > "$repo/change.php"
 git -C "$repo" add change.php
 run_in "$repo" env USER_COMMIT=1 bash .githooks/pre-commit
@@ -173,6 +190,51 @@ run_in "$repo" bash .githooks/pre-commit
 expect_status 0 "merge path skips only the AI size limit"
 expect_output "Merge commit" "merge-size exemption is reported"
 expect_output "Reviewer agent approved" "merge path still requires staged-tree approval"
+
+repo=$(new_repo failed-tests)
+printf '<?php\n' > "$repo/change.php"
+git -C "$repo" add change.php
+(cd "$repo" && bash bin/reviewer-approve.sh >/dev/null)
+printf 'REVIEWER_TEST_CMD="false"\n' >> "$repo/.reviewer-config.sh"
+run_in "$repo" bash .githooks/pre-commit
+expect_status 1 "failed unit validation blocks the commit"
+expect_output "Unit tests failed" "unit failure is reported"
+
+repo=$(new_repo failed-lint)
+printf '<?php\n' > "$repo/change.php"
+git -C "$repo" add change.php
+(cd "$repo" && bash bin/reviewer-approve.sh >/dev/null)
+printf 'REVIEWER_LINT_CMD="false"\n' >> "$repo/.reviewer-config.sh"
+run_in "$repo" bash .githooks/pre-commit
+expect_status 1 "failed lint validation blocks the commit"
+expect_output "Linter failed" "lint failure is reported"
+
+repo=$(new_repo validation-mutates-index)
+printf '<?php\n' > "$repo/change.php"
+git -C "$repo" add change.php
+(cd "$repo" && bash bin/reviewer-approve.sh >/dev/null)
+printf '%s\n' 'REVIEWER_TEST_CMD="printf \"// validation mutation\\n\" >> change.php; git add change.php"' >> "$repo/.reviewer-config.sh"
+run_in "$repo" bash .githooks/pre-commit
+expect_status 1 "index mutation during validation invalidates approval"
+expect_output "staged tree changed during validation" "validation-time index mutation is reported"
+
+repo=$(new_repo future-approval)
+printf '<?php\n' > "$repo/change.php"
+git -C "$repo" add change.php
+future_timestamp=$(( $(date +%s) + 60 ))
+printf '%s\n%s\n' "$future_timestamp" "$(git -C "$repo" write-tree)" > "$repo/reviewer-approved"
+run_in "$repo" bash .githooks/pre-commit
+expect_status 1 "future-dated bound approval is rejected"
+expect_output "timestamp is in the future" "future approval failure is reported"
+
+repo=$(new_repo expired-approval)
+printf '<?php\n' > "$repo/change.php"
+git -C "$repo" add change.php
+expired_timestamp=$(( $(date +%s) - 1801 ))
+printf '%s\n%s\n' "$expired_timestamp" "$(git -C "$repo" write-tree)" > "$repo/reviewer-approved"
+run_in "$repo" bash .githooks/pre-commit
+expect_status 1 "expired bound approval is rejected"
+expect_output "Reviewer approval expired" "expired approval failure is reported"
 
 printf '\nreviewer-gate tests: %d passed, %d failed\n' "$passed" "$failed"
 [ "$failed" -eq 0 ]


### PR DESCRIPTION
Closes #473.

## Summary

- add a black-box scratch-repository harness for the staged-tree reviewer gate
- cover approval refusal/binding/consumption, changed-tree and unstaged-change rejection, legacy/future/expired flags, docs-only cleanup, `USER_COMMIT`, nested-checkout `vendor/` isolation, merge-size behavior, validation-time index mutation, missing approval, and executable hook mode
- fix a discovered fail-open: unit-test and lint commands piped through `tail` previously reported success when the validation command failed; pipeline-local `pipefail` now preserves the failure
- run the harness in the required code-quality CI job
- expose the harness as `composer test:reviewer-gate`

The harness creates only temporary repositories and does not touch the caller index or approval flag.

## Verification

- TDD red run: failed unit/lint validations were accepted before the hook fix
- `composer test:reviewer-gate` — 33 passed
- `composer test` — 1,307 tests / 3,904 assertions
- `composer lint`
- `composer analyse`
- GitHub required matrix, code quality (including the new reviewer-gate step), full E2E, Plugin Check, CodeQL, and Codecov all pass at `8c30273`

All eight review threads were answered and resolved.