### PR TITLE
fix(notices): one honest post-reauthentication notice, replacing two wrong ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,65 @@
 
 ## Unreleased
 
+- **One honest post-reauthentication notice, replacing two that were both wrong
+  (#463, #469, #436 face 2).** The landing notice is the sentence most users see
+  after a gated action, and every clause of it was inaccurate in some path.
+
+  - It opened "Reauthentication complete." That is true only on the
+    `replay_stash()` path where a credential was verified.
+    `complete_active_session_request()` and `render_resume_page()` reach the same
+    notice with `$credential_verified` false — the user already held a session and
+    presented nothing on that request. False on two paths of three.
+  - It told the user to "review the form and submit it again". Since 4.9.0 every
+    stash takes the refusal path, so the most common arrival is a link-driven GET
+    — plugin or theme activation — which never had a form (#463).
+  - The "secrets" variant said "password and secret fields were not replayed",
+    which implies the other fields **were**. Nothing is replayed. A user who
+    submitted a profile form could reasonably conclude their email and display
+    name had been saved. They had not (#469).
+
+  The redacted/blocked distinction is also **unsound as a description of
+  secrets**, which is why the two notices collapse into one rather than both being
+  reworded. `redacted_fields_omitted` is set only inside
+  `Request_Stash::sanitize_params()`, which `build_stashed_post_params()` returns
+  before whenever `post_mode` is `none` — so it requires a rule using
+  `stash_allowlist()` whose own allowlisted field names hit
+  `sensitive_field_keys()`. Among builtin rules exactly one qualifies:
+  `user.create`. The three rules whose whole *purpose* is changing a credential —
+  `user.change_password`, `user.change_email`, `user.promote_profile` — use
+  `stash_no_replay()`, which discards the body without ever reaching
+  `sanitize_params()`, so they got the *other* notice. The POST that definitely
+  carried a password produced the message that did not mention passwords.
+
+  The flag is a **one-way signal**: raised means a secret was present and dropped;
+  not-raised means nothing at all. That is what made it useless as the selector for
+  wording about secrets, and why the two notices collapse rather than both being
+  reworded.
+
+  `Challenge::REDACTED_REPLAY_QUERY_ARG` is **kept and documented inert** per
+  `VERSIONING.md`'s security-forced-inertness clause: it is public API, and a URL
+  already in flight when a site upgrades must still explain itself. It is no longer
+  emitted; arriving with it renders the same single string, and a URL carrying both
+  args renders one notice rather than two.
+
+  The notice now also carries `role="alert"`, matching the in-page challenge
+  notices — without it a screen-reader user got no announcement that the action
+  they just took had been discarded, which is the entire content of the message.
+
+  **Zero tests asserted either notice body before this change** — only the query
+  arg in the redirect URL — which is why three separate defects survived review.
+  Six now assert the text directly. `tests/MANUAL-TESTING.md` §2.15, §2.16 and
+  §17.2 encoded the same false model (expecting the redacted notice after a
+  `user.change_password`, which never fired; expecting a return to
+  `user-edit.php`, which `HANDLER_ENDPOINTS` has forbidden since #429; and
+  expecting the password to change on authentication, which no longer happens) and
+  are corrected.
+
+  This **partially addresses** #436. Faces 1 (preserving typed input), 3 (naming
+  every matched rule) and 4 (gating before the form) are separate work with their
+  own reviews — face 3 changes `Gate::match_request()`'s first-match-wins
+  semantics, which is a security property, not a display detail.
+
 - **`wp_sudo_require()` now reports its inert `return_url` argument (#461).**
   The argument has had no effect since 4.9.0 because automatically navigating
   to a caller-supplied destination after reauthentication would run under the

--- a/bridges/wp-sudo-two-factor-lifecycle-bridge.php
+++ b/bridges/wp-sudo-two-factor-lifecycle-bridge.php
@@ -225,11 +225,28 @@ add_filter(
 				'post_mode'   => 'allowlist',
 				// Preserve the source-verified core profile fields used by
 				// user-edit.php/edit_user(). Nothing is replayed (#322), so this does
-				// not reconstruct the save. Its live effect is the notice: pass1,
-				// pass2 and pass1-text are in BOTH this allowlist and Request_Stash's
+				// not reconstruct the save.
+				//
+				// It has NO live effect on what the user sees. pass1, pass2 and
+				// pass1-text are in both this allowlist and Request_Stash's
 				// sensitive-key list, so build_stashed_post_params() drops them and
-				// sets redacted_fields_omitted — which selects the "re-enter the
-				// secret fields" landing notice instead of the generic one.
+				// sets redacted_fields_omitted — which used to select a "re-enter the
+				// secret fields" landing notice. Since #469 there is one notice on
+				// every path and that flag selects nothing; it survives on the response
+				// array only as an accurate report of what sanitize_params() did.
+				//
+				// The flag is a ONE-WAY signal, which is why wording keyed on it was
+				// wrong. sanitize_params() sets it only when it actually encounters and
+				// drops a sensitive key, so raised => a secret was present. The converse
+				// does not hold: stash_no_replay() rules discard the whole body without
+				// ever reaching sanitize_params(), so not-raised says nothing about
+				// whether a secret was there. Every builtin rule on these screens
+				// (user.promote_profile, user.change_password, user.change_email) takes
+				// that path, and network.super_admin carries no stash key at all — so on
+				// profile.php/user-edit.php this rule is the only one that can raise the
+				// flag. It is emphatically NOT the only rule anywhere that can:
+				// user.create is a builtin using stash_allowlist() with pass1/pass2/
+				// pass1-text in its list.
 				// Third-party profile fields are deliberately outside this verified
 				// bridge allowlist.
 				'post_fields' => array(

--- a/docs/current-metrics.md
+++ b/docs/current-metrics.md
@@ -9,8 +9,8 @@ Verification environment: local workspace, PHP 8.x
 
 | Metric | Value | Verification |
 |---|---:|---|
-| Unit tests | 1,301 tests | `composer test:unit` |
-| Unit assertions | 3,893 assertions | `composer test:unit` |
+| Unit tests | 1,307 tests | `composer test:unit` |
+| Unit assertions | 3,904 assertions | `composer test:unit` |
 | Integration tests in suite | 243 test methods | `rg -c "function test" tests/Integration/*.php | awk -F: '{sum+=$2} END{print sum}'` |
 | Unit test files | 38 | `ls tests/Unit/*.php | wc -l` |
 | Integration test files | 31 | `ls tests/Integration/*.php | wc -l` |
@@ -19,11 +19,11 @@ Verification environment: local workspace, PHP 8.x
 
 | Metric | Value | Verification |
 |---|---:|---|
-| Production PHP lines (`includes/`, `wp-sudo.php`, `uninstall.php`, `mu-plugin/`, `bridges/`) | 21,463 | `find ./includes ./wp-sudo.php ./uninstall.php ./mu-plugin ./bridges -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
-| Tests PHP lines (`tests/`) | 45,558 | `find ./tests -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
-| Production + tests PHP lines | 67,021 | sum of the two rows above |
-| Test-to-production ratio | 2.12:1 | `45558 / 21463` |
-| Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`, `.claude/`) | 69,296 | `find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/vendor_test/*" ! -path "*/.tmp/*" ! -path "*/.git/*" ! -path "*/.claude/*" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Production PHP lines (`includes/`, `wp-sudo.php`, `uninstall.php`, `mu-plugin/`, `bridges/`) | 21,568 | `find ./includes ./wp-sudo.php ./uninstall.php ./mu-plugin ./bridges -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Tests PHP lines (`tests/`) | 45,758 | `find ./tests -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Production + tests PHP lines | 67,326 | sum of the two rows above |
+| Test-to-production ratio | 2.12:1 | `45758 / 21568` |
+| Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`, `.claude/`) | 69,601 | `find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/vendor_test/*" ! -path "*/.tmp/*" ! -path "*/.git/*" ! -path "*/.claude/*" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
 
 ## Footprint & Performance
 

--- a/includes/class-challenge.php
+++ b/includes/class-challenge.php
@@ -77,22 +77,42 @@ class Challenge {
 	public const AJAX_REFRESH_NONCE_ACTION = 'wp_sudo_refresh_grant_nonce';
 
 	/**
-	 * Query arg used to show a notice on the landing page when the POST that was
-	 * intercepted contained redacted secret fields, so the user knows to re-enter
-	 * them. No server-stashed request is replayed (#322); this distinguishes WHY
-	 * the user must redo the action, not WHETHER.
+	 * INERT since #469 — no longer emitted, still honoured on arrival.
+	 *
+	 * It once selected a "secrets were redacted" variant of the landing notice.
+	 * That distinction was never sound. `redacted_fields_omitted` is set only
+	 * inside Request_Stash::sanitize_params(), which build_stashed_post_params()
+	 * returns before whenever `post_mode` is `none` or the allowlist is empty, so
+	 * the flag requires a rule using stash_allowlist() whose OWN allowlisted field
+	 * names hit sensitive_field_keys(). Among builtin rules exactly one qualifies:
+	 * `user.create`. The three rules whose whole PURPOSE is changing a credential —
+	 * `user.change_password`, `user.change_email`, `user.promote_profile` — use
+	 * stash_no_replay(), which discards the body without ever reaching
+	 * sanitize_params(), leaving the flag false. So the POST that definitely
+	 * carried a password got the notice that did not mention passwords.
+	 *
+	 * The flag is a ONE-WAY signal: raised means a secret was present and dropped,
+	 * but not-raised means nothing at all. That is what made it useless as the
+	 * selector for wording about secrets.
+	 *
+	 * Kept rather than deleted per VERSIONING.md's security-forced-inertness
+	 * clause: it is public API, and a URL already in flight when a site upgrades
+	 * must still explain itself. render_redacted_replay_notice() now renders the
+	 * same single string as the blocked arg.
 	 *
 	 * @var string
 	 */
 	public const REDACTED_REPLAY_QUERY_ARG = 'wp_sudo_redacted_replay';
 
 	/**
-	 * Query arg added to the landing URL for a consumed stash whose secrets were
-	 * NOT redacted — the default of the two notice flags, chosen in
-	 * build_replay_response_data() whenever `redacted_fields_omitted` is falsy.
-	 * Applies to GET stashes too, not only POSTs. It tells the user the action
-	 * was not carried out and must be re-issued; no server-stashed request is
-	 * replayed (#322).
+	 * Query arg added to the landing URL for every consumed stash, GET or POST.
+	 * It tells the user the action was not carried out and must be re-issued; no
+	 * server-stashed request is replayed (#322).
+	 *
+	 * The only notice arg emitted since #469. build_replay_response_data() used to
+	 * pick between this and REDACTED_REPLAY_QUERY_ARG on `redacted_fields_omitted`;
+	 * that flag does not mean what the choice assumed it meant — see the other
+	 * constant.
 	 *
 	 * @var string
 	 */
@@ -161,40 +181,104 @@ class Challenge {
 	}
 
 	/**
-	 * Render a notice telling the user to re-enter secret fields that were
-	 * redacted from the stash. (Nothing is replayed regardless — #322.)
+	 * Render the refusal notice for a landing URL carrying the legacy redacted arg.
+	 *
+	 * Named for the arg it answers, not for what it says: since #469 it renders the
+	 * same string as render_blocked_replay_notice(), because there was only ever one
+	 * outcome to describe. Nothing here is specific to secrets — see
+	 * REDACTED_REPLAY_QUERY_ARG for why that distinction was never sound.
+	 *
+	 * Kept only so a URL already in flight when a site upgrades still explains
+	 * itself; nothing emits the arg any more.
 	 *
 	 * @return void
 	 */
 	public function render_redacted_replay_notice(): void {
-		$notice = isset( $_GET[ self::REDACTED_REPLAY_QUERY_ARG ] ) && is_string( $_GET[ self::REDACTED_REPLAY_QUERY_ARG ] ) ? sanitize_text_field( wp_unslash( $_GET[ self::REDACTED_REPLAY_QUERY_ARG ] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Notice flag only; sanitized in helper.
-
-		if ( '1' !== $notice ) {
+		// The blocked renderer already covers a URL carrying both args; without
+		// this, an in-flight upgrade URL stacks two identical warnings.
+		if ( '1' === $this->notice_flag( self::BLOCKED_REPLAY_QUERY_ARG ) ) {
 			return;
 		}
 
-		echo '<div class="notice notice-warning is-dismissible"><p>'
-			. esc_html__( 'Reauthentication complete. For your security, password and secret fields were not replayed. Re-enter them to finish the change.', 'wp-sudo' )
+		if ( '1' !== $this->notice_flag( self::REDACTED_REPLAY_QUERY_ARG ) ) {
+			return;
+		}
+
+		$this->render_refusal_notice();
+	}
+
+	/**
+	 * Read a notice query arg as a flag.
+	 *
+	 * @param string $arg Query arg name.
+	 * @return string Sanitized value, or '' when absent.
+	 */
+	private function notice_flag( string $arg ): string {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Notice flag only; sanitized on the next line.
+		return isset( $_GET[ $arg ] ) && is_string( $_GET[ $arg ] ) ? sanitize_text_field( wp_unslash( $_GET[ $arg ] ) ) : '';
+	}
+
+	/**
+	 * Render the one post-challenge refusal notice.
+	 *
+	 * ONE string, because the two it replaced described a distinction that does
+	 * not exist. Since #322 nothing is replayed on any path, so what the user
+	 * needs to know is identical every time: the action did not happen, and doing
+	 * it again will now go straight through.
+	 *
+	 * What each clause is doing, so a later edit does not quietly reintroduce a
+	 * defect this fixes:
+	 *
+	 * - No "Reauthentication complete" opener. It is true only on the
+	 *   replay_stash() path where a credential was verified;
+	 *   complete_active_session_request() and render_resume_page() reach the same
+	 *   notice with `$credential_verified` false (#436 face 2).
+	 * - "Do it again", not "review the form". Every stash now takes the refusal
+	 *   path, so the most common arrival is a link-driven GET — plugin or theme
+	 *   activation — which never had a form (#463).
+	 * - "nothing was changed — including anything you had already typed in",
+	 *   rather than naming which fields were dropped. Naming them implied the
+	 *   rest were saved, and the flag that selected that wording does not track
+	 *   secrets at all (#469; see REDACTED_REPLAY_QUERY_ARG).
+	 * - The session clause is CONDITIONAL — "while your sudo session lasts" —
+	 *   deliberately, and must stay that way. A session is genuinely active at
+	 *   redirect time on all three paths (both non-credential callers are guarded
+	 *   by `Sudo_Session::is_active()` at their call sites, and the credential
+	 *   path has just granted one), but this renderer fires on `admin_notices`
+	 *   from a `$_GET` flag alone and checks nothing. A reload of the landing URL
+	 *   after the 1-15 minute session expires would re-render it, so any
+	 *   present-tense claim about session state ("your session is active now")
+	 *   would be false there. Asserting it would also mean re-opening a
+	 *   translated string to fix.
+	 *
+	 * `role="alert"` matches the in-page notices at render_page(). Without it the
+	 * dashboard landing announces nothing, and the announcement IS the message.
+	 *
+	 * @return void
+	 */
+	private function render_refusal_notice(): void {
+		echo '<div class="notice notice-warning is-dismissible" role="alert"><p>'
+			. esc_html__( 'For your security, WP Sudo never repeats your previous action, so it was not carried out and nothing was changed — including anything you had already typed in. Do it again to finish the change; while your sudo session lasts you will not be asked to reauthenticate.', 'wp-sudo' )
 			. '</p></div>';
 	}
 
 	/**
-	 * Render the default post-challenge notice: the action was not carried out
-	 * and must be re-issued. Shown for any consumed stash whose secrets were not
-	 * redacted (the redacted case has its own notice above).
+	 * Render the post-challenge notice: the action was not carried out and must be
+	 * re-issued.
+	 *
+	 * Shown for EVERY consumed stash since #469 — build_replay_response_data() adds
+	 * BLOCKED_REPLAY_QUERY_ARG unconditionally. There is no longer a redacted case
+	 * with a notice of its own; the other renderer answers the legacy arg with this
+	 * same string.
 	 *
 	 * @return void
 	 */
 	public function render_blocked_replay_notice(): void {
-		$notice = isset( $_GET[ self::BLOCKED_REPLAY_QUERY_ARG ] ) && is_string( $_GET[ self::BLOCKED_REPLAY_QUERY_ARG ] ) ? sanitize_text_field( wp_unslash( $_GET[ self::BLOCKED_REPLAY_QUERY_ARG ] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Notice flag only; sanitized in helper.
-
-		if ( '1' !== $notice ) {
+		if ( '1' !== $this->notice_flag( self::BLOCKED_REPLAY_QUERY_ARG ) ) {
 			return;
 		}
 
-		echo '<div class="notice notice-warning is-dismissible"><p>'
-			. esc_html__( 'Reauthentication complete. For your security, this request was not replayed automatically. Review the form and submit it again to finish the change.', 'wp-sudo' )
-			. '</p></div>';
+		$this->render_refusal_notice();
 	}
 
 	/**
@@ -1454,18 +1538,20 @@ class Challenge {
 		 * screen* — the admin page the request was aimed at, with its query (the
 		 * action + nonce, i.e. the effect) stripped and re-validated same-origin — so
 		 * re-performing it is a re-click or a re-submit that the now-active sudo
-		 * session passes straight through. Both carry the "review and submit again"
-		 * notice (the redacted variant when secret fields were dropped at stash time).
-		 * No per-rule taxonomy is involved. An interim #322 v2 design would have
+		 * session passes straight through. Both carry the same refusal notice — one
+		 * string on every path since #469, because there was never more than one
+		 * outcome to describe. No per-rule taxonomy is involved. An interim #322 v2 design would have
 		 * restored seamless auto-replay for the same-browser case behind an
 		 * origin-bound proof; 4.9.0 removed automatic replay outright instead, so
 		 * nothing here resumes an intercepted request.
 		 *
 		 * #429: POSTs previously landed on the dashboard, on the reasoning that their
 		 * re-submit needs the form re-filled regardless. That was wrong in the case it
-		 * matters most — the notice tells the user to re-enter redacted fields, and the
-		 * dashboard has no form to re-enter them into, so the instruction is
-		 * unactionable and the typed input is simply lost. v4.8.0 got the landing right
+		 * matters most — the notice tells the user to do the action again, and the
+		 * dashboard has no form to do it on, so the instruction is unactionable and
+		 * the typed input is simply lost. (The notice said "re-enter redacted fields"
+		 * when this was written; #469 replaced that wording, but the landing
+		 * requirement is about where the user ends up, not what the copy says.) v4.8.0 got the landing right
 		 * by using the stashed return_url; what was unsafe there was the SOURCE, not
 		 * the intent. return_url is derived from wp_get_referer(), so the request that
 		 * planted the stash chooses it, and honouring it re-opens the confused deputy
@@ -1526,10 +1612,12 @@ class Challenge {
 			$target = wp_validate_redirect( $screen, $neutral_url );
 		}
 
-		$notice_arg = ! empty( $stash['redacted_fields_omitted'] )
-			? self::REDACTED_REPLAY_QUERY_ARG
-			: self::BLOCKED_REPLAY_QUERY_ARG;
-		$target     = add_query_arg( $notice_arg, '1', $target );
+		// One arg, unconditionally. Both arms of the ternary this replaces returned
+		// `post_replay_blocked => true`, so the two notices described one outcome —
+		// and the flag that chose between them does not track secrets (#469). The
+		// response still reports `redacted_fields_omitted` below: it is accurate
+		// about what sanitize_params() did, and only the notice WORDING was wrong.
+		$target = add_query_arg( self::BLOCKED_REPLAY_QUERY_ARG, '1', $target );
 
 		return array(
 			'code'                    => 'success',

--- a/languages/wp-sudo.pot
+++ b/languages/wp-sudo.pot
@@ -600,12 +600,12 @@ msgid "Current settings do not match any preset. Selecting a preset will overwri
 msgstr ""
 
 #: includes/class-admin.php:1128
-#: includes/class-challenge.php:308
+#: includes/class-challenge.php:392
 msgid "An error occurred."
 msgstr ""
 
 #: includes/class-admin.php:1129
-#: includes/class-challenge.php:309
+#: includes/class-challenge.php:393
 msgid "A network error occurred. Please try again."
 msgstr ""
 
@@ -1203,224 +1203,220 @@ msgstr ""
 msgid "Application password not found."
 msgstr ""
 
-#: includes/class-challenge.php:177
-msgid "Reauthentication complete. For your security, password and secret fields were not replayed. Re-enter them to finish the change."
+#: includes/class-challenge.php:261
+msgid "For your security, WP Sudo never repeats your previous action, so it was not carried out and nothing was changed — including anything you had already typed in. Do it again to finish the change; while your sudo session lasts you will not be asked to reauthenticate."
 msgstr ""
 
-#: includes/class-challenge.php:196
-msgid "Reauthentication complete. For your security, this request was not replayed automatically. Review the form and submit it again to finish the change."
-msgstr ""
-
-#: includes/class-challenge.php:208
-#: includes/class-challenge.php:230
+#: includes/class-challenge.php:292
+#: includes/class-challenge.php:314
 msgid "Confirm Your Identity — Sudo"
 msgstr ""
 
-#: includes/class-challenge.php:307
+#: includes/class-challenge.php:391
 msgid "The server returned an unexpected response. Check the browser console for details."
 msgstr ""
 
-#: includes/class-challenge.php:310
+#: includes/class-challenge.php:394
 #: admin/js/wp-sudo-editor-reauth.js:238
 #: admin/js/wp-sudo-editor-reauth.js:400
 msgid "Authentication failed."
 msgstr ""
 
 #. translators: %s: countdown timer like "4:30"
-#: includes/class-challenge.php:312
+#: includes/class-challenge.php:396
 #, php-format
 msgid "Too many failed attempts. Try again in %s."
 msgstr ""
 
 #. translators: %s: countdown timer like "0:05"
-#: includes/class-challenge.php:314
+#: includes/class-challenge.php:398
 #, php-format
 msgid "Please wait %s before trying again."
 msgstr ""
 
 #. translators: %s: countdown timer like "9:30"
-#: includes/class-challenge.php:316
+#: includes/class-challenge.php:400
 #, php-format
 msgid "Time remaining: %s"
 msgstr ""
 
 #. translators: %s: countdown timer like "0:45"
-#: includes/class-challenge.php:318
+#: includes/class-challenge.php:402
 #, php-format
 msgid "⚠ Time remaining: %s"
 msgstr ""
 
-#: includes/class-challenge.php:319
+#: includes/class-challenge.php:403
 msgid "Your authentication session has expired."
 msgstr ""
 
-#: includes/class-challenge.php:320
+#: includes/class-challenge.php:404
 msgid "Your session may have expired."
 msgstr ""
 
-#: includes/class-challenge.php:321
+#: includes/class-challenge.php:405
 msgid "Start over"
 msgstr ""
 
-#: includes/class-challenge.php:322
+#: includes/class-challenge.php:406
 msgid "Password confirmed. Two-factor authentication required."
 msgstr ""
 
-#: includes/class-challenge.php:326
+#: includes/class-challenge.php:410
 msgid "Returning you to your page…"
 msgstr ""
 
-#: includes/class-challenge.php:327
+#: includes/class-challenge.php:411
 msgid "Leaving challenge page."
 msgstr ""
 
-#: includes/class-challenge.php:328
+#: includes/class-challenge.php:412
 msgid "Lockout expired. You may try again."
 msgstr ""
 
-#: includes/class-challenge.php:343
+#: includes/class-challenge.php:427
 msgid "You must be logged in."
 msgstr ""
 
-#: includes/class-challenge.php:362
+#: includes/class-challenge.php:446
 msgid "Activate sudo session"
 msgstr ""
 
-#: includes/class-challenge.php:367
+#: includes/class-challenge.php:451
 msgid "Invalid or expired challenge. Please try again."
 msgstr ""
 
-#: includes/class-challenge.php:370
+#: includes/class-challenge.php:454
 msgid "this action"
 msgstr ""
 
-#: includes/class-challenge.php:390
+#: includes/class-challenge.php:474
 msgid "Confirm Your Identity"
 msgstr ""
 
 #. translators: %s: action label (e.g. "Activate plugin")
-#: includes/class-challenge.php:396
+#: includes/class-challenge.php:480
 #, php-format
 msgid "To continue: %s — please enter your password."
 msgstr ""
 
 #. translators: %s: the concrete target of the action (e.g. a plugin file or user login)
-#: includes/class-challenge.php:406
+#: includes/class-challenge.php:490
 #, php-format
 msgid "Target: %s"
 msgstr ""
 
-#: includes/class-challenge.php:414
+#: includes/class-challenge.php:498
 msgid "Respect the privacy of others."
 msgstr ""
 
-#: includes/class-challenge.php:415
+#: includes/class-challenge.php:499
 msgid "Think before you type."
 msgstr ""
 
-#: includes/class-challenge.php:416
+#: includes/class-challenge.php:500
 msgid "With great power comes great responsibility."
 msgstr ""
 
-#: includes/class-challenge.php:423
+#: includes/class-challenge.php:507
 msgid "Too many failed attempts. The form is temporarily disabled. Please wait and try again."
 msgstr ""
 
 #. translators: %d: seconds remaining
-#: includes/class-challenge.php:432
+#: includes/class-challenge.php:516
 #, php-format
 msgid "Please wait %d seconds before trying again."
 msgstr ""
 
-#: includes/class-challenge.php:447
+#: includes/class-challenge.php:531
 #: admin/js/wp-sudo-editor-reauth.js:608
 msgid "Password"
 msgstr ""
 
-#: includes/class-challenge.php:454
-#: includes/class-challenge.php:483
+#: includes/class-challenge.php:538
+#: includes/class-challenge.php:567
 msgid "Confirm & Continue"
 msgstr ""
 
-#: includes/class-challenge.php:457
-#: includes/class-challenge.php:486
-#: includes/class-challenge.php:1060
+#: includes/class-challenge.php:541
+#: includes/class-challenge.php:570
+#: includes/class-challenge.php:1144
 #: admin/js/wp-sudo-editor-reauth.js:557
 msgid "Cancel"
 msgstr ""
 
-#: includes/class-challenge.php:466
+#: includes/class-challenge.php:550
 msgid "Two-Factor Authentication"
 msgstr ""
 
-#: includes/class-challenge.php:496
+#: includes/class-challenge.php:580
 msgid "Authenticating…"
 msgstr ""
 
-#: includes/class-challenge.php:619
-#: includes/class-challenge.php:717
-#: includes/class-challenge.php:817
+#: includes/class-challenge.php:703
+#: includes/class-challenge.php:801
+#: includes/class-challenge.php:901
 msgid "Invalid request."
 msgstr ""
 
-#: includes/class-challenge.php:625
-#: includes/class-challenge.php:832
+#: includes/class-challenge.php:709
+#: includes/class-challenge.php:916
 msgid "Your authentication session has expired. Please start over."
 msgstr ""
 
-#: includes/class-challenge.php:655
+#: includes/class-challenge.php:739
 msgid "Too many code requests. Please use your current code or wait."
 msgstr ""
 
-#: includes/class-challenge.php:695
+#: includes/class-challenge.php:779
 msgid "Not logged in."
 msgstr ""
 
-#: includes/class-challenge.php:732
+#: includes/class-challenge.php:816
 msgid "Your challenge session has expired. Please try again."
 msgstr ""
 
 #. translators: %d: seconds remaining
-#: includes/class-challenge.php:772
-#: includes/class-challenge.php:859
-#: includes/class-challenge.php:879
-#: includes/class-challenge.php:935
+#: includes/class-challenge.php:856
+#: includes/class-challenge.php:943
+#: includes/class-challenge.php:963
+#: includes/class-challenge.php:1019
 #, php-format
 msgid "Too many failed attempts. Please wait %d seconds."
 msgstr ""
 
-#: includes/class-challenge.php:784
+#: includes/class-challenge.php:868
 msgid "You are not allowed to perform this action."
 msgstr ""
 
-#: includes/class-challenge.php:790
-#: includes/class-challenge.php:799
+#: includes/class-challenge.php:874
+#: includes/class-challenge.php:883
 msgid "Incorrect password. Please try again."
 msgstr ""
 
 #. translators: %d: seconds remaining
-#: includes/class-challenge.php:843
+#: includes/class-challenge.php:927
 #, php-format
 msgid "Too many attempts. Please wait %d seconds."
 msgstr ""
 
-#: includes/class-challenge.php:901
+#: includes/class-challenge.php:985
 msgid "Too many resend attempts. Please try your current code or wait."
 msgstr ""
 
-#: includes/class-challenge.php:946
+#: includes/class-challenge.php:1030
 msgid "Invalid authentication code. Please try again."
 msgstr ""
 
-#: includes/class-challenge.php:1050
+#: includes/class-challenge.php:1134
 msgid "Session already confirmed"
 msgstr ""
 
-#: includes/class-challenge.php:1053
+#: includes/class-challenge.php:1137
 msgid "Your sudo session is already active. Continuing…"
 msgstr ""
 
-#: includes/class-challenge.php:1057
+#: includes/class-challenge.php:1141
 msgid "Continue"
 msgstr ""
 

--- a/tests/MANUAL-TESTING.md
+++ b/tests/MANUAL-TESTING.md
@@ -325,10 +325,19 @@ form yourself — automatic replay was removed outright in 4.9.0 (#322).
 4. **Expected:** Redirected to the challenge page. Action label shows
    "Change password."
 5. Authenticate.
-6. **Expected:** Redirected back to the profile page with a warning that
-   password and secret fields were not replayed. Re-enter the new password
+6. **Expected:** Redirected back to the profile page with a warning that the
+   action was not carried out and nothing was changed. Re-enter the new password
    while the sudo session is active and click **Update Profile**.
-7. **Expected:** Profile is updated (password changed).
+
+   The notice must **not** say that "password and secret fields were not
+   replayed". `user.change_password` uses `stash_no_replay()`, so
+   `redacted_fields_omitted` is false and the redacted variant never fired here
+   even before #469 collapsed the two into one string. An earlier revision of
+   this step asserted the opposite and would have passed only by the tester
+   reading what they expected to see.
+7. **Expected:** Profile is updated (password changed). Nothing entered on the
+   first attempt was saved — confirm any other field you changed alongside the
+   password (display name, biography) also reverted.
 8. Verify: changing **only bio, email address, or display name** (with
    no password field filled in) does **not** trigger a challenge.
 
@@ -342,10 +351,20 @@ form yourself — automatic replay was removed outright in 4.9.0 (#322).
 4. **Expected:** Redirected to the challenge page. Action label shows
    "Change password."
 5. Authenticate.
-6. **Expected:** Redirected back to the edit-user page with a warning that
-   password and secret fields were not replayed. Re-enter the new password
-   while the sudo session is active and click **Update User**.
-7. **Expected:** User's password is updated.
+6. **Expected:** Redirected to the **dashboard** — not back to the edit-user
+   page — with a warning that the action was not carried out and nothing was
+   changed.
+
+   `user-edit.php` is in `Challenge::HANDLER_ENDPOINTS`, because on a bare GET it
+   dies rather than rendering the form (`GB-USER-EDIT-DIES` in
+   `docs/upstream-sources.md`): returning there would cost the user the
+   explanation as well as their input. So the
+   fail-closed landing is the neutral page. An earlier revision of this step
+   expected a return to the edit-user screen, which the endpoint list has
+   forbidden since #429.
+7. Navigate back to **Users > Edit** for that user, set the new password again
+   while the sudo session is active, and click **Update User**.
+8. **Expected:** User's password is updated.
 
 ---
 
@@ -1449,8 +1468,11 @@ curl -sk -u "YOUR_USERNAME:YOUR_APP_PASS" \
 4. **Expected:** Redirected to the challenge page. Action label shows
    "Change password."
 5. Authenticate.
-6. **Expected:** Password is changed. No challenge fires for a plain
-   profile update (bio, email) in the same session.
+6. **Expected:** The password is **not** changed by authenticating — nothing is
+   replayed (#322). You land with the refusal notice, set the password again in
+   the now-active session, and *that* attempt succeeds.
+7. **Expected:** No challenge fires for a plain profile update (bio, email) in
+   the same session.
 
 ### 17.3 Change Password Gated (REST API)
 

--- a/tests/Unit/ChallengeTest.php
+++ b/tests/Unit/ChallengeTest.php
@@ -1876,7 +1876,13 @@ class ChallengeTest extends TestCase
 		// #322: redirect is a neutral admin URL, NOT the attacker-controllable return_url.
 		$this->assertStringNotContainsString('profile.php', $data['redirect']);
 		$this->assertStringContainsString('/wp-admin/', $data['redirect']);
-		$this->assertStringContainsString('wp_sudo_redacted_replay=1', $data['redirect']);
+		// #469: one notice arg now, whatever the stash recorded. The redacted variant
+		// claimed secrets were the reason and implied the rest of the request landed;
+		// both were false, and the flag it keyed on does not track secrets anyway.
+		$this->assertStringContainsString('wp_sudo_blocked_replay=1', $data['redirect']);
+		$this->assertStringNotContainsString('wp_sudo_redacted_replay=1', $data['redirect']);
+		// The response field is retained and still true: it accurately reports what
+		// sanitize_params() did. Only the notice wording drawn from it was wrong.
 		$this->assertTrue($data['redacted_fields_omitted']);
 		$this->assertArrayNotHasKey('replay', $data);
 		$this->assertArrayNotHasKey('post_data', $data);
@@ -2033,11 +2039,11 @@ class ChallengeTest extends TestCase
 	 * #429: a refused POST must land on its ORIGINATING SCREEN, not the dashboard.
 	 *
 	 * This is a regression guard, not a preference. v4.8.0 redirected a refused POST
-	 * to the stashed return_url — the form — so the "re-enter them" notice named
-	 * something the user could actually act on. #322 v1 removed that (return_url is
-	 * referer-derived and therefore requester-chosen, so redirecting to it re-opened
-	 * the confused deputy) and landed POSTs on the dashboard instead, where the
-	 * notice instructs the user to re-enter fields that are nowhere on screen.
+	 * to the stashed return_url — the form — so the notice named something the user
+	 * could actually act on. #322 v1 removed that (return_url is referer-derived and
+	 * therefore requester-chosen, so redirecting to it re-opened the confused deputy)
+	 * and landed POSTs on the dashboard instead, where the notice tells the user to
+	 * do again an action whose form is nowhere on screen.
 	 *
 	 * The fix is the treatment the GET path already had: derive the screen from
 	 * $stash['url'], which is the URL the gate intercepted rather than a value the
@@ -2078,12 +2084,15 @@ class ChallengeTest extends TestCase
 			$data['redirect'],
 			'A refused POST must return the user to the screen the request came from.'
 		);
-		// The notice tells the user to re-enter redacted fields; the dashboard has no
-		// form to re-enter them into, which is the whole defect.
+		// The landing must be the originating screen, not the dashboard. #469 removed
+		// the "re-enter them" wording this once guarded against, but the landing
+		// requirement is independent of the copy and outlives it: user-new.php is the
+		// one screen where the redaction flag can actually be raised by a builtin
+		// rule, so it is exactly where a dashboard landing would strand the user.
 		$this->assertNotSame(
-			'https://example.com/wp-admin/?' . \WP_Sudo\Challenge::REDACTED_REPLAY_QUERY_ARG . '=1',
+			'https://example.com/wp-admin/?' . \WP_Sudo\Challenge::BLOCKED_REPLAY_QUERY_ARG . '=1',
 			$data['redirect'],
-			'Landing on the dashboard leaves the "re-enter them" notice unactionable.'
+			'A refused user.create POST must not land on the dashboard.'
 		);
 	}
 
@@ -3153,7 +3162,9 @@ class ChallengeTest extends TestCase
 		$data = $this->invokeReplay('redacted-key', true);
 
 		$this->assertArrayNotHasKey('replay', $data, 'Redacted stash must never replay (secrets are missing).');
-		$this->assertStringContainsString('wp_sudo_redacted_replay=1', $data['redirect']);
+		// #469: the arg no longer varies with the redaction flag — see
+		// test_redacted_secret_stash_redirects_instead_of_post_replay.
+		$this->assertStringContainsString('wp_sudo_blocked_replay=1', $data['redirect']);
 
 		unset($_COOKIE[\WP_Sudo\Request_Stash::BINDING_COOKIE]);
 	}
@@ -3560,5 +3571,194 @@ class ChallengeTest extends TestCase
 		$this->assertStringNotContainsString('wp-sudo-challenge-password-form', $output);
 
 		unset($_GET['return_url'], $_COOKIE[\WP_Sudo\Sudo_Session::TOKEN_COOKIE]);
+	}
+
+	// -----------------------------------------------------------------
+	// Post-challenge notice bodies (#463, #469, #436 face 2)
+	//
+	// Before this group, ZERO tests asserted either notice's text — only the
+	// query arg in the redirect URL. That gap is why three separate wording
+	// defects survived review: the copy is the one part of the refusal the user
+	// actually reads, and nothing held it to the truth.
+	// -----------------------------------------------------------------
+
+	/**
+	 * Stub the translation and sanitization helpers the notice renderers use.
+	 */
+	private function stub_notice_helpers(): void
+	{
+		Functions\when('esc_html__')->returnArg();
+		Functions\when('sanitize_text_field')->returnArg();
+		Functions\when('wp_unslash')->returnArg();
+	}
+
+	/**
+	 * Capture a notice renderer's output.
+	 */
+	private function capture_notice(string $method): string
+	{
+		ob_start();
+		$this->challenge->{$method}();
+
+		return (string) ob_get_clean();
+	}
+
+	/**
+	 * Test the notice does not tell a link-driven GET action to review a form.
+	 *
+	 * #463: since #322 every stash takes the refusal path, so plugin and theme
+	 * activation — reached by clicking a link, carrying no form at all — lands on
+	 * its list screen and is told to "review the form and submit it again". That
+	 * is now the most common path, not an edge case.
+	 */
+	public function test_blocked_replay_notice_does_not_reference_a_form(): void
+	{
+		$this->stub_notice_helpers();
+		$_GET[\WP_Sudo\Challenge::BLOCKED_REPLAY_QUERY_ARG] = '1';
+
+		$output = $this->capture_notice('render_blocked_replay_notice');
+
+		$this->assertNotSame('', $output, 'The blocked-replay arg must render a notice.');
+		$this->assertStringNotContainsString(
+			'Review the form',
+			$output,
+			'A link-driven GET action has no form to review (#463).'
+		);
+
+		unset($_GET[\WP_Sudo\Challenge::BLOCKED_REPLAY_QUERY_ARG]);
+	}
+
+	/**
+	 * Test the notice does not open by claiming a reauthentication just happened.
+	 *
+	 * "Reauthentication complete" is true only on the replay_stash() path where a
+	 * credential was verified. complete_active_session_request() and
+	 * render_resume_page() both reach the same notice with $credential_verified
+	 * false — the user already held a session and presented nothing on that
+	 * request. The opener is false on two of the three paths.
+	 */
+	public function test_blocked_replay_notice_does_not_claim_reauthentication_occurred(): void
+	{
+		$this->stub_notice_helpers();
+		$_GET[\WP_Sudo\Challenge::BLOCKED_REPLAY_QUERY_ARG] = '1';
+
+		$output = $this->capture_notice('render_blocked_replay_notice');
+
+		$this->assertStringNotContainsString(
+			'Reauthentication complete',
+			$output,
+			'False on complete_active_session_request() and render_resume_page().'
+		);
+
+		unset($_GET[\WP_Sudo\Challenge::BLOCKED_REPLAY_QUERY_ARG]);
+	}
+
+	/**
+	 * Test the notice states that nothing was carried out.
+	 *
+	 * The load-bearing fact for both #463 and #469: the whole request was
+	 * discarded. Any wording that leaves the user believing part of it landed is
+	 * the defect, whichever arg brought them here.
+	 */
+	public function test_blocked_replay_notice_states_nothing_was_changed(): void
+	{
+		$this->stub_notice_helpers();
+		$_GET[\WP_Sudo\Challenge::BLOCKED_REPLAY_QUERY_ARG] = '1';
+
+		$output = $this->capture_notice('render_blocked_replay_notice');
+
+		$this->assertStringContainsString('nothing was changed', $output);
+		$this->assertStringContainsString('do it again', strtolower($output));
+
+		unset($_GET[\WP_Sudo\Challenge::BLOCKED_REPLAY_QUERY_ARG]);
+	}
+
+	/**
+	 * Test the redacted arg renders the same body as the blocked arg.
+	 *
+	 * #469 / #436 face 2: the redacted/blocked axis is unsound as a description
+	 * of secrets. `redacted_fields_omitted` is set only inside
+	 * Request_Stash::sanitize_params(), which build_stashed_post_params() returns
+	 * before whenever post_mode is `none` — so among builtin rules only
+	 * user.create can raise it, while every credential-carrying rule
+	 * (user.change_password, user.change_email, user.promote_profile) uses
+	 * stash_no_replay() and gets the OTHER notice. A POST that definitely carried
+	 * a password produced the message that did not mention passwords, and naming
+	 * which fields "were not replayed" implied the rest were.
+	 *
+	 * One string, true on every path, is the fix. The arg is kept only so a URL
+	 * already in flight across an upgrade still explains itself.
+	 */
+	public function test_redacted_replay_arg_renders_the_same_body_as_blocked(): void
+	{
+		$this->stub_notice_helpers();
+
+		$_GET[\WP_Sudo\Challenge::BLOCKED_REPLAY_QUERY_ARG] = '1';
+		$blocked = $this->capture_notice('render_blocked_replay_notice');
+		unset($_GET[\WP_Sudo\Challenge::BLOCKED_REPLAY_QUERY_ARG]);
+
+		$_GET[\WP_Sudo\Challenge::REDACTED_REPLAY_QUERY_ARG] = '1';
+		$redacted = $this->capture_notice('render_redacted_replay_notice');
+		unset($_GET[\WP_Sudo\Challenge::REDACTED_REPLAY_QUERY_ARG]);
+
+		$this->assertNotSame('', $redacted, 'The legacy arg must still explain itself.');
+		$this->assertSame(
+			$blocked,
+			$redacted,
+			'One honest string on every path — the axis described secrets wrongly.'
+		);
+		$this->assertStringNotContainsString(
+			'were not replayed',
+			$redacted,
+			'Naming which fields were not replayed implies the others were (#469).'
+		);
+	}
+
+	/**
+	 * Test only one notice renders when both args are present.
+	 *
+	 * Both renderers are hooked to admin_notices, and a URL surviving an upgrade
+	 * can carry both args. Two identical warnings stacked on one screen is its
+	 * own defect.
+	 */
+	public function test_only_one_notice_renders_when_both_args_are_present(): void
+	{
+		$this->stub_notice_helpers();
+		$_GET[\WP_Sudo\Challenge::BLOCKED_REPLAY_QUERY_ARG]  = '1';
+		$_GET[\WP_Sudo\Challenge::REDACTED_REPLAY_QUERY_ARG] = '1';
+
+		$output = $this->capture_notice('render_blocked_replay_notice')
+			. $this->capture_notice('render_redacted_replay_notice');
+
+		$this->assertSame(
+			1,
+			substr_count($output, 'notice-warning'),
+			'Exactly one notice must render when a URL carries both args.'
+		);
+
+		unset(
+			$_GET[\WP_Sudo\Challenge::BLOCKED_REPLAY_QUERY_ARG],
+			$_GET[\WP_Sudo\Challenge::REDACTED_REPLAY_QUERY_ARG]
+		);
+	}
+
+	/**
+	 * Test the notice is announced to assistive technology.
+	 *
+	 * The in-page challenge notices at render_page() carry role="alert"; these do
+	 * not. On the dashboard landing a screen-reader user gets no announcement
+	 * that the action they just took was discarded — which is the entire content
+	 * of the message.
+	 */
+	public function test_blocked_replay_notice_is_announced_to_assistive_technology(): void
+	{
+		$this->stub_notice_helpers();
+		$_GET[\WP_Sudo\Challenge::BLOCKED_REPLAY_QUERY_ARG] = '1';
+
+		$output = $this->capture_notice('render_blocked_replay_notice');
+
+		$this->assertStringContainsString('role="alert"', $output);
+
+		unset($_GET[\WP_Sudo\Challenge::BLOCKED_REPLAY_QUERY_ARG]);
 	}
 }


### PR DESCRIPTION
Closes #463. Closes #469. Partially addresses #436 (face 2 only).

The post-reauthentication landing notice is the sentence most users see after a gated action. Every clause of it was wrong somewhere, and nothing tested it — **zero tests asserted either notice body before this PR**, only the query arg in the redirect URL. That gap is why three separate defects survived review.

## What was wrong

| Claim in the old copy | Reality |
|---|---|
| "Reauthentication complete." | True only on the `replay_stash()` path. `complete_active_session_request()` and `render_resume_page()` reach the same notice with `$credential_verified` false — the user already held a session and presented nothing. **False on 2 of 3 paths.** |
| "Review the form and submit it again." | Since 4.9.0 every stash takes the refusal path, so the most common arrival is a link-driven GET — plugin or theme activation — with no form at all (#463). |
| "Password and secret fields were not replayed." | Naming which fields were dropped implies the rest were kept. Nothing is replayed. A user submitting a profile form could reasonably conclude their email and display name saved. They did not (#469). |

## Why one string instead of two reworded ones

The redacted/blocked axis is not merely unhelpful — it is **unsound as a description of secrets**.

It is a **one-way signal**. `Request_Stash::sanitize_params()` sets `redacted_fields_omitted` only when it actually encounters and drops a sensitive key — so *raised* means a secret was present. The converse does not hold: `build_stashed_post_params()` returns before `sanitize_params()` whenever `post_mode` is `none` or the allowlist is empty, so *not-raised* means nothing at all.

`stash_no_replay()` returns `post_mode => none`, and the three rules matching profile-form POSTs that can carry `pass1`/`pass2` — `user.change_password`, `user.change_email`, `user.promote_profile` — all use it, so they got the *other* notice. Walking the builtin rules, exactly one can raise the flag: **`user.create`**, whose `stash_allowlist()` names `pass1`, `pass2` and `pass1-text`.

The POST that definitely carried a password produced the message that did not mention passwords.

## The change

- One string on every path, carrying the reassuring half #463 asked for.
- `Challenge::REDACTED_REPLAY_QUERY_ARG` **kept and documented inert** per `VERSIONING.md`'s security-forced-inertness clause — it is public API, and a URL in flight when a site upgrades must still explain itself. No longer emitted; arriving with it renders the same string; a URL carrying both args renders one notice, not two.
- `build_replay_response_data()` emits `BLOCKED_REPLAY_QUERY_ARG` unconditionally. The response still reports `redacted_fields_omitted` — it is accurate about what `sanitize_params()` did, and only the wording drawn from it was wrong.
- `role="alert"`, matching the in-page challenge notices. Without it a screen-reader user got no announcement that their action had been discarded — which is the entire content of the message.

The session clause is deliberately **conditional** ("while your sudo session lasts"). A session is genuinely active at redirect time on all three paths, but the renderer fires on `admin_notices` from a `$_GET` flag and checks nothing, so a reload after the 1–15 minute session expires would re-render it. Gating the renderer on `Sudo_Session::is_active()` was rejected: it would suppress the explanation exactly when the user most needs it.

## Tests

Six new cases assert the notice text directly — no form reference, no reauthentication claim, states nothing was changed, both args render identical bodies, exactly one notice when both are present, and `role="alert"`.

Three existing cases that asserted the redacted/blocked *axis* were rewritten rather than deleted, each keeping the property it existed to guard (`assertArrayNotHasKey('replay', …)`, and the originating-screen landing for a refused `user.create` POST).

`tests/MANUAL-TESTING.md` §2.15, §2.16 and §17.2 encoded the false model and are corrected: §2.15 expected the redacted notice after a `user.change_password`, which never fired; §2.16 expected a return to `user-edit.php`, which `HANDLER_ENDPOINTS` has forbidden since #429; §17.2 expected the password to change on authentication, which no replay means it does not.

## Deliberately out of scope

Per the design review recorded on [#436](https://github.com/dknauss/Sudo/issues/436#issuecomment-5111906607), which was run before any code and which changed the shape of this work:

- **Face 1** (preserving typed input) — the obvious server-side prefill reintroduces the confused deputy #322 removed. The safe version is a client-side `sessionStorage` snapshot, never capturing password inputs. New feature, own surface.
- **Face 3** (naming every matched rule) — `Gate::match_request()` is first-match-wins; changing it touches `Request_Stash::save()`'s signature, the stash schema, and what "informed confirmation" names. That last part is a security property, not a display detail. **This is where the risk is.**
- **Face 4** (gating before the form) — dissolves the class rather than improving recovery, and the plugin already does it for plugin activation via `filter_plugin_action_links()`. The most valuable of the three.

`readme.txt`'s known-limitation entry still lists all four faces as unfixed. It sits under the shipped `= 4.9.1 =` heading, so it is left alone — recording the fixes belongs in the next release's section at version-bump time, not in a rewrite of a released one.

## Verification

`composer test:unit` 1307 tests / 3904 assertions · `composer lint` clean · `composer analyse` PHPStan + Psalm no errors · `composer verify:metrics` in sync (re-measured, not merged) · `composer verify:sources` 67 citations present · `bin/make-pot.sh` idempotent.

## Known, non-blocking

Carried from the third review round, for whoever next opens these files:

- The `REDACTED_REPLAY_QUERY_ARG` docblock and the CHANGELOG describe `user.change_password`, `user.change_email` and `user.promote_profile` as "the three rules whose whole purpose is changing a credential". `user.promote_profile`'s label is "Change user role" and its callback gates on a role change — its purpose is a role, not a credential. The accurate framing is about the *requests*: all three match profile-form POSTs that can carry `pass1`/`pass2`. Nothing rests on the characterization — the mechanism beside it (`stash_no_replay()` never reaches `sanitize_params()`, so the flag stays false) is stated correctly and independently.
- "Raised means a secret was present" is shorthand. `is_sensitive_key()` matches on key *name*, so an empty `pass1` submitted with the form also raises the flag. This is the shorthand the codebase already uses in `build_stashed_post_params()`'s and `sanitize_params()`'s own `@param` lines, and the load-bearing direction of the claim is exact.
