### PR TITLE
ci: fail when the committed SBOM drifts

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -312,6 +312,12 @@ jobs:
       - name: Install Composer dependencies
         run: composer install --no-interaction --prefer-dist
 
+      - name: Verify committed SBOM drift
+        run: composer verify:sbom
+
+      - name: Verify SBOM checker regression tests
+        run: composer test:sbom
+
       - name: Verify metrics file drift
         run: composer verify:metrics
 

--- a/bin/verify-sbom.sh
+++ b/bin/verify-sbom.sh
@@ -24,16 +24,26 @@ fi
 		--output-format=JSON \
 		--spec-version=1.6 \
 		--output-reproducible \
+		--mc-version=dev-main \
 	>/dev/null
 )
 
-# The generator records the checkout's current Git commit on the root component.
-# A committed SBOM necessarily contains the parent commit, so that pair can never
-# match after the SBOM commit itself. Normalize only those two root-component
-# properties; dependency references remain byte-for-byte verified.
-normalize_root_reference() {
+# The generator records the checkout's Git commit on the root component and the
+# Composer executable version in its tool metadata. Neither describes a locked
+# dependency: the commit necessarily changes when the SBOM is committed, PR CI
+# checks out a synthetic merge commit, and the runner's Composer patch can move.
+# Normalize only those environmental fields. Dependency components and references
+# remain byte-for-byte verified.
+normalize_environment_metadata() {
 	php -r '
 		$data = json_decode( file_get_contents( $argv[1] ), true, 512, JSON_THROW_ON_ERROR );
+		foreach ( array_keys( $data["metadata"]["tools"] ?? array() ) as $index ) {
+			$tool = &$data["metadata"]["tools"][ $index ];
+			if ( ( $tool["name"] ?? "" ) === "composer" && ! isset( $tool["vendor"] ) ) {
+				$tool["version"] = "<normalized-composer-version>";
+			}
+			unset( $tool );
+		}
 		foreach ( array_keys( $data["metadata"]["component"]["properties"] ?? array() ) as $index ) {
 			$property = &$data["metadata"]["component"]["properties"][ $index ];
 			if ( in_array( $property["name"] ?? "", array( "cdx:composer:package:distReference", "cdx:composer:package:sourceReference" ), true ) ) {
@@ -45,15 +55,15 @@ normalize_root_reference() {
 	' "${1}" "${2}"
 }
 
-normalize_root_reference "${SBOM_FILE}" "${NORMALIZED_COMMITTED}"
-normalize_root_reference "${TMP_SBOM}" "${NORMALIZED_GENERATED}"
+normalize_environment_metadata "${SBOM_FILE}" "${NORMALIZED_COMMITTED}"
+normalize_environment_metadata "${TMP_SBOM}" "${NORMALIZED_GENERATED}"
 
 if ! diff -u "${NORMALIZED_COMMITTED}" "${NORMALIZED_GENERATED}" >/dev/null; then
 	cat >&2 <<'MSG'
 Error: .sbom/bom.json is stale.
 Run `composer sbom`, review the diff, and commit the updated SBOM.
 
-Diff (root Git references normalized):
+Diff (environment-derived metadata normalized):
 MSG
 	diff -u "${NORMALIZED_COMMITTED}" "${NORMALIZED_GENERATED}" >&2 || true
 	exit 1

--- a/bin/verify-sbom.sh
+++ b/bin/verify-sbom.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SBOM_FILE="${ROOT_DIR}/.sbom/bom.json"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+TMP_SBOM="${TMP_DIR}/bom.json"
+NORMALIZED_COMMITTED="${TMP_DIR}/committed.json"
+NORMALIZED_GENERATED="${TMP_DIR}/generated.json"
+
+if [[ ! -f "${SBOM_FILE}" ]]; then
+	cat >&2 <<'MSG'
+Error: .sbom/bom.json is missing.
+Run `composer sbom` and commit the generated SBOM.
+MSG
+	exit 1
+fi
+
+(
+	cd "${ROOT_DIR}"
+	composer CycloneDX:make-sbom \
+		--output-file="${TMP_SBOM}" \
+		--output-format=JSON \
+		--spec-version=1.6 \
+		--output-reproducible \
+	>/dev/null
+)
+
+# The generator records the checkout's current Git commit on the root component.
+# A committed SBOM necessarily contains the parent commit, so that pair can never
+# match after the SBOM commit itself. Normalize only those two root-component
+# properties; dependency references remain byte-for-byte verified.
+normalize_root_reference() {
+	php -r '
+		$data = json_decode( file_get_contents( $argv[1] ), true, 512, JSON_THROW_ON_ERROR );
+		foreach ( array_keys( $data["metadata"]["component"]["properties"] ?? array() ) as $index ) {
+			$property = &$data["metadata"]["component"]["properties"][ $index ];
+			if ( in_array( $property["name"] ?? "", array( "cdx:composer:package:distReference", "cdx:composer:package:sourceReference" ), true ) ) {
+				$property["value"] = "<normalized-root-git-reference>";
+			}
+			unset( $property );
+		}
+		file_put_contents( $argv[2], json_encode( $data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR ) . PHP_EOL );
+	' "${1}" "${2}"
+}
+
+normalize_root_reference "${SBOM_FILE}" "${NORMALIZED_COMMITTED}"
+normalize_root_reference "${TMP_SBOM}" "${NORMALIZED_GENERATED}"
+
+if ! diff -u "${NORMALIZED_COMMITTED}" "${NORMALIZED_GENERATED}" >/dev/null; then
+	cat >&2 <<'MSG'
+Error: .sbom/bom.json is stale.
+Run `composer sbom`, review the diff, and commit the updated SBOM.
+
+Diff (root Git references normalized):
+MSG
+	diff -u "${NORMALIZED_COMMITTED}" "${NORMALIZED_GENERATED}" >&2 || true
+	exit 1
+fi
+
+printf 'SBOM verified: .sbom/bom.json is in sync.\n'

--- a/bin/verify-sbom.sh
+++ b/bin/verify-sbom.sh
@@ -37,6 +37,15 @@ fi
 normalize_environment_metadata() {
 	php -r '
 		$data = json_decode( file_get_contents( $argv[1] ), true, 512, JSON_THROW_ON_ERROR );
+		$root_reference = $data["metadata"]["component"]["bom-ref"] ?? null;
+		if ( is_string( $root_reference ) ) {
+			$data["metadata"]["component"]["bom-ref"] = "<normalized-root-bom-reference>";
+			foreach ( array_keys( $data["dependencies"] ?? array() ) as $index ) {
+				if ( ( $data["dependencies"][ $index ]["ref"] ?? null ) === $root_reference ) {
+					$data["dependencies"][ $index ]["ref"] = "<normalized-root-bom-reference>";
+				}
+			}
+		}
 		foreach ( array_keys( $data["metadata"]["tools"] ?? array() ) as $index ) {
 			$tool = &$data["metadata"]["tools"][ $index ];
 			if ( ( $tool["name"] ?? "" ) === "composer" && ! isset( $tool["vendor"] ) ) {

--- a/composer.json
+++ b/composer.json
@@ -60,6 +60,6 @@
         "analyse:phpstan": "phpstan analyse --memory-limit=1G",
         "analyse:psalm": "psalm --config=psalm.xml.dist --threads=1 --no-progress --no-cache",
         "analyse:psalm:shepherd": "psalm --config=psalm.xml.dist --threads=1 --no-progress --no-cache --shepherd",
-        "sbom": "composer CycloneDX:make-sbom --output-file=.sbom/bom.json --output-format=JSON --spec-version=1.6 --output-reproducible"
+        "sbom": "composer CycloneDX:make-sbom --output-file=.sbom/bom.json --output-format=JSON --spec-version=1.6 --output-reproducible --mc-version=dev-main"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -46,9 +46,11 @@
         "test:poc": "phpunit -c poc/install-package-gate/phpunit.xml.dist",
         "test:integration": "bash bin/run-integration-tests.sh phpunit-integration.xml.dist",
         "test:coverage": "phpunit --configuration phpunit.xml.dist --coverage-clover coverage.xml --coverage-text",
+        "test:sbom": "bash tests/verify-sbom/run.sh",
         "test:sources": "bash tests/verify-sources/run.sh",
         "verify:metrics": "bash bin/verify-metrics.sh",
         "verify:i18n": "bash bin/verify-i18n.sh",
+        "verify:sbom": "bash bin/verify-sbom.sh",
         "verify:sources": "bash bin/verify-sources.sh",
         "i18n:make-pot": "bash bin/make-pot.sh",
         "analyse": [

--- a/tests/verify-sbom/run.sh
+++ b/tests/verify-sbom/run.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SBOM_FILE="${ROOT_DIR}/.sbom/bom.json"
+BACKUP_FILE="$(mktemp)"
+OUTPUT_FILE="$(mktemp)"
+trap 'cp "${BACKUP_FILE}" "${SBOM_FILE}"; rm -f "${BACKUP_FILE}" "${OUTPUT_FILE}"' EXIT
+
+cp "${SBOM_FILE}" "${BACKUP_FILE}"
+
+if ! "${ROOT_DIR}/bin/verify-sbom.sh" >"${OUTPUT_FILE}" 2>&1; then
+	printf 'FAIL: current SBOM should pass verification.\n' >&2
+	cat "${OUTPUT_FILE}" >&2
+	exit 1
+fi
+
+php -r '
+	$data = json_decode( file_get_contents( $argv[1] ), true, 512, JSON_THROW_ON_ERROR );
+	$data["components"][0]["version"] = "stale-test-version";
+	file_put_contents( $argv[1], json_encode( $data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR ) . PHP_EOL );
+' "${SBOM_FILE}"
+
+if "${ROOT_DIR}/bin/verify-sbom.sh" >"${OUTPUT_FILE}" 2>&1; then
+	printf 'FAIL: stale SBOM should fail verification.\n' >&2
+	exit 1
+fi
+
+if ! grep -q 'composer sbom' "${OUTPUT_FILE}"; then
+	printf 'FAIL: stale-SBOM error should name the regeneration command.\n' >&2
+	cat "${OUTPUT_FILE}" >&2
+	exit 1
+fi
+
+printf 'verify-sbom regression tests passed.\n'

--- a/tests/verify-sbom/run.sh
+++ b/tests/verify-sbom/run.sh
@@ -17,6 +17,26 @@ fi
 
 php -r '
 	$data = json_decode( file_get_contents( $argv[1] ), true, 512, JSON_THROW_ON_ERROR );
+	$data["metadata"]["tools"][0]["version"] = "different-composer-version";
+	foreach ( $data["metadata"]["component"]["properties"] as &$property ) {
+		if ( in_array( $property["name"], array( "cdx:composer:package:distReference", "cdx:composer:package:sourceReference" ), true ) ) {
+			$property["value"] = "different-checkout-reference";
+		}
+	}
+	unset( $property );
+	file_put_contents( $argv[1], json_encode( $data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR ) . PHP_EOL );
+' "${SBOM_FILE}"
+
+if ! "${ROOT_DIR}/bin/verify-sbom.sh" >"${OUTPUT_FILE}" 2>&1; then
+	printf 'FAIL: environment-only SBOM differences should be normalized.\n' >&2
+	cat "${OUTPUT_FILE}" >&2
+	exit 1
+fi
+
+cp "${BACKUP_FILE}" "${SBOM_FILE}"
+
+php -r '
+	$data = json_decode( file_get_contents( $argv[1] ), true, 512, JSON_THROW_ON_ERROR );
 	$data["components"][0]["version"] = "stale-test-version";
 	file_put_contents( $argv[1], json_encode( $data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR ) . PHP_EOL );
 ' "${SBOM_FILE}"

--- a/tests/verify-sbom/run.sh
+++ b/tests/verify-sbom/run.sh
@@ -18,6 +18,14 @@ fi
 php -r '
 	$data = json_decode( file_get_contents( $argv[1] ), true, 512, JSON_THROW_ON_ERROR );
 	$data["metadata"]["tools"][0]["version"] = "different-composer-version";
+	$root_reference = $data["metadata"]["component"]["bom-ref"];
+	$data["metadata"]["component"]["bom-ref"] = "different-root-bom-reference";
+	foreach ( $data["dependencies"] as &$dependency ) {
+		if ( $dependency["ref"] === $root_reference ) {
+			$dependency["ref"] = "different-root-bom-reference";
+		}
+	}
+	unset( $dependency );
 	foreach ( $data["metadata"]["component"]["properties"] as &$property ) {
 		if ( in_array( $property["name"], array( "cdx:composer:package:distReference", "cdx:composer:package:sourceReference" ), true ) ) {
 			$property["value"] = "different-checkout-reference";


### PR DESCRIPTION
Closes #520.

## Summary
- regenerate the CycloneDX SBOM into a temporary file and fail on dependency drift
- normalize only environment-derived root Git references and Composer tool-version metadata
- pin the generated main-component version so GitHub synthetic merge refs do not create false drift
- exercise clean, environment-only, and deliberately stale dependency cases
- run the verifier and its regression test in the required code-quality job

## Validation
- `composer test` — 1307 tests, 3904 assertions
- `composer lint`
- `composer analyse`
- `composer test:sbom`
- `composer verify:sbom`
- `composer verify:metrics`
- `composer audit --locked --no-interaction`