### PR TITLE
docs: guard auto-merge review ordering

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -469,9 +469,10 @@ behavior that the model cannot hold in working memory.
   Resolving the last thread can merge the PR immediately; a later push may only
   recreate a deleted, orphaned branch. If a finding is deferred instead of
   fixed, say so in the thread before resolving it.
-- After a PR merges, verify each file named by a review finding from the merged
-  commit (`git show origin/main:<path>` after fetching), not from the local
-  branch or the thread's resolved state.
+- After a PR merges, obtain its exact merge commit SHA and verify each file
+  named by a review finding from that commit (`git show <merge-sha>:<path>`),
+  not from a moving branch tip, the local branch, or the thread's resolved
+  state.
 - After a PR is merged, delete the remote branch and prune local tracking refs.
 - Before creating a branch, check whether an existing open PR already covers the
   same scope.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -465,6 +465,13 @@ behavior that the model cannot hold in working memory.
   `release/...`.
 - Keep each branch tied to one logical PR or task. Prefer follow-up branches over
   continually reusing a stale branch for unrelated work.
+- When auto-merge is armed, push every review fix before resolving its thread.
+  Resolving the last thread can merge the PR immediately; a later push may only
+  recreate a deleted, orphaned branch. If a finding is deferred instead of
+  fixed, say so in the thread before resolving it.
+- After a PR merges, verify each file named by a review finding from the merged
+  commit (`git show origin/main:<path>` after fetching), not from the local
+  branch or the thread's resolved state.
 - After a PR is merged, delete the remote branch and prune local tracking refs.
 - Before creating a branch, check whether an existing open PR already covers the
   same scope.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,9 +100,9 @@ Push review fixes before resolving their threads. Resolving the last thread can
 trigger auto-merge immediately, so resolving first can merge without the fix and
 leave a later push on an orphaned branch. State explicitly when a finding is
 being deferred rather than fixed. After merge, fetch and inspect the merged
-commit for every file named by a finding; a resolved thread does not prove its
-requested change landed. The canonical rule is in `AGENTS.md` under Branch
-Hygiene.
+commit by its exact merge SHA for every file named by a finding; a moving
+`origin/main` tip and a resolved thread do not prove the requested change
+landed. The canonical rule is in `AGENTS.md` under Branch Hygiene.
 
 ### User bypass (your own commits only)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,16 @@ directly. A commit is docs-only when no code files are staged — only `.md`,
 approval check automatically. Any commit touching `.php`, scripts, or other
 code still requires a fresh reviewer approval.
 
+### Review-thread resolution with auto-merge
+
+Push review fixes before resolving their threads. Resolving the last thread can
+trigger auto-merge immediately, so resolving first can merge without the fix and
+leave a later push on an orphaned branch. State explicitly when a finding is
+being deferred rather than fixed. After merge, fetch and inspect the merged
+commit for every file named by a finding; a resolved thread does not prove its
+requested change landed. The canonical rule is in `AGENTS.md` under Branch
+Hygiene.
+
 ### User bypass (your own commits only)
 
 For commits you write yourself (not AI-generated):


### PR DESCRIPTION
Closes #456.

Records the operational order that prevents auto-merge from landing before review fixes:

- push fixes before resolving their threads;
- state when a finding is deferred rather than fixed;
- verify files named by review findings from the fetched merged commit.

The canonical rule lives in `AGENTS.md`; `CLAUDE.md` puts the same guard at the point where Claude follows the reviewer workflow.

Validation: pre-commit docs-only validation passed; `git diff --cached --check` passed.