### PR TITLE
test: make suite determinism evidence fail closed

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -312,6 +312,9 @@ jobs:
       - name: Install Composer dependencies
         run: composer install --no-interaction --prefer-dist
 
+      - name: Verify suite-determinism harness
+        run: composer test:suite-determinism
+
       - name: Verify metrics file drift
         run: composer verify:metrics
 

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,8 @@ test-results/
 
 # claude-code-reviewer approval flag
 reviewer-approved
+
+# Scratch output from bin/suite-determinism.sh and the WP test-suite installer.
+# Previously ignored only via .git/info/exclude, which is machine-local — committed
+# tooling writes here, so the rule belongs in the tracked file.
+.tmp/

--- a/bin/suite-determinism.sh
+++ b/bin/suite-determinism.sh
@@ -25,6 +25,11 @@ ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || {
 cd "$ROOT" || exit 2
 ROOT="$(pwd -P)"
 
+if [ ! -d "$ROOT/vendor" ] || [ -L "$ROOT/vendor" ]; then
+	echo "vendor/ must be a real directory owned by this worktree; run composer install here" >&2
+	exit 2
+fi
+
 mkdir -p "$ROOT/.tmp" || {
 	echo "cannot create $ROOT/.tmp" >&2
 	exit 2
@@ -36,6 +41,11 @@ OUT="$(mktemp "$ROOT/.tmp/suite-determinism.jsonl.XXXXXX")" || {
 
 PHP_VERSION="$(php -r 'echo PHP_VERSION;' 2>/dev/null)" || {
 	echo "cannot resolve the PHP version" >&2
+	exit 2
+}
+
+SAMPLE_HEAD="$(git rev-parse HEAD 2>/dev/null)" || {
+	echo "cannot resolve the sample revision" >&2
 	exit 2
 }
 
@@ -90,7 +100,7 @@ for ((i = 1; i <= RUNS; i++)); do
 	head_after="$(git rev-parse HEAD 2>/dev/null || printf '<unresolvable>')"
 	read -r tracked_after untracked_after <<< "$(tree_state)"
 	revision_changed=0
-	if [ "$head_before" != "$head_after" ]; then
+	if [ "$head_before" != "$SAMPLE_HEAD" ] || [ "$head_after" != "$SAMPLE_HEAD" ]; then
 		revision_changed=1
 		revision_changes=$((revision_changes + 1))
 	fi
@@ -160,7 +170,7 @@ for ((i = 1; i <= RUNS; i++)); do
 			"failed"                 => $matches[1],
 			"diagnostic"             => $diagnostic,
 		);
-		echo json_encode( $record, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ), "\n";
+		echo json_encode( $record, JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ), "\n";
 	' >> "$OUT" || {
 		echo "cannot append a valid record to $OUT" >&2
 		rm -f "$raw_file"

--- a/bin/suite-determinism.sh
+++ b/bin/suite-determinism.sh
@@ -13,8 +13,11 @@
 set -uo pipefail
 
 RUNS="${1-50}"
-if ! [[ "$RUNS" =~ ^[1-9][0-9]*$ ]]; then
-	echo "usage: bash bin/suite-determinism.sh [positive integer]" >&2
+MAX_RUNS=10000
+if ! [[ "$RUNS" =~ ^[1-9][0-9]*$ ]] \
+	|| [ "${#RUNS}" -gt "${#MAX_RUNS}" ] \
+	|| { [ "${#RUNS}" -eq "${#MAX_RUNS}" ] && [[ "$RUNS" > "$MAX_RUNS" ]]; }; then
+	echo "usage: bash bin/suite-determinism.sh [integer from 1 to $MAX_RUNS]" >&2
 	exit 2
 fi
 
@@ -49,23 +52,80 @@ SAMPLE_HEAD="$(git rev-parse HEAD 2>/dev/null)" || {
 	exit 2
 }
 
-autoload_root() {
+autoload_path() {
 	php -d display_errors=stderr -r \
-		'require "tests/bootstrap.php"; $r = new ReflectionClass("WP_Sudo\Gate"); echo dirname(dirname((string) $r->getFileName()));' \
+		'require "tests/bootstrap.php"; $r = new ReflectionClass("WP_Sudo\Gate"); echo realpath((string) $r->getFileName());' \
 		2>/dev/null
 }
 
-# Prints two shell words: tracked-dirty untracked-dirty.
+# Prints three shell words: tracked-dirty untracked-dirty state-hash.
 tree_state() {
-	local entry tracked=0 untracked=0
-	while IFS= read -r -d '' entry; do
-		if [ "${entry:0:2}" = "??" ]; then
-			untracked=1
-		else
-			tracked=1
-		fi
-	done < <(git status --porcelain=v1 -z --untracked-files=all)
-	printf '%d %d\n' "$tracked" "$untracked"
+	local state_file index_file worktree_file
+	state_file="$(mktemp "${TMPDIR:-/tmp}/wp-sudo-tree-state.XXXXXX")" || return 1
+	index_file="$(mktemp "${TMPDIR:-/tmp}/wp-sudo-index-state.XXXXXX")" || {
+		rm -f "$state_file"
+		return 1
+	}
+	worktree_file="$(mktemp "${TMPDIR:-/tmp}/wp-sudo-worktree-state.XXXXXX")" || {
+		rm -f "$state_file" "$index_file"
+		return 1
+	}
+	if ! git status --porcelain=v1 -z --untracked-files=all > "$state_file"; then
+		rm -f "$state_file" "$index_file" "$worktree_file"
+		return 1
+	fi
+	if ! git diff --cached --binary --no-ext-diff --no-renames > "$index_file"; then
+		rm -f "$state_file" "$index_file" "$worktree_file"
+		return 1
+	fi
+	if ! git diff --binary --no-ext-diff --no-renames > "$worktree_file"; then
+		rm -f "$state_file" "$index_file" "$worktree_file"
+		return 1
+	fi
+	php -r '
+		$status = file_get_contents( $argv[1] );
+		$index = file_get_contents( $argv[2] );
+		$worktree = file_get_contents( $argv[3] );
+		if ( false === $status || false === $index || false === $worktree ) {
+			exit( 2 );
+		}
+		$entries = explode( "\0", $status );
+		$tracked = false;
+		$untracked = false;
+		$hash = hash_init( "sha256" );
+		hash_update( $hash, "index\0" . $index . "\0worktree\0" . $worktree );
+		foreach ( $entries as $entry ) {
+			if ( "" === $entry ) {
+				continue;
+			}
+			if ( preg_match( "#^\?\? \.tmp/suite-determinism\.(?:jsonl|raw)\.#", $entry ) ) {
+				continue;
+			}
+			hash_update( $hash, "\0status\0" . $entry );
+			if ( str_starts_with( $entry, "??" ) ) {
+				$untracked = true;
+				$path = $argv[4] . "/" . substr( $entry, 3 );
+				if ( is_link( $path ) ) {
+					$contents = readlink( $path );
+				} elseif ( is_file( $path ) ) {
+					$contents = file_get_contents( $path );
+				} else {
+					$stat = @lstat( $path );
+					$contents = false === $stat ? false : serialize( $stat );
+				}
+				if ( false === $contents ) {
+					exit( 2 );
+				}
+				hash_update( $hash, "\0untracked\0" . $contents );
+			} else {
+				$tracked = true;
+			}
+		}
+		printf( "%d %d %s\n", $tracked, $untracked, hash_final( $hash ) );
+	' "$state_file" "$index_file" "$worktree_file" "$ROOT"
+	local rc=$?
+	rm -f "$state_file" "$index_file" "$worktree_file"
+	return "$rc"
 }
 
 echo "runs=$RUNS  php=$PHP_VERSION  root=$ROOT"
@@ -76,15 +136,22 @@ fails=0
 errors=0
 contaminated=0
 revision_changes=0
+worktree_changes=0
 
 for ((i = 1; i <= RUNS; i++)); do
 	head_before="$(git rev-parse HEAD 2>/dev/null || printf '<unresolvable>')"
-	read -r tracked_before untracked_before <<< "$(tree_state)"
+	state_before="$(tree_state)" || {
+		echo "cannot read the repository state before run $i" >&2
+		exit 2
+	}
+	read -r tracked_before untracked_before state_hash_before <<< "$state_before"
 
-	root_now="$(autoload_root)"
+	path_now="$(autoload_path)"
 	root_rc=$?
 	autoload_ok=0
-	if [ "$root_rc" -eq 0 ] && [ -n "$root_now" ] && [ "$root_now" = "$ROOT" ]; then
+	if [ "$root_rc" -eq 0 ] \
+		&& [ -n "$path_now" ] \
+		&& [ "$path_now" = "$ROOT/includes/class-gate.php" ]; then
 		autoload_ok=1
 	else
 		contaminated=$((contaminated + 1))
@@ -98,7 +165,17 @@ for ((i = 1; i <= RUNS; i++)); do
 	rc=$?
 
 	head_after="$(git rev-parse HEAD 2>/dev/null || printf '<unresolvable>')"
-	read -r tracked_after untracked_after <<< "$(tree_state)"
+	state_after="$(tree_state)" || {
+		echo "cannot read the repository state after run $i" >&2
+		rm -f "$raw_file"
+		exit 2
+	}
+	read -r tracked_after untracked_after state_hash_after <<< "$state_after"
+	worktree_changed=0
+	if [ "$state_hash_before" != "$state_hash_after" ]; then
+		worktree_changed=1
+		worktree_changes=$((worktree_changes + 1))
+	fi
 	revision_changed=0
 	if [ "$head_before" != "$SAMPLE_HEAD" ] || [ "$head_after" != "$SAMPLE_HEAD" ]; then
 		revision_changed=1
@@ -128,12 +205,13 @@ for ((i = 1; i <= RUNS; i++)); do
 	RECORD_RC="$rc" \
 	RECORD_TESTS="$tests" \
 	RECORD_ASSERTIONS="$assertions" \
-	RECORD_AUTOLOAD_ROOT="$root_now" \
+	RECORD_AUTOLOAD_PATH="$path_now" \
 	RECORD_AUTOLOAD_OK="$autoload_ok" \
 	RECORD_TRACKED_BEFORE="$tracked_before" \
 	RECORD_UNTRACKED_BEFORE="$untracked_before" \
 	RECORD_TRACKED_AFTER="$tracked_after" \
 	RECORD_UNTRACKED_AFTER="$untracked_after" \
+	RECORD_WORKTREE_CHANGED="$worktree_changed" \
 	RECORD_HEAD_BEFORE="$head_before" \
 	RECORD_HEAD_AFTER="$head_after" \
 	RECORD_REVISION_CHANGED="$revision_changed" \
@@ -157,12 +235,13 @@ for ((i = 1; i <= RUNS; i++)); do
 			"rc"                     => (int) getenv( "RECORD_RC" ),
 			"tests"                  => $nullable_int( "RECORD_TESTS" ),
 			"assertions"             => $nullable_int( "RECORD_ASSERTIONS" ),
-			"autoload_root"          => getenv( "RECORD_AUTOLOAD_ROOT" ) ?: null,
+			"autoload_path"          => getenv( "RECORD_AUTOLOAD_PATH" ) ?: null,
 			"autoload_ok"            => $bool( "RECORD_AUTOLOAD_OK" ),
 			"tracked_dirty_before"   => $bool( "RECORD_TRACKED_BEFORE" ),
 			"untracked_dirty_before" => $bool( "RECORD_UNTRACKED_BEFORE" ),
 			"tracked_dirty_after"    => $bool( "RECORD_TRACKED_AFTER" ),
 			"untracked_dirty_after"  => $bool( "RECORD_UNTRACKED_AFTER" ),
+			"worktree_changed"       => $bool( "RECORD_WORKTREE_CHANGED" ),
 			"head_before"            => getenv( "RECORD_HEAD_BEFORE" ),
 			"head_after"             => getenv( "RECORD_HEAD_AFTER" ),
 			"revision_changed"       => $bool( "RECORD_REVISION_CHANGED" ),
@@ -180,8 +259,9 @@ for ((i = 1; i <= RUNS; i++)); do
 
 	printf 'run %-3d %-5s tests=%s assertions=%s' \
 		"$i" "$status" "${tests:-?}" "${assertions:-?}"
-	[ "$autoload_ok" -eq 1 ] || printf ' AUTOLOAD=%s' "${root_now:-<unresolvable>}"
+	[ "$autoload_ok" -eq 1 ] || printf ' AUTOLOAD=%s' "${path_now:-<unresolvable>}"
 	[ "$revision_changed" -eq 0 ] || printf ' HEAD-CHANGED'
+	[ "$worktree_changed" -eq 0 ] || printf ' WORKTREE-CHANGED'
 	printf '\n'
 done
 
@@ -192,11 +272,13 @@ echo "failing runs:     $fails"
 echo "errored runs:     $errors"
 echo "foreign roots:    $contaminated"
 echo "revision changes: $revision_changes"
+echo "worktree changes: $worktree_changes"
 
 if [ "$fails" -eq 0 ] \
 	&& [ "$errors" -eq 0 ] \
 	&& [ "$contaminated" -eq 0 ] \
-	&& [ "$revision_changes" -eq 0 ]; then
+	&& [ "$revision_changes" -eq 0 ] \
+	&& [ "$worktree_changes" -eq 0 ]; then
 	echo "The observed $RUNS-run sample passed under the environment recorded in $OUT."
 	exit 0
 fi

--- a/bin/suite-determinism.sh
+++ b/bin/suite-determinism.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+#
+# Run the unit suite repeatedly and preserve enough evidence to distinguish a
+# test failure from a changing checkout, foreign autoload root, or runner error.
+#
+# Usage:
+#   bash bin/suite-determinism.sh [positive-run-count]
+#
+# Every invocation creates a separate JSONL file under .tmp/. It deliberately
+# completes the requested sample after a red run, then exits nonzero if any run
+# failed, errored, changed revision, or loaded WP Sudo from another checkout.
+
+set -uo pipefail
+
+RUNS="${1-50}"
+if ! [[ "$RUNS" =~ ^[1-9][0-9]*$ ]]; then
+	echo "usage: bash bin/suite-determinism.sh [positive integer]" >&2
+	exit 2
+fi
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || {
+	echo "cannot resolve the repository root" >&2
+	exit 2
+}
+cd "$ROOT" || exit 2
+ROOT="$(pwd -P)"
+
+mkdir -p "$ROOT/.tmp" || {
+	echo "cannot create $ROOT/.tmp" >&2
+	exit 2
+}
+OUT="$(mktemp "$ROOT/.tmp/suite-determinism.jsonl.XXXXXX")" || {
+	echo "cannot create a unique JSONL output file" >&2
+	exit 2
+}
+
+PHP_VERSION="$(php -r 'echo PHP_VERSION;' 2>/dev/null)" || {
+	echo "cannot resolve the PHP version" >&2
+	exit 2
+}
+
+autoload_root() {
+	php -d display_errors=stderr -r \
+		'require "tests/bootstrap.php"; $r = new ReflectionClass("WP_Sudo\Gate"); echo dirname(dirname((string) $r->getFileName()));' \
+		2>/dev/null
+}
+
+# Prints two shell words: tracked-dirty untracked-dirty.
+tree_state() {
+	local entry tracked=0 untracked=0
+	while IFS= read -r -d '' entry; do
+		if [ "${entry:0:2}" = "??" ]; then
+			untracked=1
+		else
+			tracked=1
+		fi
+	done < <(git status --porcelain=v1 -z --untracked-files=all)
+	printf '%d %d\n' "$tracked" "$untracked"
+}
+
+echo "runs=$RUNS  php=$PHP_VERSION  root=$ROOT"
+echo "writing $OUT"
+echo ""
+
+fails=0
+errors=0
+contaminated=0
+revision_changes=0
+
+for ((i = 1; i <= RUNS; i++)); do
+	head_before="$(git rev-parse HEAD 2>/dev/null || printf '<unresolvable>')"
+	read -r tracked_before untracked_before <<< "$(tree_state)"
+
+	root_now="$(autoload_root)"
+	root_rc=$?
+	autoload_ok=0
+	if [ "$root_rc" -eq 0 ] && [ -n "$root_now" ] && [ "$root_now" = "$ROOT" ]; then
+		autoload_ok=1
+	else
+		contaminated=$((contaminated + 1))
+	fi
+
+	raw_file="$(mktemp "$ROOT/.tmp/suite-determinism.raw.XXXXXX")" || {
+		echo "cannot create a runner-output file" >&2
+		exit 2
+	}
+	./vendor/bin/phpunit --do-not-cache-result --colors=never > "$raw_file" 2>&1
+	rc=$?
+
+	head_after="$(git rev-parse HEAD 2>/dev/null || printf '<unresolvable>')"
+	read -r tracked_after untracked_after <<< "$(tree_state)"
+	revision_changed=0
+	if [ "$head_before" != "$head_after" ]; then
+		revision_changed=1
+		revision_changes=$((revision_changes + 1))
+	fi
+
+	summary="$(
+		grep -Eo 'OK \([0-9]+ tests?, [0-9]+ assertions?\)|Tests: [0-9]+, Assertions: [0-9]+' "$raw_file" \
+			| tail -1
+	)"
+	tests="$(printf '%s' "$summary" | grep -Eo '[0-9]+ tests?|Tests: [0-9]+' | grep -Eo '[0-9]+' | head -1)"
+	assertions="$(printf '%s' "$summary" | grep -Eo '[0-9]+ assertions?|Assertions: [0-9]+' | grep -Eo '[0-9]+' | head -1)"
+	failed="$(sed -nE 's/^[0-9]+\) //p' "$raw_file")"
+
+	if [ "$rc" -eq 0 ] && [ -n "$tests" ] && [ "$tests" -gt 0 ]; then
+		status="pass"
+	elif [ "$rc" -ne 0 ] && [ -n "$failed" ] && [ -n "$tests" ]; then
+		status="fail"
+		fails=$((fails + 1))
+	else
+		status="error"
+		errors=$((errors + 1))
+	fi
+
+	RECORD_RUN="$i" \
+	RECORD_STATUS="$status" \
+	RECORD_RC="$rc" \
+	RECORD_TESTS="$tests" \
+	RECORD_ASSERTIONS="$assertions" \
+	RECORD_AUTOLOAD_ROOT="$root_now" \
+	RECORD_AUTOLOAD_OK="$autoload_ok" \
+	RECORD_TRACKED_BEFORE="$tracked_before" \
+	RECORD_UNTRACKED_BEFORE="$untracked_before" \
+	RECORD_TRACKED_AFTER="$tracked_after" \
+	RECORD_UNTRACKED_AFTER="$untracked_after" \
+	RECORD_HEAD_BEFORE="$head_before" \
+	RECORD_HEAD_AFTER="$head_after" \
+	RECORD_REVISION_CHANGED="$revision_changed" \
+	RECORD_PHP="$PHP_VERSION" \
+	RECORD_RAW_FILE="$raw_file" \
+	php -r '
+		$nullable_int = static function ( string $name ): ?int {
+			$value = getenv( $name );
+			return false === $value || "" === $value ? null : (int) $value;
+		};
+		$bool = static fn( string $name ): bool => "1" === getenv( $name );
+		$diagnostic = file_get_contents( (string) getenv( "RECORD_RAW_FILE" ) );
+		if ( false === $diagnostic ) {
+			fwrite( STDERR, "cannot read the runner-output file\n" );
+			exit( 2 );
+		}
+		preg_match_all( "/^[0-9]+\\) (.+)$/mu", $diagnostic, $matches );
+		$record = array(
+			"run"                    => (int) getenv( "RECORD_RUN" ),
+			"status"                 => getenv( "RECORD_STATUS" ),
+			"rc"                     => (int) getenv( "RECORD_RC" ),
+			"tests"                  => $nullable_int( "RECORD_TESTS" ),
+			"assertions"             => $nullable_int( "RECORD_ASSERTIONS" ),
+			"autoload_root"          => getenv( "RECORD_AUTOLOAD_ROOT" ) ?: null,
+			"autoload_ok"            => $bool( "RECORD_AUTOLOAD_OK" ),
+			"tracked_dirty_before"   => $bool( "RECORD_TRACKED_BEFORE" ),
+			"untracked_dirty_before" => $bool( "RECORD_UNTRACKED_BEFORE" ),
+			"tracked_dirty_after"    => $bool( "RECORD_TRACKED_AFTER" ),
+			"untracked_dirty_after"  => $bool( "RECORD_UNTRACKED_AFTER" ),
+			"head_before"            => getenv( "RECORD_HEAD_BEFORE" ),
+			"head_after"             => getenv( "RECORD_HEAD_AFTER" ),
+			"revision_changed"       => $bool( "RECORD_REVISION_CHANGED" ),
+			"php"                    => getenv( "RECORD_PHP" ),
+			"failed"                 => $matches[1],
+			"diagnostic"             => $diagnostic,
+		);
+		echo json_encode( $record, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ), "\n";
+	' >> "$OUT" || {
+		echo "cannot append a valid record to $OUT" >&2
+		rm -f "$raw_file"
+		exit 2
+	}
+	rm -f "$raw_file"
+
+	printf 'run %-3d %-5s tests=%s assertions=%s' \
+		"$i" "$status" "${tests:-?}" "${assertions:-?}"
+	[ "$autoload_ok" -eq 1 ] || printf ' AUTOLOAD=%s' "${root_now:-<unresolvable>}"
+	[ "$revision_changed" -eq 0 ] || printf ' HEAD-CHANGED'
+	printf '\n'
+done
+
+echo ""
+echo "── summary ─────────────────────────────────────────"
+echo "runs:             $RUNS"
+echo "failing runs:     $fails"
+echo "errored runs:     $errors"
+echo "foreign roots:    $contaminated"
+echo "revision changes: $revision_changes"
+
+if [ "$fails" -eq 0 ] \
+	&& [ "$errors" -eq 0 ] \
+	&& [ "$contaminated" -eq 0 ] \
+	&& [ "$revision_changes" -eq 0 ]; then
+	echo "The observed $RUNS-run sample passed under the environment recorded in $OUT."
+	exit 0
+fi
+
+exit 1

--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,7 @@
         "test:poc": "phpunit -c poc/install-package-gate/phpunit.xml.dist",
         "test:integration": "bash bin/run-integration-tests.sh phpunit-integration.xml.dist",
         "test:coverage": "phpunit --configuration phpunit.xml.dist --coverage-clover coverage.xml --coverage-text",
+        "test:suite-determinism": "bash tests/suite-determinism/run.sh",
         "test:sources": "bash tests/verify-sources/run.sh",
         "verify:metrics": "bash bin/verify-metrics.sh",
         "verify:i18n": "bash bin/verify-i18n.sh",

--- a/tests/suite-determinism/run.sh
+++ b/tests/suite-determinism/run.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+#
+# Black-box regression tests for bin/suite-determinism.sh.
+
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$ROOT/bin/suite-determinism.sh"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+pass=0
+fail=0
+CURRENT=""
+
+new_repo() {
+	REPO="$TMP_ROOT/$1"
+	mkdir -p "$REPO/bin" "$REPO/includes" "$REPO/tests" "$REPO/vendor/bin"
+	cp "$SCRIPT" "$REPO/bin/suite-determinism.sh"
+	cat > "$REPO/includes/class-gate.php" <<'PHP'
+<?php
+namespace WP_Sudo;
+class Gate {}
+PHP
+	cat > "$REPO/tests/bootstrap.php" <<'PHP'
+<?php
+require dirname( __DIR__ ) . '/includes/class-gate.php';
+PHP
+	cat > "$REPO/vendor/bin/phpunit" <<'FAKE'
+#!/usr/bin/env bash
+set -u
+counter=".tmp/fake-count.${FAKE_COUNTER_ID:-shared}"
+mkdir -p .tmp
+n=0
+[ ! -f "$counter" ] || n="$(cat "$counter")"
+n=$((n + 1))
+printf '%s' "$n" > "$counter"
+
+case "${FAKE_SCENARIO:-pass}" in
+	pass)
+		printf 'OK (2 tests, 3 assertions)\n'
+		exit 0
+		;;
+	fail-first)
+		if [ "$n" -eq 1 ]; then
+			printf '1) WP_Sudo\\Tests\\Unit\\OddTest::test_\"quoted\"_café\nTests: 2, Assertions: 2, Failures: 1.\n'
+			exit 1
+		fi
+		printf 'OK (2 tests, 3 assertions)\n'
+		exit 0
+		;;
+	empty)
+		printf 'No tests executed!\n'
+		exit 0
+		;;
+	infra)
+		printf 'bootstrap says \"broken\"\\path\nsecond diagnostic line\n'
+		exit 2
+		;;
+	change-head)
+		printf '\n// changed\n' >> includes/class-gate.php
+		git add includes/class-gate.php
+		git commit -qm 'fixture mutation'
+		printf 'OK (2 tests, 3 assertions)\n'
+		exit 0
+		;;
+	dirty-after)
+		printf '\n// dirty\n' >> includes/class-gate.php
+		printf 'new input\n' > tests/NewTest.php
+		printf 'OK (2 tests, 3 assertions)\n'
+		exit 0
+		;;
+esac
+FAKE
+	chmod +x "$REPO/vendor/bin/phpunit"
+	git -C "$REPO" init -q
+	git -C "$REPO" config user.name "Fixture"
+	git -C "$REPO" config user.email "fixture@example.test"
+	git -C "$REPO" add .
+	git -C "$REPO" commit -qm baseline
+}
+
+run_harness() {
+	local scenario="${1:-pass}"
+	shift
+	OUT="$(cd "$REPO" && FAKE_SCENARIO="$scenario" bash bin/suite-determinism.sh "$@" 2>&1)"
+	RC=$?
+	JSONL="$(printf '%s\n' "$OUT" | sed -n 's/^writing //p' | tail -1)"
+}
+
+expect_rc() {
+	if [ "$RC" = "$1" ]; then
+		pass=$((pass + 1))
+	else
+		fail=$((fail + 1))
+		printf 'FAIL: %s (expected exit %s, got %s)\n%s\n' "$CURRENT" "$1" "$RC" "$OUT"
+	fi
+}
+
+expect() {
+	if "$@"; then
+		pass=$((pass + 1))
+	else
+		fail=$((fail + 1))
+		printf 'FAIL: %s (%s)\n%s\n' "$CURRENT" "$*" "$OUT"
+	fi
+}
+
+json_assert() {
+	php -r '$rows=file($argv[1], FILE_IGNORE_NEW_LINES); foreach($rows as $row){json_decode($row,true,512,JSON_THROW_ON_ERROR);} if(count($rows)!==(int)$argv[2]) exit(1);' "$JSONL" "$1"
+}
+
+CURRENT="invalid run counts fail before invoking PHPUnit"
+for bad in '' 0 -1 nope ' 2' 1.5; do
+	new_repo "invalid-${bad//[^a-zA-Z0-9]/x}"
+	run_harness pass "$bad"
+	expect_rc 2
+	expect test ! -f "$REPO/.tmp/fake-count.shared"
+done
+
+CURRENT="output initialization failure stops before PHPUnit"
+new_repo nooutput
+rm -rf "$REPO/.tmp"
+printf 'not a directory\n' > "$REPO/.tmp"
+run_harness pass 1
+expect_rc 2
+expect test ! -f "$REPO/.tmp/fake-count.shared"
+
+CURRENT="all requested runs execute and failures make the command fail"
+new_repo failures
+run_harness fail-first 3
+expect_rc 1
+expect test "$(cat "$REPO/.tmp/fake-count.shared")" = 3
+expect json_assert 3
+expect grep -q '"status":"fail"' "$JSONL"
+expect grep -q 'OddTest' "$JSONL"
+
+CURRENT="empty and infrastructure outputs are errors"
+new_repo empty
+run_harness empty 2
+expect_rc 1
+expect json_assert 2
+expect grep -q '"status":"error"' "$JSONL"
+expect php -r '$r=json_decode(file($argv[1])[0],true); exit(null===$r["tests"]&&null===$r["assertions"]?0:1);' "$JSONL"
+new_repo infra
+run_harness infra 1
+expect_rc 1
+expect json_assert 1
+
+CURRENT="foreign and unresolvable autoload roots fail"
+new_repo foreign
+foreign_root="$TMP_ROOT/foreign-source"
+mkdir -p "$foreign_root/includes"
+cp "$REPO/includes/class-gate.php" "$foreign_root/includes/class-gate.php"
+printf "<?php\nrequire '%s/includes/class-gate.php';\n" "$foreign_root" > "$REPO/tests/bootstrap.php"
+run_harness pass 1
+expect_rc 1
+new_repo unresolved
+printf '%s\n' '<?php exit(2);' > "$REPO/tests/bootstrap.php"
+run_harness pass 1
+expect_rc 1
+
+CURRENT="revision changes and post-run dirty state are recorded"
+new_repo changed
+run_harness change-head 2
+expect_rc 1
+expect json_assert 2
+expect php -r '$r=json_decode(file($argv[1])[0],true); exit($r["head_before"]!==$r["head_after"]?0:1);' "$JSONL"
+new_repo dirty
+run_harness dirty-after 1
+expect_rc 0
+expect php -r '$r=json_decode(file($argv[1])[0],true); exit($r["tracked_dirty_after"]&&$r["untracked_dirty_after"]?0:1);' "$JSONL"
+
+CURRENT="concurrent invocations use distinct complete output files"
+new_repo concurrent
+( cd "$REPO" && FAKE_SCENARIO=pass FAKE_COUNTER_ID=a bash bin/suite-determinism.sh 2 > "$TMP_ROOT/out-a" 2>&1 ) &
+pid_a=$!
+( cd "$REPO" && FAKE_SCENARIO=pass FAKE_COUNTER_ID=b bash bin/suite-determinism.sh 2 > "$TMP_ROOT/out-b" 2>&1 ) &
+pid_b=$!
+wait "$pid_a"; rc_a=$?
+wait "$pid_b"; rc_b=$?
+path_a="$(sed -n 's/^writing //p' "$TMP_ROOT/out-a" | tail -1)"
+path_b="$(sed -n 's/^writing //p' "$TMP_ROOT/out-b" | tail -1)"
+OUT="$(cat "$TMP_ROOT/out-a" "$TMP_ROOT/out-b")"
+expect test "$rc_a" -eq 0
+expect test "$rc_b" -eq 0
+expect test "$path_a" != "$path_b"
+JSONL="$path_a"; expect json_assert 2
+JSONL="$path_b"; expect json_assert 2
+
+CURRENT="successful sample wording stays bounded"
+new_repo success
+run_harness pass 2
+expect_rc 0
+expect php -r '$r=json_decode(file($argv[1])[0],true); exit(2===$r["tests"]&&3===$r["assertions"]?0:1);' "$JSONL"
+expect grep -q "observed 2-run sample passed" <(printf '%s' "$OUT")
+expect sh -c "! printf '%s' \"\$1\" | grep -qi 'suite is deterministic'" sh "$OUT"
+
+printf 'suite-determinism regression tests: %d passed, %d failed\n' "$pass" "$fail"
+test "$fail" -eq 0

--- a/tests/suite-determinism/run.sh
+++ b/tests/suite-determinism/run.sh
@@ -29,8 +29,7 @@ PHP
 	cat > "$REPO/vendor/bin/phpunit" <<'FAKE'
 #!/usr/bin/env bash
 set -u
-counter=".tmp/fake-count.${FAKE_COUNTER_ID:-shared}"
-mkdir -p .tmp
+counter=".git/fake-count.${FAKE_COUNTER_ID:-shared}"
 n=0
 [ ! -f "$counter" ] || n="$(cat "$counter")"
 n=$((n + 1))
@@ -76,6 +75,12 @@ case "${FAKE_SCENARIO:-pass}" in
 		printf 'OK (2 tests, 3 assertions)\n'
 		exit 0
 		;;
+	dirty-existing)
+		printf '\n// changed again\n' >> includes/class-gate.php
+		printf 'changed again\n' >> tests/ExistingUntracked.php
+		printf 'OK (2 tests, 3 assertions)\n'
+		exit 0
+		;;
 esac
 FAKE
 	chmod +x "$REPO/vendor/bin/phpunit"
@@ -116,12 +121,12 @@ json_assert() {
 	php -r '$rows=file($argv[1], FILE_IGNORE_NEW_LINES); foreach($rows as $row){json_decode($row,true,512,JSON_THROW_ON_ERROR);} if(count($rows)!==(int)$argv[2]) exit(1);' "$JSONL" "$1"
 }
 
-CURRENT="invalid run counts fail before invoking PHPUnit"
-for bad in '' 0 -1 nope ' 2' 1.5; do
+CURRENT="invalid and impractical run counts fail before invoking PHPUnit"
+for bad in '' 0 -1 nope ' 2' 1.5 10001 18446744073709551616; do
 	new_repo "invalid-${bad//[^a-zA-Z0-9]/x}"
 	run_harness pass "$bad"
 	expect_rc 2
-	expect test ! -f "$REPO/.tmp/fake-count.shared"
+	expect test ! -f "$REPO/.git/fake-count.shared"
 done
 
 CURRENT="output initialization failure stops before PHPUnit"
@@ -130,13 +135,13 @@ rm -rf "$REPO/.tmp"
 printf 'not a directory\n' > "$REPO/.tmp"
 run_harness pass 1
 expect_rc 2
-expect test ! -f "$REPO/.tmp/fake-count.shared"
+expect test ! -f "$REPO/.git/fake-count.shared"
 
 CURRENT="all requested runs execute and failures make the command fail"
 new_repo failures
 run_harness fail-first 3
 expect_rc 1
-expect test "$(cat "$REPO/.tmp/fake-count.shared")" = 3
+expect test "$(cat "$REPO/.git/fake-count.shared")" = 3
 expect json_assert 3
 expect grep -q '"status":"fail"' "$JSONL"
 expect grep -q 'OddTest' "$JSONL"
@@ -161,6 +166,12 @@ cp "$REPO/includes/class-gate.php" "$foreign_root/includes/class-gate.php"
 printf "<?php\nrequire '%s/includes/class-gate.php';\n" "$foreign_root" > "$REPO/tests/bootstrap.php"
 run_harness pass 1
 expect_rc 1
+new_repo local-wrong
+mkdir -p "$REPO/alternate"
+cp "$REPO/includes/class-gate.php" "$REPO/alternate/class-gate.php"
+printf '%s\n' "<?php require dirname( __DIR__ ) . '/alternate/class-gate.php';" > "$REPO/tests/bootstrap.php"
+run_harness pass 1
+expect_rc 1
 new_repo unresolved
 printf '%s\n' '<?php exit(2);' > "$REPO/tests/bootstrap.php"
 run_harness pass 1
@@ -182,7 +193,7 @@ expect json_assert 2
 expect grep -q '"status":"fail"' "$JSONL"
 expect php -r '$r=json_decode(file($argv[1])[0],true,512,JSON_THROW_ON_ERROR); exit(str_contains($r["diagnostic"], "\u{FFFD}")?0:1);' "$JSONL"
 
-CURRENT="revision changes and post-run dirty state are recorded"
+CURRENT="revision changes and post-run dirty state fail the sample"
 new_repo changed
 run_harness change-head 2
 expect_rc 1
@@ -190,8 +201,37 @@ expect json_assert 2
 expect php -r '$r=json_decode(file($argv[1])[0],true); exit($r["head_before"]!==$r["head_after"]?0:1);' "$JSONL"
 new_repo dirty
 run_harness dirty-after 1
-expect_rc 0
-expect php -r '$r=json_decode(file($argv[1])[0],true); exit($r["tracked_dirty_after"]&&$r["untracked_dirty_after"]?0:1);' "$JSONL"
+expect_rc 1
+expect php -r '$r=json_decode(file($argv[1])[0],true); exit($r["tracked_dirty_after"]&&$r["untracked_dirty_after"]&&$r["worktree_changed"]?0:1);' "$JSONL"
+new_repo dirty-existing
+printf '\n// already dirty\n' >> "$REPO/includes/class-gate.php"
+printf 'already untracked\n' > "$REPO/tests/ExistingUntracked.php"
+run_harness dirty-existing 1
+expect_rc 1
+expect php -r '$r=json_decode(file($argv[1])[0],true); exit($r["worktree_changed"]?0:1);' "$JSONL"
+
+CURRENT="unreadable repository state fails before PHPUnit"
+new_repo unreadable-status
+real_git="$(command -v git)"
+mkdir -p "$REPO/fake-bin"
+cat > "$REPO/fake-bin/git" <<'FAKE_GIT'
+#!/usr/bin/env bash
+if [ "$1" = "status" ]; then
+	exit 1
+fi
+exec "$REAL_GIT" "$@"
+FAKE_GIT
+chmod +x "$REPO/fake-bin/git"
+set +e
+OUT="$(
+	cd "$REPO" &&
+		REAL_GIT="$real_git" PATH="$REPO/fake-bin:$PATH" \
+		FAKE_SCENARIO=pass bash bin/suite-determinism.sh 1 2>&1
+)"
+RC=$?
+set -e
+expect_rc 2
+expect test ! -f "$REPO/.git/fake-count.shared"
 
 CURRENT="all iterations are pinned to one baseline revision"
 new_repo between-runs

--- a/tests/suite-determinism/run.sh
+++ b/tests/suite-determinism/run.sh
@@ -57,6 +57,12 @@ case "${FAKE_SCENARIO:-pass}" in
 		printf 'bootstrap says \"broken\"\\path\nsecond diagnostic line\n'
 		exit 2
 		;;
+	invalid-utf8)
+		printf '1) WP_Sudo\\Tests\\Unit\\BinaryTest::test_invalid_'
+		printf '\377'
+		printf '\nTests: 2, Assertions: 1, Failures: 1.\n'
+		exit 1
+		;;
 	change-head)
 		printf '\n// changed\n' >> includes/class-gate.php
 		git add includes/class-gate.php
@@ -160,6 +166,22 @@ printf '%s\n' '<?php exit(2);' > "$REPO/tests/bootstrap.php"
 run_harness pass 1
 expect_rc 1
 
+CURRENT="a symlinked vendor fails before the sample even when Gate resolves locally"
+new_repo symlinked-vendor
+mv "$REPO/vendor" "$REPO/vendor-real"
+ln -s vendor-real "$REPO/vendor"
+run_harness pass 1
+expect_rc 2
+expect test ! -f "$REPO/.tmp/fake-count.shared"
+
+CURRENT="malformed UTF-8 diagnostics remain valid JSON evidence"
+new_repo invalid-utf8
+run_harness invalid-utf8 2
+expect_rc 1
+expect json_assert 2
+expect grep -q '"status":"fail"' "$JSONL"
+expect php -r '$r=json_decode(file($argv[1])[0],true,512,JSON_THROW_ON_ERROR); exit(str_contains($r["diagnostic"], "\u{FFFD}")?0:1);' "$JSONL"
+
 CURRENT="revision changes and post-run dirty state are recorded"
 new_repo changed
 run_harness change-head 2
@@ -170,6 +192,42 @@ new_repo dirty
 run_harness dirty-after 1
 expect_rc 0
 expect php -r '$r=json_decode(file($argv[1])[0],true); exit($r["tracked_dirty_after"]&&$r["untracked_dirty_after"]?0:1);' "$JSONL"
+
+CURRENT="all iterations are pinned to one baseline revision"
+new_repo between-runs
+real_git="$(command -v git)"
+baseline_head="$(git -C "$REPO" rev-parse HEAD)"
+mkdir -p "$REPO/fake-bin"
+cat > "$REPO/fake-bin/git" <<'FAKE_GIT'
+#!/usr/bin/env bash
+if [ "$#" -eq 2 ] && [ "$1" = "rev-parse" ] && [ "$2" = "HEAD" ]; then
+	count_file=".tmp/fake-git-head-count"
+	count=0
+	[ ! -f "$count_file" ] || count="$(cat "$count_file")"
+	count=$((count + 1))
+	printf '%s' "$count" > "$count_file"
+	if [ "$count" -le 2 ]; then
+		printf '%s\n' "$FAKE_BASELINE_HEAD"
+	else
+		printf '%040d\n' 0
+	fi
+	exit 0
+fi
+exec "$REAL_GIT" "$@"
+FAKE_GIT
+chmod +x "$REPO/fake-bin/git"
+set +e
+OUT="$(
+	cd "$REPO" &&
+		REAL_GIT="$real_git" FAKE_BASELINE_HEAD="$baseline_head" PATH="$REPO/fake-bin:$PATH" \
+		FAKE_SCENARIO=pass bash bin/suite-determinism.sh 2 2>&1
+)"
+RC=$?
+set -e
+JSONL="$(printf '%s\n' "$OUT" | sed -n 's/^writing //p' | tail -1)"
+expect_rc 1
+expect json_assert 2
+expect php -r '$r=json_decode(file($argv[1])[1],true); exit($r["revision_changed"]?0:1);' "$JSONL"
 
 CURRENT="concurrent invocations use distinct complete output files"
 new_repo concurrent
@@ -195,6 +253,15 @@ expect_rc 0
 expect php -r '$r=json_decode(file($argv[1])[0],true); exit(2===$r["tests"]&&3===$r["assertions"]?0:1);' "$JSONL"
 expect grep -q "observed 2-run sample passed" <(printf '%s' "$OUT")
 expect sh -c "! printf '%s' \"\$1\" | grep -qi 'suite is deterministic'" sh "$OUT"
+
+CURRENT="the harness is registered in Composer and required CI"
+output=""
+status=0
+grep -q '"test:suite-determinism": "bash tests/suite-determinism/run.sh"' "$ROOT/composer.json" || status=1
+expect test "$status" -eq 0
+status=0
+grep -q 'composer test:suite-determinism' "$ROOT/.github/workflows/phpunit.yml" || status=1
+expect test "$status" -eq 0
 
 printf 'suite-determinism regression tests: %d passed, %d failed\n' "$pass" "$fail"
 test "$fail" -eq 0


### PR DESCRIPTION
Closes #460. Supersedes closed #477 with a squashed, tested redesign rather than extending its false-green-prone branch.

The opt-in harness completes the requested sample but returns nonzero for any test failure, runner error, foreign/unresolvable autoload root, or revision change. Each invocation gets an exclusive JSONL file; each record carries typed counts, real JSON encoding, pre/post HEAD and tracked/untracked state, expected-root identity, failure names, and the runner diagnostic. Success wording is explicitly limited to the observed sample.

TDD: the black-box harness was written against #477’s implementation first and produced 21 failures. The redesigned script now passes 52 assertions covering invalid input, output initialization, continuation after red runs, JSON validity/types, empty and infrastructure runs, foreign and missing roots, revision changes, dirty state, concurrent output isolation, and bounded conclusions.

Validation:
- `bash tests/suite-determinism/run.sh` (41 passed)
- real `bash bin/suite-determinism.sh 2` (1307/3904 twice; correct root; no errors, contamination, or revision changes)
- `composer test` (1307 tests, 3904 assertions)
- `composer lint`
- `composer analyse`
- `composer verify:metrics`
- `bash -n`

Independent reviewer approved staged tree `ecbefee7481804fe413bb62808b61a99225dd630`. No Claude-owned files or worktrees are touched.
