### PR TITLE
test: prove narrow activation governance bootstrap

### DIFF
--- a/docs/current-metrics.md
+++ b/docs/current-metrics.md
@@ -2,7 +2,7 @@
 
 This file is the single source of truth for current repository counts.
 
-Last verified: 2026-07-28
+Last verified: 2026-07-29
 Verification environment: local workspace, PHP 8.x
 
 ## Test Metrics
@@ -11,7 +11,7 @@ Verification environment: local workspace, PHP 8.x
 |---|---:|---|
 | Unit tests | 1,308 tests | `composer test:unit` |
 | Unit assertions | 3,907 assertions | `composer test:unit` |
-| Integration tests in suite | 243 test methods | `rg -c "function test" tests/Integration/*.php | awk -F: '{sum+=$2} END{print sum}'` |
+| Integration tests in suite | 245 test methods | `rg -c "function test" tests/Integration/*.php | awk -F: '{sum+=$2} END{print sum}'` |
 | Unit test files | 38 | `ls tests/Unit/*.php | wc -l` |
 | Integration test files | 31 | `ls tests/Integration/*.php | wc -l` |
 
@@ -20,10 +20,10 @@ Verification environment: local workspace, PHP 8.x
 | Metric | Value | Verification |
 |---|---:|---|
 | Production PHP lines (`includes/`, `wp-sudo.php`, `uninstall.php`, `mu-plugin/`, `bridges/`) | 21,581 | `find ./includes ./wp-sudo.php ./uninstall.php ./mu-plugin ./bridges -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
-| Tests PHP lines (`tests/`) | 45,863 | `find ./tests -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
-| Production + tests PHP lines | 67,444 | sum of the two rows above |
-| Test-to-production ratio | 2.13:1 | `45863 / 21581` |
-| Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`, `.claude/`) | 69,719 | `find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/vendor_test/*" ! -path "*/.tmp/*" ! -path "*/.git/*" ! -path "*/.claude/*" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Tests PHP lines (`tests/`) | 45,951 | `find ./tests -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Production + tests PHP lines | 67,532 | sum of the two rows above |
+| Test-to-production ratio | 2.13:1 | `45951 / 21581` |
+| Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`, `.claude/`) | 69,807 | `find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/vendor_test/*" ! -path "*/.tmp/*" ! -path "*/.git/*" ! -path "*/.claude/*" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
 
 ## Footprint & Performance
 

--- a/tests/Integration/UpgraderTest.php
+++ b/tests/Integration/UpgraderTest.php
@@ -433,6 +433,94 @@ class UpgraderTest extends TestCase {
 	}
 
 	/**
+	 * Fresh browser activation grants governance only to the activating admin.
+	 *
+	 * This asserts the security property behind the ordering in
+	 * Plugin::activate(), not merely that the direct grant happens first. The
+	 * 3.3.0 migration broadly grants every administrator when it sees no
+	 * manage_wp_sudo holder; the activator must already be such a holder before
+	 * that query runs.
+	 */
+	public function test_fresh_activation_does_not_grant_governance_to_a_second_administrator(): void {
+		if ( is_multisite() ) {
+			$this->markTestSkipped( 'The 3.3.0 governance backfill is single-site only.' );
+		}
+
+		$this->update_wp_sudo_option( Upgrader::VERSION_OPTION, '0.0.0' );
+		$activator = $this->make_admin();
+		$other     = $this->make_admin();
+
+		foreach ( Admin::GOVERNANCE_CAPS as $cap ) {
+			$activator->remove_cap( $cap );
+			$other->remove_cap( $cap );
+		}
+
+		wp_set_current_user( $activator->ID );
+		$this->activate_plugin();
+
+		$granted   = get_userdata( $activator->ID );
+		$untouched = get_userdata( $other->ID );
+		$this->assertInstanceOf( \WP_User::class, $granted );
+		$this->assertInstanceOf( \WP_User::class, $untouched );
+
+		foreach ( Admin::GOVERNANCE_CAPS as $cap ) {
+			$this->assertSame(
+				true,
+				$granted->caps[ $cap ] ?? null,
+				"Fresh activation must grant {$cap} directly to the activating administrator."
+			);
+			$this->assertArrayNotHasKey(
+				$cap,
+				$untouched->caps,
+				"Fresh activation must not grant {$cap} to another administrator."
+			);
+		}
+	}
+
+	/**
+	 * A userless activation retains the broad governance bootstrap fallback.
+	 *
+	 * WP-CLI activation without --user has no activating administrator to grant
+	 * directly. In that branch upgrade_3_3_0() must still prevent first-run
+	 * lockout by granting every existing administrator.
+	 */
+	public function test_fresh_userless_activation_grants_governance_to_existing_administrators(): void {
+		if ( is_multisite() ) {
+			$this->markTestSkipped( 'The 3.3.0 governance backfill is single-site only.' );
+		}
+
+		$this->update_wp_sudo_option( Upgrader::VERSION_OPTION, '0.0.0' );
+		$first  = $this->make_admin();
+		$second = $this->make_admin();
+
+		foreach ( Admin::GOVERNANCE_CAPS as $cap ) {
+			$first->remove_cap( $cap );
+			$second->remove_cap( $cap );
+		}
+
+		wp_set_current_user( 0 );
+		$this->activate_plugin();
+
+		$first  = get_userdata( $first->ID );
+		$second = get_userdata( $second->ID );
+		$this->assertInstanceOf( \WP_User::class, $first );
+		$this->assertInstanceOf( \WP_User::class, $second );
+
+		foreach ( Admin::GOVERNANCE_CAPS as $cap ) {
+			$this->assertSame(
+				true,
+				$first->caps[ $cap ] ?? null,
+				"Userless activation must grant {$cap} to the first existing administrator."
+			);
+			$this->assertSame(
+				true,
+				$second->caps[ $cap ] ?? null,
+				"Userless activation must grant {$cap} to the second existing administrator."
+			);
+		}
+	}
+
+	/**
 	 * SURF-01: 2.2.0 preserves already-valid three-tier policy values.
 	 *
 	 * Verifies that 'disabled', 'limited', 'unrestricted' values survive

--- a/tests/Integration/UpgraderTest.php
+++ b/tests/Integration/UpgraderTest.php
@@ -478,13 +478,13 @@ class UpgraderTest extends TestCase {
 	}
 
 	/**
-	 * A userless activation retains the broad governance bootstrap fallback.
+	 * Activation with no current user retains the broad bootstrap fallback.
 	 *
-	 * WP-CLI activation without --user has no activating administrator to grant
-	 * directly. In that branch upgrade_3_3_0() must still prevent first-run
-	 * lockout by granting every existing administrator.
+	 * When get_current_user_id() is zero, there is no activating administrator
+	 * to grant directly. In that branch upgrade_3_3_0() must still prevent
+	 * first-run lockout by granting every existing administrator.
 	 */
-	public function test_fresh_userless_activation_grants_governance_to_existing_administrators(): void {
+	public function test_fresh_activation_without_current_user_grants_governance_to_existing_administrators(): void {
 		if ( is_multisite() ) {
 			$this->markTestSkipped( 'The 3.3.0 governance backfill is single-site only.' );
 		}
@@ -510,12 +510,12 @@ class UpgraderTest extends TestCase {
 			$this->assertSame(
 				true,
 				$first->caps[ $cap ] ?? null,
-				"Userless activation must grant {$cap} to the first existing administrator."
+				"Activation without a current user must grant {$cap} to the first existing administrator."
 			);
 			$this->assertSame(
 				true,
 				$second->caps[ $cap ] ?? null,
-				"Userless activation must grant {$cap} to the second existing administrator."
+				"Activation without a current user must grant {$cap} to the second existing administrator."
 			);
 		}
 	}


### PR DESCRIPTION
## Summary

- prove a fresh browser activation grants governance capabilities only to the activating administrator
- prove userless activation retains the intentional all-administrator fallback
- update canonical test and line-count metrics

## Dependency status

#531 has merged. This branch is rebased directly onto current `main`; its main-relative diff is now only the two integration tests and regenerated metrics.

## TDD evidence

The regression test was run against the pre-#531 activation order and failed because the second administrator unexpectedly received `manage_wp_sudo`. Restoring #531's order made both new tests pass.

## Validation

- `composer test` — 1,308 tests, 3,907 assertions
- `composer lint`
- `composer analyse`
- full integration suite — 250 tests, 901 assertions, 18 skipped
- focused upgrader integration file — 11 tests, 59 assertions
- `composer verify:metrics`
- independent staged-tree review, repeated after the final main rebase and metrics regeneration

Closes #530.