### PR TITLE
fix(ux): preserve editor work when sudo expires

### DIFF
--- a/admin/js/wp-sudo-admin-bar.js
+++ b/admin/js/wp-sudo-admin-bar.js
@@ -42,24 +42,49 @@
 
 	// Track which milestones have been announced.
 	var milestones = { 60: false, 30: false, 10: false, 0: false };
+	var intervalId = null;
 
-	var intervalId = setInterval( function() {
-		r--;
-		if ( r <= 0 ) {
-			clearInterval( intervalId );
-			l.textContent = 'Sudo: 0:00';
-			sr.textContent = 'Sudo session expired.';
-			window.location.reload();
-			return;
-		}
-
+	/**
+	 * Render the current remaining time.
+	 *
+	 * @return {void}
+	 */
+	function renderTime() {
 		var m = Math.floor( r / 60 );
 		var s = r % 60;
 		l.textContent = 'Sudo: ' + m + ':' + ( s < 10 ? '0' : '' ) + s;
 
 		if ( r <= 60 ) {
 			n.classList.add( 'wp-sudo-expiring' );
+		} else {
+			n.classList.remove( 'wp-sudo-expiring' );
 		}
+	}
+
+	/**
+	 * Advance the timer by one second.
+	 *
+	 * @return {void}
+	 */
+	function tick() {
+		r--;
+		if ( r <= 0 ) {
+			clearInterval( intervalId );
+			intervalId = null;
+			l.textContent = 'Sudo: 0:00';
+			sr.textContent = 'Sudo session expired.';
+			if ( 0 !== Number( config.reload_on_expiry ) ) {
+				window.location.reload();
+			} else {
+				if ( a ) {
+					a.hidden = true;
+				}
+				n.classList.remove( 'wp-sudo-active', 'wp-sudo-expiring' );
+			}
+			return;
+		}
+
+		renderTime();
 
 		// Announce at milestone intervals only.
 		if ( r === 60 && ! milestones[ 60 ] ) {
@@ -72,7 +97,41 @@
 			milestones[ 10 ] = true;
 			sr.textContent = 'Sudo session: 10 seconds remaining.';
 		}
-	}, 1000 );
+	}
+
+	/**
+	 * Start or restart the countdown.
+	 *
+	 * @return {void}
+	 */
+	function startTimer() {
+		if ( null !== intervalId ) {
+			clearInterval( intervalId );
+		}
+		intervalId = setInterval( tick, 1000 );
+	}
+
+	startTimer();
+
+	// The block editor can grant a new session without navigating. Keep the
+	// persistent admin-bar status synchronized with the editor indicator's
+	// established session event.
+	window.addEventListener( 'wp-sudo-session-granted', function( event ) {
+		var remaining = parseInt( event.detail && event.detail.remaining, 10 ) || 0;
+		if ( remaining <= 0 ) {
+			return;
+		}
+
+		r = remaining;
+		milestones = { 60: false, 30: false, 10: false, 0: false };
+		if ( a ) {
+			a.hidden = false;
+		}
+		n.classList.add( 'wp-sudo-active' );
+		sr.textContent = '';
+		renderTime();
+		startTimer();
+	} );
 
 	// Clean up interval on page unload to prevent bfcache issues.
 	window.addEventListener( 'pagehide', function() {

--- a/docs/current-metrics.md
+++ b/docs/current-metrics.md
@@ -2,15 +2,15 @@
 
 This file is the single source of truth for current repository counts.
 
-Last verified: 2026-07-28
+Last verified: 2026-07-29
 Verification environment: local workspace, PHP 8.x
 
 ## Test Metrics
 
 | Metric | Value | Verification |
 |---|---:|---|
-| Unit tests | 1,308 tests | `composer test:unit` |
-| Unit assertions | 3,907 assertions | `composer test:unit` |
+| Unit tests | 1,309 tests | `composer test:unit` |
+| Unit assertions | 3,911 assertions | `composer test:unit` |
 | Integration tests in suite | 243 test methods | `rg -c "function test" tests/Integration/*.php | awk -F: '{sum+=$2} END{print sum}'` |
 | Unit test files | 38 | `ls tests/Unit/*.php | wc -l` |
 | Integration test files | 31 | `ls tests/Integration/*.php | wc -l` |
@@ -19,11 +19,11 @@ Verification environment: local workspace, PHP 8.x
 
 | Metric | Value | Verification |
 |---|---:|---|
-| Production PHP lines (`includes/`, `wp-sudo.php`, `uninstall.php`, `mu-plugin/`, `bridges/`) | 21,581 | `find ./includes ./wp-sudo.php ./uninstall.php ./mu-plugin ./bridges -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
-| Tests PHP lines (`tests/`) | 45,863 | `find ./tests -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
-| Production + tests PHP lines | 67,444 | sum of the two rows above |
-| Test-to-production ratio | 2.13:1 | `45863 / 21581` |
-| Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`, `.claude/`) | 69,719 | `find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/vendor_test/*" ! -path "*/.tmp/*" ! -path "*/.git/*" ! -path "*/.claude/*" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Production PHP lines (`includes/`, `wp-sudo.php`, `uninstall.php`, `mu-plugin/`, `bridges/`) | 21,587 | `find ./includes ./wp-sudo.php ./uninstall.php ./mu-plugin ./bridges -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Tests PHP lines (`tests/`) | 45,908 | `find ./tests -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Production + tests PHP lines | 67,495 | sum of the two rows above |
+| Test-to-production ratio | 2.13:1 | `45908 / 21587` |
+| Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`, `.claude/`) | 69,770 | `find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/vendor_test/*" ! -path "*/.tmp/*" ! -path "*/.git/*" ! -path "*/.claude/*" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
 
 ## Footprint & Performance
 

--- a/docs/ui-ux-testing-prompts.md
+++ b/docs/ui-ux-testing-prompts.md
@@ -22,7 +22,7 @@ Each section uses `- [ ]` checkboxes so the document works as a runnable checkli
 - [ ] **Settings page:** MU-plugin install/uninstall shows spinner during AJAX, then updates the status text and displays a result message.
 - [ ] **Admin bar timer:** Countdown ticks every second with M:SS format so the user always knows the session state.
 - [ ] **Admin bar timer:** Node turns red (`wp-sudo-expiring` class) at 60 s remaining.
-- [ ] **Admin bar timer:** Page reloads automatically when the timer reaches 0, removing the countdown node.
+- [ ] **Admin bar timer:** At 0, classic admin screens reload and remove the countdown node; block-editor screens withdraw the node without navigation, then restore it after an in-editor grant.
 
 ### H2 -- Match Between System and the Real World
 
@@ -96,7 +96,7 @@ Each section uses `- [ ]` checkboxes so the document works as a runnable checkli
 - [ ] **Challenge page:** Non-JSON server responses log to the browser console and show "The server returned an unexpected response" with a console hint.
 - [ ] **Challenge page:** Network errors show "A network error occurred. Please try again."
 - [ ] **Settings page:** MU-plugin install/uninstall error messages specify the cause (e.g., "Check file permissions.").
-- [ ] **Admin bar timer:** On expiry, announces "Sudo session expired." and auto-reloads to reset state.
+- [ ] **Admin bar timer:** On expiry, announces "Sudo session expired." Classic screens reload to reset state; block-editor screens preserve work, withdraw the stale node, and restore it when an in-editor grant reports the new duration.
 
 ### H10 – Help and Documentation
 

--- a/includes/class-admin-bar.php
+++ b/includes/class-admin-bar.php
@@ -211,6 +211,9 @@ class Admin_Bar {
 			return;
 		}
 
+		$screen           = get_current_screen();
+		$reload_on_expiry = ! ( $screen && $screen->is_block_editor() );
+
 		$remaining = Sudo_Session::time_remaining( $user_id );
 
 		if ( $remaining <= 0 ) {
@@ -235,7 +238,10 @@ class Admin_Bar {
 		wp_localize_script(
 			'wp-sudo-admin-bar',
 			'wpSudoAdminBar',
-			array( 'remaining' => $remaining )
+			array(
+				'remaining'        => $remaining,
+				'reload_on_expiry' => $reload_on_expiry ? 1 : 0,
+			)
 		);
 	}
 }

--- a/tests/MANUAL-TESTING.md
+++ b/tests/MANUAL-TESTING.md
@@ -116,9 +116,13 @@ with at least one `api_key` connector configured (core ships Akismet, whose key 
 
 1. Set session duration to 1 minute in Settings > Sudo.
 2. Activate sudo.
-3. Wait for the timer to count down to zero.
-4. **Expected:** Timer disappears from admin bar. Page auto-reloads.
+3. On a classic admin screen, wait for the timer to count down to zero.
+4. **Expected:** The page auto-reloads and the timer node is absent.
    The next gated action triggers a challenge.
+5. Repeat from a block-editor screen with unsaved content.
+6. **Expected:** The timer node is withdrawn without navigating or
+   discarding the editor state. Complete an in-editor reauthentication.
+7. **Expected:** The timer node returns with the newly granted duration.
 
 ### 1.5 Rate Limiting (Non-Blocking)
 
@@ -833,10 +837,13 @@ curl -sk "YOUR_SITE_URL/wp-cron.php" -w "HTTP: %{http_code}, body: %{size_downlo
    - **Expected:** Timer turns red.
    - **Accessibility:** Milestone announcements at 1 minute, 30 seconds,
      and 10 seconds are read by screen readers.
-8. Let the session expire.
-9. **Expected:** Timer disappears, page auto-reloads.
-10. Click the deactivation link during an active session.
-11. **Expected:** Session ends, you stay on the current page (not
+8. Let the session expire on a classic admin screen.
+9. **Expected:** The page auto-reloads and the timer disappears.
+10. Let the session expire in the block editor.
+11. **Expected:** The timer disappears without navigation. An in-editor
+    reauthentication restores it with the new session duration.
+12. Click the deactivation link during an active session.
+13. **Expected:** Session ends, you stay on the current page (not
     redirected to the dashboard).
 
 ---

--- a/tests/Unit/AdminBarTest.php
+++ b/tests/Unit/AdminBarTest.php
@@ -28,6 +28,7 @@ class AdminBarTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 		Functions\when( 'force_ssl_admin' )->justReturn( false );
+		Functions\when( 'get_current_screen' )->justReturn( null );
 		$this->admin_bar = new Admin_Bar();
 	}
 
@@ -352,6 +353,50 @@ class AdminBarTest extends TestCase {
 		Functions\when( 'wp_enqueue_style' )->justReturn( true );
 		Functions\when( 'wp_enqueue_script' )->justReturn( true );
 		Functions\when( 'wp_localize_script' )->justReturn( true );
+
+		$this->admin_bar->enqueue_assets();
+		$this->assertTrue( true );
+	}
+
+	public function test_enqueue_assets_disables_expiry_reload_in_block_editor(): void {
+		Functions\when( 'get_current_user_id' )->justReturn( 5 );
+
+		$future = time() + 300;
+		$token  = 'block-editor-token';
+
+		Functions\when( 'get_user_meta' )->alias( function ( $uid, $key, $single ) use ( $future, $token ) {
+			if ( Sudo_Session::META_KEY === $key ) {
+				return $future;
+			}
+			if ( Sudo_Session::PROOF_META_KEY === $key ) {
+				return $this->make_proof_map( (int) $uid, $token, $future );
+			}
+			return '';
+		} );
+		Functions\when( 'get_current_screen' )->justReturn(
+			new class() {
+				public function is_block_editor(): bool {
+					return true;
+				}
+			}
+		);
+
+		$_COOKIE[ Sudo_Session::TOKEN_COOKIE ] = $token;
+
+		Functions\expect( 'wp_enqueue_style' )->once();
+		Functions\expect( 'wp_enqueue_script' )->once();
+		Functions\expect( 'wp_localize_script' )
+			->once()
+			->with(
+				'wp-sudo-admin-bar',
+				'wpSudoAdminBar',
+				\Mockery::on(
+					static function ( array $config ): bool {
+						return is_int( $config['remaining'] ?? null )
+							&& 0 === ( $config['reload_on_expiry'] ?? null );
+					}
+				)
+			);
 
 		$this->admin_bar->enqueue_assets();
 		$this->assertTrue( true );

--- a/tests/e2e/specs/admin-bar-timer.spec.ts
+++ b/tests/e2e/specs/admin-bar-timer.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Admin bar timer tests — TIMR-01, TIMR-02, TIMR-03, TIMR-04
+ * Admin bar timer tests — TIMR-01, TIMR-02, TIMR-03, TIMR-04, TIMR-05
  *
  * Verify the admin bar countdown timer behaviour during an active sudo session.
  * Uses page.clock to control JavaScript time deterministically — no real waiting.
@@ -12,7 +12,7 @@
  *   - Label span:           #wp-admin-bar-wp-sudo-active .ab-label
  *   - Timer text format:    'Sudo: M:SS'  (e.g. 'Sudo: 14:59')
  *   - Expiring CSS class:   wp-sudo-expiring  (added to li when remaining <= 60)
- *   - Reload trigger:       window.location.reload() when remaining <= 0
+ *   - Classic-screen reload: window.location.reload() when remaining <= 0
  *
  * CRITICAL PITFALL (Pitfall 4 / TIMR-specific):
  *   page.clock.install() MUST be called BEFORE page.goto() and BEFORE
@@ -30,7 +30,8 @@
  *
  * PHP/JS clock separation (TIMR-04 specific):
  *   page.clock only affects browser-side JavaScript. PHP uses the real wall clock (time()).
- *   The JS countdown timer can reach zero and call window.location.reload() via fake clock,
+ *   On classic screens, the JS countdown timer can reach zero and call
+ *   window.location.reload() via fake clock,
  *   but the PHP session will still be active on the reloaded page unless we expire it
  *   server-side. TIMR-04 uses WP-CLI to clear the server-side proof record before
  *   ticking to zero, ensuring PHP also considers the session expired on reload.
@@ -287,5 +288,85 @@ test.describe( 'Admin bar timer', () => {
             page.locator( '#wp-admin-bar-wp-sudo-active' ),
             'Timer node must be absent after session-expiry reload'
         ).not.toBeVisible();
+    } );
+
+    /**
+     * TIMR-05: Block-editor expiry does not reload the page.
+     *
+     * The timer may still update a visible admin bar when fullscreen mode is off,
+     * while the editor indicator owns the in-editor state. Only the destructive
+     * expiry navigation is disabled; TIMR-04 preserves it on classic screens.
+     */
+    test( 'TIMR-05: block-editor timer disables expiry reload', async ( {
+        page,
+    } ) => {
+        await activateSudoSession( page );
+        await page.clock.install();
+        await page.goto( '/wp-admin/post-new.php' );
+        await page.waitForFunction(
+            () => !! ( window as any ).wp?.data?.select?.( 'core/editor' ),
+            undefined,
+            { timeout: 30_000 }
+        );
+
+        await expect(
+            page.locator( 'script[src*="/admin/js/wp-sudo-admin-bar.js"]' ),
+            'The timer remains available when the editor admin bar is visible'
+        ).toHaveCount( 1 );
+        await expect(
+            page.locator( 'script[src*="/admin/js/wp-sudo-session-indicator.js"]' ),
+            'The editor-specific session indicator must remain available'
+        ).toHaveCount( 1 );
+
+        await expect
+            .poll( () =>
+                page.evaluate(
+                    () =>
+                        Number(
+                            ( window as any ).wpSudoAdminBar?.reload_on_expiry
+                        )
+                )
+            )
+            .toBe( 0 );
+
+        let mainFrameNavigations = 0;
+        page.on( 'framenavigated', ( frame ) => {
+            if ( frame === page.mainFrame() ) {
+                mainFrameNavigations++;
+            }
+        } );
+
+        await page.clock.runFor( 910_000 );
+        await page.waitForTimeout( 500 );
+        expect(
+            mainFrameNavigations,
+            'Sudo expiry must not navigate away from editor work'
+        ).toBe( 0 );
+        await expect( page.locator( 'body' ) ).toHaveClass( /block-editor-page/ );
+
+        const timerNode = page.locator( '#wp-admin-bar-wp-sudo-active' );
+        await expect(
+            timerNode.locator( '.ab-item' ),
+            'An expired timer must not remain presented as an active session'
+        ).toHaveAttribute( 'hidden', '' );
+        await expect( timerNode.locator( '[role="status"]' ) ).toHaveText(
+            'Sudo session expired.'
+        );
+
+        await page.evaluate( () => {
+            window.dispatchEvent(
+                new CustomEvent( 'wp-sudo-session-granted', {
+                    detail: { remaining: 300 },
+                } )
+            );
+        } );
+
+        await expect(
+            timerNode.locator( '.ab-item' ),
+            'An in-editor grant must restore the persistent admin-bar status'
+        ).not.toHaveAttribute( 'hidden', '' );
+        await expect( timerNode.locator( '.ab-label' ) ).toHaveText(
+            /^Sudo: 4:5\d$/
+        );
     } );
 } );


### PR DESCRIPTION
## Summary

- keep classic admin expiry reloads while preserving unsaved block-editor work
- withdraw the stale editor timer without hiding its live expiry announcement
- restore and restart the persistent timer when the editor grants a new session
- prove the classic/editor split and expiry-to-regrant lifecycle in a real browser

## Root cause and impact

`wp-sudo-admin-bar.js` reloaded every admin page when its local countdown reached zero. The script is also enqueued in the block editor, so an unrelated Sudo expiry could navigate away from long-lived editor work. Simply suppressing the reload left the admin bar stuck at `0:00` after a later in-editor grant.

`Admin_Bar::enqueue_assets()` now derives an explicit `reload_on_expiry` flag from `WP_Screen::is_block_editor()`. Classic screens retain the existing reload. On block-editor screens, expiry hides only the stale interactive timer, preserves the `role=status` live region long enough to announce expiry, and listens to the established `wp-sudo-session-granted` event to restore/restart the timer with the server-reported duration.

## Stack order

This PR is intentionally based on #502 (`ci/482-javascript-lint`) because that PR reformats and owns the same JavaScript file. Merge #502 first, then retarget this PR to `main`; do not hand-resolve the formatter overlap.

## Validation after restack

- TDD: TIMR-05 failed before the expiry/regrant implementation.
- `composer test` — 1,309 tests, 3,911 assertions.
- `composer lint`.
- `composer analyse` — PHPStan level 6 and Psalm clean.
- `npm run lint:js`.
- `composer verify:i18n`.
- `composer verify:metrics` with untracked `node_modules` isolated; verifier gap is fixed separately by #544.
- Isolated WordPress 7.0 wp-env on unused ports: all five `admin-bar-timer.spec.ts` cases pass.
  - TIMR-04 proves classic-screen expiry still reloads.
  - TIMR-05 proves editor expiry does not navigate, the stale control is withdrawn while its live-region announcement remains, and a later grant restores the countdown.
- Current staged metrics tree approved before commit; branch is clean.

WordPress API verification: WordPress 6.4 `WP_Screen::is_block_editor()` in `wp-admin/includes/class-wp-screen.php`.

Closes #300.