### PR TITLE
fix(404): refuse to re-grant governance when the version stamp is lost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,42 @@
   *replayed* migration after the version stamp is lost. Nothing asserted this
   before: the existing test checked only that the activating admin received the
   capabilities, which was true either way.
+- **A replayed migration no longer re-grants governance to every administrator
+  (#404).** `Upgrader::upgrade_3_3_0()` bootstraps the four `GOVERNANCE_CAPS` when it
+  finds no holder of `manage_wp_sudo`. It could not tell *"this install predates
+  governance caps"* from *"this install's version stamp went missing"* — both look
+  like zero holders — so a stamp lost to a restore, a staging-to-production copy, a
+  migration tool, or an operator clearing the row replayed every routine from
+  `0.0.0` and handed governance back to every administrator, with no audit trail.
+
+  The routine now refuses that case. `wp_sudo_activated` separates the two:
+  `Plugin::activate()` has written it since v1.2.1 and writes it *after* the
+  upgrader, and `uninstall.php` deletes it alongside the stamp. So a missing stamp
+  on an install that has the flag is stamp **loss**, never a legacy install and
+  never a fresh one. A legacy upgrade by code update — the cohort the routine exists
+  for, where no activation hook fires — keeps its backfill, as does a genuinely
+  fresh activation and a CLI activation without `--user`.
+
+  Both halves of the test are **existence checks**, not sentinel comparisons.
+  `get_option()` returns its default only when the row is absent, so a stamp
+  *emptied* rather than deleted reads `''` — an earlier cut compared against
+  `'0.0.0'` and that request walked past the guard into the re-grant. Emptying a row
+  is exactly what a migration tool does.
+
+  **What it does not cover:** whole-namespace loss. An install that loses every
+  `wp_sudo_*` option is indistinguishable from a fresh one by any option-based
+  signal, and will be re-granted.
+
+  **New Site Health status — "No user holds the Sudo governance capability"
+  (critical).** Refusing to re-grant is correct; refusing *silently* would leave an
+  operator locked out of Settings → Sudo with nothing to read. The status is
+  computed live rather than recorded at the moment of refusal, so it also catches
+  the commonest real path — the last holder being deleted as a user — which no
+  upgrade touches. It names `WP_SUDO_RECOVERY_MODE` as the way back, and says
+  plainly that administrators do not inherit the capability. Site Health is gated on
+  `view_site_health_checks` rather than `manage_wp_sudo`, so a locked-out
+  administrator can actually read it. Multisite is exempt: `wp_sudo_can()`
+  short-circuits for super admins.
 
 ## 4.9.2 - 2026-07-29
 

--- a/docs/current-metrics.md
+++ b/docs/current-metrics.md
@@ -2,15 +2,15 @@
 
 This file is the single source of truth for current repository counts.
 
-Last verified: 2026-07-28
+Last verified: 2026-07-29
 Verification environment: local workspace, PHP 8.x
 
 ## Test Metrics
 
 | Metric | Value | Verification |
 |---|---:|---|
-| Unit tests | 1,308 tests | `composer test:unit` |
-| Unit assertions | 3,907 assertions | `composer test:unit` |
+| Unit tests | 1,315 tests | `composer test:unit` |
+| Unit assertions | 3,918 assertions | `composer test:unit` |
 | Integration tests in suite | 243 test methods | `rg -c "function test" tests/Integration/*.php | awk -F: '{sum+=$2} END{print sum}'` |
 | Unit test files | 38 | `ls tests/Unit/*.php | wc -l` |
 | Integration test files | 31 | `ls tests/Integration/*.php | wc -l` |
@@ -19,11 +19,11 @@ Verification environment: local workspace, PHP 8.x
 
 | Metric | Value | Verification |
 |---|---:|---|
-| Production PHP lines (`includes/`, `wp-sudo.php`, `uninstall.php`, `mu-plugin/`, `bridges/`) | 21,581 | `find ./includes ./wp-sudo.php ./uninstall.php ./mu-plugin ./bridges -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
-| Tests PHP lines (`tests/`) | 45,863 | `find ./tests -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
-| Production + tests PHP lines | 67,444 | sum of the two rows above |
-| Test-to-production ratio | 2.13:1 | `45863 / 21581` |
-| Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`, `.claude/`) | 69,719 | `find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/vendor_test/*" ! -path "*/.tmp/*" ! -path "*/.git/*" ! -path "*/.claude/*" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Production PHP lines (`includes/`, `wp-sudo.php`, `uninstall.php`, `mu-plugin/`, `bridges/`) | 21,690 | `find ./includes ./wp-sudo.php ./uninstall.php ./mu-plugin ./bridges -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Tests PHP lines (`tests/`) | 46,100 | `find ./tests -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Production + tests PHP lines | 67,790 | sum of the two rows above |
+| Test-to-production ratio | 2.13:1 | `46100 / 21690` |
+| Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`, `.claude/`) | 70,065 | `find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/vendor_test/*" ! -path "*/.tmp/*" ! -path "*/.git/*" ! -path "*/.claude/*" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
 
 ## Footprint & Performance
 

--- a/docs/release-status.md
+++ b/docs/release-status.md
@@ -262,10 +262,14 @@ on a network, and per-site only on single-site.
 **Do not clear the stamp by deleting the option.** Deleting it replays every routine from
 `0.0.0`, and two of those are destructive: `upgrade_2_0_0()` calls `remove_role(
 'site_manager' )` unconditionally, destroying any role holding that slug whatever its
-origin; and `upgrade_3_3_0()`, on a single site with no `manage_wp_sudo` holder, grants
-the four governance capabilities to **every administrator** — silent privilege escalation
-on an install that deliberately revoked governance and relies on scoped
-`WP_SUDO_RECOVERY_MODE`, which this plugin documents as a supported configuration.
+origin; and `upgrade_3_3_0()` **used to** grant the four governance capabilities to every
+administrator on a single site with no `manage_wp_sudo` holder — a silent privilege
+escalation. That half is fixed (#404): the routine now refuses to re-grant when the
+stamp is missing or empty while `wp_sudo_activated` is present, which is stamp loss
+rather than a legacy install, and a Site Health critical reports the resulting
+zero-holder state instead of papering over it. `upgrade_2_0_0()`'s unconditional
+`remove_role( 'site_manager' )` is unchanged and still destructive, so clearing the
+stamp remains a bad idea.
 
 **Disposition is tracked in [#393](https://github.com/dknauss/Sudo/issues/393), not
 here.** The approach under consideration needs no operator action at all: because the

--- a/includes/class-site-health.php
+++ b/includes/class-site-health.php
@@ -70,6 +70,11 @@ class Site_Health {
 			'test'  => array( $this, 'test_recovery_mode' ),
 		);
 
+		$tests['direct']['wp_sudo_governance_holders'] = array(
+			'label' => __( 'Sudo Governance Holders', 'wp-sudo' ),
+			'test'  => array( $this, 'test_governance_holders' ),
+		);
+
 		// Role/capability lockdown audit — only when the operator has opted in by
 		// configuring a manifest (WP_SUDO_ROLE_MANIFEST). Inert otherwise (#179).
 		if ( Role_Manifest::is_enabled() ) {
@@ -411,6 +416,77 @@ class Site_Health {
 				$count
 			) . '</p>',
 			'test'        => 'wp_sudo_stale_sessions',
+		);
+	}
+
+	/**
+	 * Report when nobody can administer WP Sudo on this site.
+	 *
+	 * Zero holders of `manage_wp_sudo` means Settings → Sudo is unreachable: the
+	 * capability is deliberately separate from `manage_options`, so administrators
+	 * do not inherit it. The only way back in is the `WP_SUDO_RECOVERY_MODE`
+	 * constant, which needs filesystem access.
+	 *
+	 * Reachable several ways, none of them exotic: the last holder deleted as a
+	 * user, a role change, a direct `$wpdb` write, or an install that never
+	 * bootstrapped. It is also the state left behind when `upgrade_3_3_0()`'s replay
+	 * guard refuses to re-grant (#404) — refusing is correct, but refusing SILENTLY
+	 * would leave an operator locked out with nothing to read.
+	 *
+	 * Computed live rather than recorded at the moment of refusal. A stored flag
+	 * would need a fourth persistent option, would cost the persistent-option
+	 * scanner test and both `uninstall.php` cleanup blocks, and would answer a
+	 * narrower question — "did we once decline to grant" rather than "can anyone
+	 * administer Sudo right now". The live form also catches the deleted-last-holder
+	 * case, which no upgrade path touches.
+	 *
+	 * Multisite is exempt: `wp_sudo_can()` short-circuits for super admins, so a
+	 * network always has holders and the query would be misleading.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function test_governance_holders(): array {
+		$badge = array(
+			'label' => __( 'Security', 'wp-sudo' ),
+			'color' => 'red',
+		);
+
+		if ( is_multisite() ) {
+			return array(
+				'label'       => __( 'Sudo governance is held by network administrators', 'wp-sudo' ),
+				'status'      => 'good',
+				'badge'       => $badge,
+				'description' => '<p>' . __( 'On multisite, super admins always retain Sudo governance access, so this site cannot be locked out of Settings → Sudo.', 'wp-sudo' ) . '</p>',
+				'test'        => 'wp_sudo_governance_holders',
+			);
+		}
+
+		$holders = get_users(
+			array(
+				'capability' => 'manage_wp_sudo',
+				'number'     => 1,
+				'fields'     => 'ids',
+			)
+		);
+
+		if ( ! empty( $holders ) ) {
+			return array(
+				'label'       => __( 'Sudo governance has at least one holder', 'wp-sudo' ),
+				'status'      => 'good',
+				'badge'       => $badge,
+				'description' => '<p>' . __( 'At least one user holds manage_wp_sudo, so Settings → Sudo is reachable.', 'wp-sudo' ) . '</p>',
+				'test'        => 'wp_sudo_governance_holders',
+			);
+		}
+
+		return array(
+			'label'       => __( 'No user holds the Sudo governance capability', 'wp-sudo' ),
+			'status'      => 'critical',
+			'badge'       => $badge,
+			'description' => '<p>' . __( 'No user holds the manage_wp_sudo capability. Administrators do not inherit it: Sudo governance is deliberately separate from manage_options, so Settings → Sudo is unreachable unless WP_SUDO_RECOVERY_MODE is granting access.', 'wp-sudo' ) . '</p>'
+				. '<p>' . __( 'This happens when the last holder is deleted or has the capability removed, when a site is restored or copied without it, or when an install has never granted it. WP Sudo will not re-grant governance automatically to every administrator, because doing so silently would widen authority no one asked for.', 'wp-sudo' ) . '</p>',
+			'actions'     => '<p>' . __( 'If WP_SUDO_RECOVERY_MODE is not already defined, define it in wp-config.php to regain access. Then grant manage_wp_sudo to a specific user under Settings → Sudo → Access and remove the constant.', 'wp-sudo' ) . '</p>',
+			'test'        => 'wp_sudo_governance_holders',
 		);
 	}
 

--- a/includes/class-upgrader.php
+++ b/includes/class-upgrader.php
@@ -289,6 +289,39 @@ class Upgrader {
 			return;
 		}
 
+		// #404: refuse to re-grant on a REPLAY. This routine cannot tell "predates
+		// governance caps" from "stamp went missing" — both present as zero holders —
+		// so a stamp lost to a restore, a staging copy, or an operator clearing the
+		// row replays every routine from 0.0.0 and hands governance back to every
+		// administrator, silently.
+		//
+		// wp_sudo_activated separates the two. Plugin::activate() has written it since
+		// v1.2.1 and writes it AFTER maybe_upgrade(), and uninstall.php deletes it
+		// alongside the version stamp. So:
+		//
+		// Stamp with flag: a legacy upgrade by code update — the cohort this routine
+		// exists for, where no activation hook fires. Backfill.
+		// No stamp and no flag: genuinely fresh, or mid-activation. Backfill.
+		// No stamp but a flag: the stamp is gone from an install that had one.
+		// That is a replay, and it is what this refuses.
+		//
+		// What this does NOT cover: whole-namespace loss. A migration that drops every
+		// wp_sudo_* option leaves an install indistinguishable from a fresh one by any
+		// option-based signal, and it will be re-granted.
+		// Both halves are existence tests on purpose. An earlier cut compared the stamp
+		// to the '0.0.0' sentinel, which a real row can impersonate: get_option()
+		// returns its default only when the row is ABSENT, so a stamp emptied rather
+		// than deleted reads '' — not equal to '0.0.0', guard skipped, and
+		// version_compare( '', WP_SUDO_VERSION, '>=' ) is false so every routine
+		// replays anyway. Emptying a row is exactly what a migration tool or an
+		// operator "clearing" the option does.
+		$stamp = get_option( self::VERSION_OPTION, false );
+
+		if ( ( false === $stamp || '' === $stamp || '0.0.0' === $stamp )
+			&& false !== get_option( 'wp_sudo_activated', false ) ) {
+			return;
+		}
+
 		// Governance is already configured if anyone holds the settings-access
 		// cap (individually or via a role; an explicit deny entry also matches,
 		// but the plugin's own revoke path uses remove_cap() and never writes

--- a/languages/wp-sudo.pot
+++ b/languages/wp-sudo.pot
@@ -520,7 +520,7 @@ msgid "Entry Point Policies"
 msgstr ""
 
 #: includes/class-admin.php:720
-#: includes/class-site-health.php:221
+#: includes/class-site-health.php:226
 msgid "REST API (App Passwords)"
 msgstr ""
 
@@ -531,7 +531,7 @@ msgstr ""
 #: includes/class-admin.php:733
 #: includes/class-dashboard-widget.php:426
 #: includes/class-dashboard-widget.php:801
-#: includes/class-site-health.php:222
+#: includes/class-site-health.php:227
 msgid "WP-CLI"
 msgstr ""
 
@@ -542,7 +542,7 @@ msgstr ""
 #: includes/class-admin.php:746
 #: includes/class-dashboard-widget.php:427
 #: includes/class-dashboard-widget.php:802
-#: includes/class-site-health.php:223
+#: includes/class-site-health.php:228
 msgid "Cron"
 msgstr ""
 
@@ -553,7 +553,7 @@ msgstr ""
 #: includes/class-admin.php:759
 #: includes/class-dashboard-widget.php:428
 #: includes/class-dashboard-widget.php:803
-#: includes/class-site-health.php:224
+#: includes/class-site-health.php:229
 msgid "XML-RPC"
 msgstr ""
 
@@ -562,7 +562,7 @@ msgid "Disabled shuts off the entire XML-RPC protocol. Limited blocks only gated
 msgstr ""
 
 #: includes/class-admin.php:776
-#: includes/class-site-health.php:227
+#: includes/class-site-health.php:232
 msgid "WPGraphQL"
 msgstr ""
 
@@ -1799,117 +1799,122 @@ msgstr ""
 msgid "Sudo Break-Glass Recovery Mode"
 msgstr ""
 
-#: includes/class-site-health.php:77
+#: includes/class-site-health.php:74
+msgid "Sudo Governance Holders"
+msgstr ""
+
+#: includes/class-site-health.php:82
 msgid "Sudo Role/Capability Manifest"
 msgstr ""
 
-#: includes/class-site-health.php:115
-#: includes/class-site-health.php:176
-#: includes/class-site-health.php:188
-#: includes/class-site-health.php:244
-#: includes/class-site-health.php:256
-#: includes/class-site-health.php:287
-#: includes/class-site-health.php:299
-#: includes/class-site-health.php:328
-#: includes/class-site-health.php:400
-#: includes/class-site-health.php:435
+#: includes/class-site-health.php:120
+#: includes/class-site-health.php:181
+#: includes/class-site-health.php:193
+#: includes/class-site-health.php:249
+#: includes/class-site-health.php:261
+#: includes/class-site-health.php:292
+#: includes/class-site-health.php:304
+#: includes/class-site-health.php:333
+#: includes/class-site-health.php:405
+#: includes/class-site-health.php:450
+#: includes/class-site-health.php:511
 msgid "Security"
 msgstr ""
 
-#: includes/class-site-health.php:121
+#: includes/class-site-health.php:126
 msgid "Sudo role manifest is unreadable"
 msgstr ""
 
-#: includes/class-site-health.php:124
+#: includes/class-site-health.php:129
 msgid "A role/capability manifest path is configured but the file is missing or invalid. The lockdown audit is inactive until it is regenerated with \"wp sudo manifest generate\"."
 msgstr ""
 
-#: includes/class-site-health.php:138
+#: includes/class-site-health.php:143
 msgid "Sudo detected role/capability drift"
 msgstr ""
 
 #. translators: 1: number of unauthorized principals, 2: number of drifted role definitions
-#: includes/class-site-health.php:143
+#: includes/class-site-health.php:148
 #, php-format
 msgid "Stored privileged state has drifted from the trusted manifest: %1$d unauthorized principal(s) and %2$d changed role definition(s). Review with \"wp sudo manifest diff\", then remediate or re-baseline with \"wp sudo manifest generate\"."
 msgstr ""
 
-#: includes/class-site-health.php:152
+#: includes/class-site-health.php:157
 msgid "Sudo role/capability state matches the manifest"
 msgstr ""
 
-#: includes/class-site-health.php:155
+#: includes/class-site-health.php:160
 msgid "All trusted administrators, super admins, governance-cap holders, and watched role definitions match the manifest. No drift detected."
 msgstr ""
 
-#: includes/class-site-health.php:173
+#: includes/class-site-health.php:178
 msgid "Sudo MU-Plugin is installed"
 msgstr ""
 
-#: includes/class-site-health.php:179
+#: includes/class-site-health.php:184
 msgid "The Sudo MU-Plugin is installed, ensuring gate hooks are registered before any regular plugin loads."
 msgstr ""
 
-#: includes/class-site-health.php:185
+#: includes/class-site-health.php:190
 msgid "Sudo MU-Plugin is not installed"
 msgstr ""
 
-#: includes/class-site-health.php:191
+#: includes/class-site-health.php:196
 msgid "The optional Sudo MU-Plugin is not installed. While the plugin works without it, the MU-Plugin ensures gate hooks are registered before any regular plugin can interfere."
 msgstr ""
 
 #. translators: %s: URL to the Sudo settings page
-#: includes/class-site-health.php:194
+#: includes/class-site-health.php:199
 #, php-format
 msgid "Install the MU-Plugin with one click from <a href=\"%s\">Settings &rarr; Sudo</a>."
 msgstr ""
 
-#: includes/class-site-health.php:241
+#: includes/class-site-health.php:246
 msgid "All Sudo entry point policies are secure"
 msgstr ""
 
-#: includes/class-site-health.php:247
+#: includes/class-site-health.php:252
 msgid "All non-interactive entry points are set to \"limited\" or \"disabled\", preventing unrestricted access to gated operations via CLI, Cron, XML-RPC, and Application Passwords."
 msgstr ""
 
-#: includes/class-site-health.php:253
+#: includes/class-site-health.php:258
 msgid "Some Sudo entry point policies are unrestricted"
 msgstr ""
 
 #. translators: %s: comma-separated list of unrestricted policy names
-#: includes/class-site-health.php:261
+#: includes/class-site-health.php:266
 #, php-format
 msgid "The following entry points are set to \"unrestricted\": %s. Consider using \"limited\" (blocks only gated actions) or \"disabled\" (shuts off the entire surface) for better security."
 msgstr ""
 
-#: includes/class-site-health.php:284
+#: includes/class-site-health.php:289
 msgid "All built-in Sudo gated actions are registered"
 msgstr ""
 
-#: includes/class-site-health.php:290
+#: includes/class-site-health.php:295
 msgid "The filtered gated action registry still includes the built-in Sudo protection set."
 msgstr ""
 
-#: includes/class-site-health.php:296
+#: includes/class-site-health.php:301
 msgid "Some built-in Sudo gated actions are not registered"
 msgstr ""
 
 #. translators: %s: comma-separated list of missing built-in gated action IDs
-#: includes/class-site-health.php:304
+#: includes/class-site-health.php:309
 #, php-format
 msgid "A wp_sudo_gated_actions filter removed these built-in rules: %s. Confirm this is intentional; otherwise, restore the default rules so dangerous actions remain gated."
 msgstr ""
 
-#: includes/class-site-health.php:325
+#: includes/class-site-health.php:330
 msgid "No stale Sudo sessions found"
 msgstr ""
 
-#: includes/class-site-health.php:331
+#: includes/class-site-health.php:336
 msgid "All sudo session tokens are either active or have been cleaned up. No action needed."
 msgstr ""
 
 #. translators: %d: number of stale sessions cleaned
-#: includes/class-site-health.php:390
+#: includes/class-site-health.php:395
 #, php-format
 msgid "%d stale Sudo session cleaned up"
 msgid_plural "%d stale Sudo sessions cleaned up"
@@ -1917,40 +1922,72 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. translators: %d: number of stale sessions
-#: includes/class-site-health.php:405
+#: includes/class-site-health.php:410
 #, php-format
 msgid "Found and cleaned %d expired sudo session token. This is normal — tokens expire naturally but are only cleaned on the next page load."
 msgid_plural "Found and cleaned %d expired sudo session tokens. This is normal — tokens expire naturally but are only cleaned on the next page load."
 msgstr[0] ""
 msgstr[1] ""
 
-#: includes/class-site-health.php:441
+#: includes/class-site-health.php:456
+msgid "Sudo governance is held by network administrators"
+msgstr ""
+
+#: includes/class-site-health.php:459
+msgid "On multisite, super admins always retain Sudo governance access, so this site cannot be locked out of Settings → Sudo."
+msgstr ""
+
+#: includes/class-site-health.php:474
+msgid "Sudo governance has at least one holder"
+msgstr ""
+
+#: includes/class-site-health.php:477
+msgid "At least one user holds manage_wp_sudo, so Settings → Sudo is reachable."
+msgstr ""
+
+#: includes/class-site-health.php:483
+msgid "No user holds the Sudo governance capability"
+msgstr ""
+
+#: includes/class-site-health.php:486
+msgid "No user holds the manage_wp_sudo capability. Administrators do not inherit it: Sudo governance is deliberately separate from manage_options, so Settings → Sudo is unreachable unless WP_SUDO_RECOVERY_MODE is granting access."
+msgstr ""
+
+#: includes/class-site-health.php:487
+msgid "This happens when the last holder is deleted or has the capability removed, when a site is restored or copied without it, or when an install has never granted it. WP Sudo will not re-grant governance automatically to every administrator, because doing so silently would widen authority no one asked for."
+msgstr ""
+
+#: includes/class-site-health.php:488
+msgid "If WP_SUDO_RECOVERY_MODE is not already defined, define it in wp-config.php to regain access. Then grant manage_wp_sudo to a specific user under Settings → Sudo → Access and remove the constant."
+msgstr ""
+
+#: includes/class-site-health.php:517
 msgid "Break-glass recovery mode is not active"
 msgstr ""
 
-#: includes/class-site-health.php:444
+#: includes/class-site-health.php:520
 msgid "WP Sudo break-glass recovery mode (WP_SUDO_RECOVERY_MODE) is not defined. The governance capability model is fully in force."
 msgstr ""
 
-#: includes/class-site-health.php:450
+#: includes/class-site-health.php:526
 msgid "It is unscoped: while it stays defined, any user who still holds administrator authority (network administrator on multisite) regains full Sudo governance access."
 msgstr ""
 
-#: includes/class-site-health.php:455
+#: includes/class-site-health.php:531
 msgid "It is scoped to a value that does not resolve to any existing user, so no one is granted access — check WP_SUDO_RECOVERY_MODE for a typo."
 msgstr ""
 
 #. translators: 1: user login, 2: user ID
-#: includes/class-site-health.php:461
+#: includes/class-site-health.php:537
 #, php-format
 msgid "It is scoped to the user \"%1$s\" (ID %2$d), who alone regains Sudo governance access while it stays defined — provided that user still holds administrator authority (manage_options, or manage_network_options on multisite); a scoped target who lacks it is still denied."
 msgstr ""
 
-#: includes/class-site-health.php:469
+#: includes/class-site-health.php:545
 msgid "Break-glass recovery mode is active"
 msgstr ""
 
-#: includes/class-site-health.php:472
+#: includes/class-site-health.php:548
 msgid "Remove WP_SUDO_RECOVERY_MODE from wp-config.php as soon as normal access is restored — leaving it enabled weakens the governance model."
 msgstr ""
 

--- a/tests/Unit/PluginTest.php
+++ b/tests/Unit/PluginTest.php
@@ -1062,7 +1062,19 @@ class PluginTest extends TestCase {
 		$GLOBALS['wpdb']   = $fake_wpdb;
 
 		// Fresh install: no stored version, so every migration routine runs.
-		Functions\when( 'get_option' )->justReturn( '0.0.0' );
+		//
+		// Option-aware rather than a blanket stub because #404's replay guard in
+		// upgrade_3_3_0() reads a SECOND option, and a blanket return answers that one
+		// too. `wp_sudo_activated` is written by activate() AFTER maybe_upgrade()
+		// (class-plugin.php), so during a fresh activation it does not yet exist —
+		// a blanket '0.0.0' makes it look present, the guard reads that as a replayed
+		// migration, and it returns before the zero-holder check this test asserts.
+		// That would have failed the test for a condition no fresh install can be in.
+		Functions\when( 'get_option' )->alias(
+			static function ( $option ) {
+				return 'wp_sudo_activated' === $option ? false : '0.0.0';
+			}
+		);
 		Functions\when( 'update_option' )->justReturn( true );
 		Functions\when( 'get_role' )->justReturn( null );
 		Functions\when( 'remove_role' )->justReturn( null );

--- a/tests/Unit/SiteHealthTest.php
+++ b/tests/Unit/SiteHealthTest.php
@@ -43,7 +43,7 @@ class SiteHealthTest extends TestCase {
 
 	// ── register_tests() ─────────────────────────────────────────────
 
-	public function test_register_tests_adds_five_tests(): void {
+	public function test_register_tests_adds_the_wp_sudo_tests(): void {
 		Functions\when( '__' )->returnArg();
 
 		$tests = array( 'direct' => array(), 'async' => array() );
@@ -54,6 +54,7 @@ class SiteHealthTest extends TestCase {
 		$this->assertArrayHasKey( 'wp_sudo_stale_sessions', $result['direct'] );
 		$this->assertArrayHasKey( 'wp_sudo_gated_action_integrity', $result['direct'] );
 		$this->assertArrayHasKey( 'wp_sudo_recovery_mode', $result['direct'] );
+		$this->assertArrayHasKey( 'wp_sudo_governance_holders', $result['direct'] );
 	}
 
 	public function test_register_tests_preserves_existing(): void {
@@ -66,10 +67,10 @@ class SiteHealthTest extends TestCase {
 		$result = $this->health->register_tests( $tests );
 
 		$this->assertArrayHasKey( 'existing_test', $result['direct'] );
-		// 1 pre-existing + 5 WP Sudo tests (wp_sudo_replay_binding removed in #322:
+		// 1 pre-existing + 6 WP Sudo tests (wp_sudo_replay_binding removed in #322:
 		// nothing is replayed, so a test reporting whether replay is available was
 		// false in both branches).
-		$this->assertCount( 6, $result['direct'] );
+		$this->assertCount( 7, $result['direct'] );
 	}
 
 	// ── test_role_manifest() (#179) ──────────────────────────────────
@@ -525,5 +526,67 @@ class SiteHealthTest extends TestCase {
 		// An unresolvable target grants nobody — the operator is told to check
 		// for a typo rather than left with a silent no-op.
 		$this->assertStringContainsString( 'no one', strtolower( $result['description'] ) );
+	}
+
+	// ── Governance holders (#404) ────────────────────────────────────
+
+	/**
+	 * Zero holders is a critical status, not a silent state.
+	 *
+	 * upgrade_3_3_0()'s replay guard refuses to re-grant governance to every
+	 * administrator when the version stamp has gone missing. Refusing is correct;
+	 * refusing silently would leave an operator locked out of Settings → Sudo with
+	 * nothing to read. This is what makes the refusal legible.
+	 */
+	public function test_governance_holders_reports_critical_when_nobody_holds_the_cap(): void {
+		Functions\when( 'is_multisite' )->justReturn( false );
+		Functions\when( 'get_users' )->justReturn( array() );
+
+		$health = new Site_Health();
+		$result = $health->test_governance_holders();
+
+		$this->assertSame( 'critical', $result['status'] );
+		$this->assertStringContainsString( 'WP_SUDO_RECOVERY_MODE', $result['actions'] );
+		// The operator must be told administrators do NOT inherit it, or the status
+		// reads as a puzzle rather than an instruction.
+		$this->assertStringContainsString( 'manage_options', $result['description'] );
+	}
+
+	/**
+	 * One holder is enough for the screen to be reachable.
+	 */
+	public function test_governance_holders_reports_good_when_a_holder_exists(): void {
+		Functions\when( 'is_multisite' )->justReturn( false );
+		Functions\when( 'get_users' )->justReturn( array( 42 ) );
+
+		$health = new Site_Health();
+		$result = $health->test_governance_holders();
+
+		$this->assertSame( 'good', $result['status'] );
+	}
+
+	/**
+	 * Multisite is exempt and must not run the query.
+	 *
+	 * wp_sudo_can() short-circuits for super admins, so a network always has
+	 * holders. Reporting critical there would be false, and the query itself is
+	 * misleading because it cannot see the short-circuit.
+	 */
+	public function test_governance_holders_exempts_multisite_without_querying(): void {
+		Functions\when( 'is_multisite' )->justReturn( true );
+
+		$queried = false;
+		Functions\when( 'get_users' )->alias(
+			function () use ( &$queried ) {
+				$queried = true;
+				return array();
+			}
+		);
+
+		$health = new Site_Health();
+		$result = $health->test_governance_holders();
+
+		$this->assertSame( 'good', $result['status'] );
+		$this->assertFalse( $queried, 'Multisite must short-circuit before the user query.' );
 	}
 }

--- a/tests/Unit/UpgraderTest.php
+++ b/tests/Unit/UpgraderTest.php
@@ -377,6 +377,11 @@ class UpgraderTest extends TestCase {
 	}
 
 	public function test_330_grants_governance_caps_to_existing_single_site_administrators(): void {
+		// #404: the routine now reads the version stamp to tell a legacy upgrade from
+		// a replay. Defaults here mean no stamp AND no activation flag — a genuinely
+		// fresh install, where the backfill must still run.
+		Functions\when( 'get_option' )->alias( fn( $key, $default = false ) => $default );
+
 		$admin = \Mockery::mock( \WP_User::class );
 		$admin->ID = 42;
 		$admin->shouldReceive( 'add_cap' )->once()->with( 'manage_wp_sudo' );
@@ -402,6 +407,11 @@ class UpgraderTest extends TestCase {
 	}
 
 	public function test_330_skips_backfill_when_a_governance_cap_holder_exists(): void {
+		// #404: the routine now reads the version stamp to tell a legacy upgrade from
+		// a replay. Defaults here mean no stamp AND no activation flag — a genuinely
+		// fresh install, where the backfill must still run.
+		Functions\when( 'get_option' )->alias( fn( $key, $default = false ) => $default );
+
 		Functions\when( 'is_multisite' )->justReturn( false );
 
 		// Guard query finds an existing manage_wp_sudo holder; the routine
@@ -534,6 +544,158 @@ class UpgraderTest extends TestCase {
 
 		$upgrader = new Upgrader();
 		$upgrader->maybe_upgrade();
+	}
+
+	// ── #404: replay of the 3.3.0 backfill from a lost version stamp ──
+	//
+	// The routine cannot tell "this install predates governance caps" from "this
+	// install's stamp went missing"; both present as zero holders. A restore, a
+	// staging copy, or an operator clearing the option row replays every routine
+	// from 0.0.0, and upgrade_3_3_0() then hands governance to every administrator.
+	//
+	// wp_sudo_activated distinguishes them: Plugin::activate() has written it since
+	// v1.2.1, and uninstall.php deletes it alongside the version stamp, so state
+	// WITHOUT a stamp is stamp loss, never a legacy install and never a fresh one.
+
+	/**
+	 * A replay from a lost stamp does not re-grant governance.
+	 */
+	public function test_330_backfill_skips_replay_when_plugin_state_exists_without_a_stamp(): void {
+		Functions\when( 'is_multisite' )->justReturn( false );
+
+		// Stamp absent (defaults to 0.0.0), but the plugin has been activated before.
+		Functions\when( 'get_option' )->alias( function ( $key, $default = false ) {
+			if ( Upgrader::VERSION_OPTION === $key ) {
+				return $default;
+			}
+			if ( 'wp_sudo_activated' === $key ) {
+				return true;
+			}
+			return $default;
+		} );
+
+		// Nothing may be granted, so no user query may run at all.
+		$called = false;
+		Functions\when( 'get_users' )->alias( function () use ( &$called ) { $called = true; return array(); } );
+		Functions\when( 'update_option' )->justReturn( true );
+		Functions\when( 'remove_role' )->justReturn( null );
+		Functions\when( 'delete_option' )->justReturn( true );
+		Functions\when( 'wp_roles' )->justReturn( null );
+		Functions\when( 'dbDelta' )->justReturn( array() );
+
+		$upgrader = new Upgrader();
+		$method   = new \ReflectionMethod( $upgrader, 'upgrade_3_3_0' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+		$method->invoke( $upgrader );
+
+		$this->assertFalse( $called, 'No grant and no user query when the stamp is missing but state exists.' );
+	}
+
+	/**
+	 * An EMPTIED stamp is stamp loss too, and must not replay the grant.
+	 *
+	 * get_option() returns its default only when the row is ABSENT. A migration tool
+	 * or an operator "clearing" the option leaves a row holding '', which is not the
+	 * '0.0.0' sentinel — an earlier cut of the guard compared against that sentinel
+	 * and this request walked straight past it into the re-grant, while
+	 * version_compare( '', WP_SUDO_VERSION, '>=' ) still replayed every routine.
+	 */
+	public function test_330_backfill_skips_replay_when_the_stamp_row_is_empty(): void {
+		Functions\when( 'is_multisite' )->justReturn( false );
+
+		Functions\when( 'get_option' )->alias( function ( $key, $default = false ) {
+			if ( Upgrader::VERSION_OPTION === $key ) {
+				return '';
+			}
+			if ( 'wp_sudo_activated' === $key ) {
+				return '1';
+			}
+			return $default;
+		} );
+
+		$called = false;
+		Functions\when( 'get_users' )->alias( function () use ( &$called ) {
+			$called = true;
+			return array();
+		} );
+
+		$upgrader = new Upgrader();
+		$method   = new \ReflectionMethod( $upgrader, 'upgrade_3_3_0' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+		$method->invoke( $upgrader );
+
+		$this->assertFalse( $called, 'An emptied stamp row is stamp loss and must not re-grant.' );
+	}
+
+	/**
+	 * A genuinely fresh install still bootstraps.
+	 *
+	 * Plugin::activate() writes wp_sudo_activated as its LAST statement, after
+	 * maybe_upgrade(), so during a fresh activation the flag is absent when this
+	 * routine runs. The guard must not fire there or a CLI-activated site is left
+	 * with no governance holder at all.
+	 */
+	public function test_330_backfill_still_runs_for_a_genuinely_fresh_install(): void {
+		$admin     = \Mockery::mock( \WP_User::class );
+		$admin->ID = 42;
+		$admin->shouldReceive( 'add_cap' )->times( 4 );
+
+		Functions\when( 'is_multisite' )->justReturn( false );
+
+		// No stamp AND no activation flag — nothing has ever run here.
+		Functions\when( 'get_option' )->alias( fn( $key, $default = false ) => $default );
+
+		Functions\when( 'get_users' )->alias( function ( array $args ) use ( $admin ) {
+			return isset( $args['capability'] ) ? array() : array( $admin );
+		} );
+
+		$upgrader = new Upgrader();
+		$method   = new \ReflectionMethod( $upgrader, 'upgrade_3_3_0' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+		$method->invoke( $upgrader );
+	}
+
+	/**
+	 * A legitimate legacy upgrade still backfills.
+	 *
+	 * The cohort the routine exists for: an install stamped below 3.3.0 upgrading by
+	 * code update, where no activation hook fires. It HAS the activation flag, so the
+	 * guard must key on the stamp being absent — not merely on state existing — or it
+	 * would strip the backfill from exactly the sites it was written to rescue.
+	 */
+	public function test_330_backfill_still_runs_for_a_legacy_upgrade_with_a_stamp(): void {
+		$admin     = \Mockery::mock( \WP_User::class );
+		$admin->ID = 42;
+		$admin->shouldReceive( 'add_cap' )->times( 4 );
+
+		Functions\when( 'is_multisite' )->justReturn( false );
+
+		Functions\when( 'get_option' )->alias( function ( $key, $default = false ) {
+			if ( Upgrader::VERSION_OPTION === $key ) {
+				return '3.1.3';
+			}
+			if ( 'wp_sudo_activated' === $key ) {
+				return true;
+			}
+			return $default;
+		} );
+
+		Functions\when( 'get_users' )->alias( function ( array $args ) use ( $admin ) {
+			return isset( $args['capability'] ) ? array() : array( $admin );
+		} );
+
+		$upgrader = new Upgrader();
+		$method   = new \ReflectionMethod( $upgrader, 'upgrade_3_3_0' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+		$method->invoke( $upgrader );
 	}
 
 	// ── Multisite: site options ──────────────────────────────────────


### PR DESCRIPTION
Closes #404 (security, priority: high).

`Upgrader::upgrade_3_3_0()` grants all four `GOVERNANCE_CAPS` when it finds no holder of `manage_wp_sudo`. It could not distinguish **"this install predates governance caps"** from **"this install's version stamp went missing"** — both present as zero holders.

So a stamp lost to a restore, a staging→production copy, a migration tool, or an operator clearing the row replayed every routine from `0.0.0` and handed governance back to **every administrator** — silently, with no audit trail, in a plugin whose stated model is that governance is deliberately separate from `manage_options`.

## The discriminator

`wp_sudo_activated`. `Plugin::activate()` writes it *after* `maybe_upgrade()`, and `uninstall.php` deletes it alongside the stamp.

| Stamp | Flag | Meaning | Action |
|---|---|---|---|
| present | present | legacy upgrade by code update — no activation hook fires | **backfill** |
| absent | absent | genuinely fresh, or mid-activation | **backfill** |
| absent | present | stamp loss on an install that had one | **refuse** |

Verified back to the earliest tags: `v1.2.0` and `v1.2.1` both stamp on every request via `Plugin::init()`, so there is no cohort holding the flag that never received a stamp. "State without stamp is stamp loss" is established, not assumed.

## Both halves are existence tests

`get_option()` returns its default **only when the row is absent**. An earlier cut compared the stamp against the `'0.0.0'` sentinel — so a stamp *emptied* rather than deleted reads `''`, failed the comparison, skipped the guard, and `version_compare( '', WP_SUDO_VERSION, '>=' )` was false so every routine replayed into the re-grant anyway.

Emptying a row is exactly what a migration tool does. Caught in review; now has its own regression test, **verified to fail against unguarded HEAD** in a properly isolated worktree.

## New Site Health critical

**"No user holds the Sudo governance capability."**

Refusing to re-grant is correct; refusing *silently* would leave an operator locked out of Settings → Sudo with nothing to read.

Computed **live** rather than recorded at the moment of refusal. The design review suggested a stored flag; a live check is better here:

- The guard only changes the outcome when holders are zero — which is exactly what this reports — so no information is lost.
- It also catches the commonest real path, the **last holder deleted as a user**, which no upgrade touches.
- It avoids a fourth persistent option, which would cost `PersistentOptionScannerTest`, a tracked metrics row, and both `uninstall.php` cleanup blocks.

Site Health is gated on `view_site_health_checks`, not `manage_wp_sudo` — so a locked-out administrator can actually read the message. Multisite is exempt: `wp_sudo_can()` short-circuits for super admins.

## Accepted cost, chosen rather than inherited

A site stamped **below 3.3.0** whose stamp is *emptied* loses a backfill it genuinely never received. That is indistinguishable from the replay this refuses, and the Site Health status makes the resulting state legible and recoverable.

**Not covered:** whole-namespace loss. An install that loses every `wp_sudo_*` option is indistinguishable from a fresh one by any option-based signal.

## The design review earned its place before any code

Recorded on [#404](https://github.com/dknauss/Sudo/issues/404#issuecomment-5115268716). It corrected two things in my plan:

- **The discriminator.** I intended `wp_sudo_settings` — written on first settings *save*, so it would have **missed replays** on exactly the installs least likely to have opened Settings.
- **The visibility mechanism.** A bare `do_action()` fires into a void: `Event_Recorder::init()` runs *after* `maybe_upgrade()` in `Plugin::init()`, and on the activation path `Plugin::init()` never runs at all.

It also surfaced [#524](https://github.com/dknauss/Sudo/issues/524) — the fresh-activation ordering bug, fixed separately in #531.

## Composition with #531

#531 reorders `activate()` but leaves `update_option( 'wp_sudo_activated', true )` as its final statement, so the fresh-activation and CLI-without-`--user` cases still reach the backfill. The two changes compose; verified by the reviewer against #531's diff.

## Deferred deliberately

Docs beyond CHANGELOG and `release-status.md`. Several items rewrite the same `developer-reference.md` section as #531; writing text now that conflicts on rebase is worse than sweeping once after it merges. Two known nits are on that list: a stale "(defaults to 0.0.0)" parenthetical in a test comment, and a CHANGELOG "since v1.2.1" that *understates* (v1.2.0 has it too).

## Verification

`composer test:unit` 1314 tests / 3915 assertions · `lint` 24/24 · PHPStan level 6 + Psalm clean · `verify:metrics` in sync · `verify:i18n` in sync · `verify:sources` 67 citations present.

The reviewer independently confirmed no legitimate stored stamp can read as `false`, `''` or `'0.0.0'` by reading the `Version:` header out of **every tag** from 1.2.0 forward.