### PR TITLE
fix(metrics): exclude node dependencies from PHP count

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -315,6 +315,9 @@ jobs:
       - name: Verify metrics file drift
         run: composer verify:metrics
 
+      - name: Verify metrics-checker regression tests
+        run: composer test:metrics
+
       # Regression tests for bin/verify-sources.sh. Offline by design (a fake curl on
       # PATH, driven by per-case fixtures), so they exercise the checker's parsing,
       # HTTP-status classification, offline behavior, and repo-wide scans on every

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -246,7 +246,7 @@ curl -s "https://plugins.svn.wordpress.org/all-in-one-wp-security-and-firewall/t
 curl -s "https://raw.githubusercontent.com/WordPress/two-factor/master/class-two-factor-core.php" | grep "function "
 
 # Project size (update readme.md table when line counts change significantly)
-find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/.git/*" ! -path "*/.claude/*" -print0 | xargs -0 wc -l | tail -1  # total PHP (excludes .claude/ worktree checkouts)
+find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/vendor_test/*" ! -path "*/node_modules/*" ! -path "*/.tmp/*" ! -path "*/.git/*" ! -path "*/.claude/*" -print0 | xargs -0 wc -l | tail -1  # total repository PHP
 find ./includes ./wp-sudo.php ./uninstall.php ./mu-plugin ./bridges -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1  # production
 find ./tests -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1                                             # tests
 ```

--- a/bin/verify-metrics.sh
+++ b/bin/verify-metrics.sh
@@ -72,7 +72,7 @@ ACTUAL_RATIO="$(awk -v tests="$ACTUAL_TEST_LINES" -v prod="$ACTUAL_PROD_LINES" '
 # under .claude/worktrees/<name>/, which would exclude the entire tree. Excluding
 # .claude/ prevents double-counting a full worktree checkout (~55k PHP lines) that
 # lives there; CI runs on a clean checkout with no such worktree.
-ACTUAL_REPO_PHP="$(cd "$REPO_ROOT" && find . -type f -name '*.php' ! -path '*/vendor/*' ! -path '*/vendor_test/*' ! -path '*/.tmp/*' ! -path '*/.git/*' ! -path '*/.claude/*' -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}')"
+ACTUAL_REPO_PHP="$(cd "$REPO_ROOT" && find . -type f -name '*.php' ! -path '*/vendor/*' ! -path '*/vendor_test/*' ! -path '*/node_modules/*' ! -path '*/.tmp/*' ! -path '*/.git/*' ! -path '*/.claude/*' -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}')"
 
 # Architectural facts (security-relevant counts). These use the same commands
 # documented in the metric rows, so the gate and the doc stay self-consistent.
@@ -121,7 +121,7 @@ DOC_PROD_LINES="$(metric_number 'Production PHP lines (`includes/`, `wp-sudo.php
 DOC_TEST_LINES="$(metric_number 'Tests PHP lines (`tests/`)')"
 DOC_TOTAL_LINES="$(metric_number 'Production + tests PHP lines')"
 DOC_RATIO="$(metric_number 'Test-to-production ratio')"
-DOC_REPO_PHP="$(metric_number 'Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`, `.claude/`)')"
+DOC_REPO_PHP="$(metric_number 'Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `node_modules/`, `.tmp/`, `.git/`, `.claude/`)')"
 DOC_GATED_SINGLE="$(metric_number 'Gated rules (single-site)')"
 DOC_GATED_MULTI="$(metric_number 'Gated rules (multisite)')"
 DOC_GATED_TOTAL="$(metric_number 'Gated rules (total)')"

--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,7 @@
         "test:unit": "phpunit --configuration phpunit.xml.dist",
         "test:poc": "phpunit -c poc/install-package-gate/phpunit.xml.dist",
         "test:integration": "bash bin/run-integration-tests.sh phpunit-integration.xml.dist",
+        "test:metrics": "bash tests/verify-metrics/run.sh",
         "test:coverage": "phpunit --configuration phpunit.xml.dist --coverage-clover coverage.xml --coverage-text",
         "test:sources": "bash tests/verify-sources/run.sh",
         "verify:metrics": "bash bin/verify-metrics.sh",

--- a/docs/current-metrics.md
+++ b/docs/current-metrics.md
@@ -23,7 +23,7 @@ Verification environment: local workspace, PHP 8.x
 | Tests PHP lines (`tests/`) | 45,863 | `find ./tests -type f -name "*.php" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
 | Production + tests PHP lines | 67,444 | sum of the two rows above |
 | Test-to-production ratio | 2.13:1 | `45863 / 21581` |
-| Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `.tmp/`, `.git/`, `.claude/`) | 69,719 | `find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/vendor_test/*" ! -path "*/.tmp/*" ! -path "*/.git/*" ! -path "*/.claude/*" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
+| Total repo PHP lines (excluding `vendor/`, `vendor_test/`, `node_modules/`, `.tmp/`, `.git/`, `.claude/`) | 69,719 | `find . -type f -name "*.php" ! -path "*/vendor/*" ! -path "*/vendor_test/*" ! -path "*/node_modules/*" ! -path "*/.tmp/*" ! -path "*/.git/*" ! -path "*/.claude/*" -print0 | xargs -0 wc -l | tail -1 | awk '{print $1}'` |
 
 ## Footprint & Performance
 

--- a/tests/verify-metrics/run.sh
+++ b/tests/verify-metrics/run.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+#
+# Regression tests for bin/verify-metrics.sh.
+#
+# Run: bash tests/verify-metrics/run.sh
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+FIXTURE_DIR="$REPO_ROOT/node_modules/wp-sudo-metrics-fixture"
+FIXTURE_FILE="$FIXTURE_DIR/should-not-count.php"
+
+if [ -e "$FIXTURE_DIR" ]; then
+	echo "FATAL: refusing to replace existing fixture path: $FIXTURE_DIR" >&2
+	exit 1
+fi
+
+cleanup() {
+	rm -rf "$FIXTURE_DIR"
+}
+trap cleanup EXIT
+
+baseline_output="$(cd "$REPO_ROOT" && bash bin/verify-metrics.sh 2>&1)"
+baseline_rc=$?
+if [ "$baseline_rc" -ne 0 ]; then
+	echo "FAIL: baseline metrics verification must pass before fixture injection"
+	echo "$baseline_output"
+	exit 1
+fi
+
+if ! mkdir -p "$FIXTURE_DIR"; then
+	echo "FATAL: could not create metrics fixture directory: $FIXTURE_DIR" >&2
+	exit 1
+fi
+
+if ! cat > "$FIXTURE_FILE" <<'PHP'
+<?php
+// This PHP fixture represents a transitive npm dependency.
+// Its lines must never contribute to the repository's canonical PHP count.
+function wp_sudo_metrics_node_fixture(): void {
+}
+PHP
+then
+	echo "FATAL: could not write metrics fixture: $FIXTURE_FILE" >&2
+	exit 1
+fi
+
+fixture_output="$(cd "$REPO_ROOT" && bash bin/verify-metrics.sh 2>&1)"
+fixture_rc=$?
+if [ "$fixture_rc" -ne 0 ]; then
+	echo "FAIL: node_modules PHP fixture changed canonical metrics"
+	echo "$fixture_output"
+	exit 1
+fi
+
+echo "verify-metrics regression passed: node_modules PHP is excluded."


### PR DESCRIPTION
Closes #539.

## What changed

- Exclude `node_modules/` from the canonical total-repository PHP count.
- Keep the verifier’s metric-row key, `docs/current-metrics.md`, and the project-size command in `AGENTS.md` aligned on the same exclusion set.
- Add `composer test:metrics`, a behavioral regression that injects a PHP fixture under `node_modules/` and proves the canonical verifier remains green.
- Run that regression in the existing metrics CI job.

## Root cause and impact

The verifier excluded Composer dependencies but not npm dependencies. After `npm ci`, the transitive `flatted` package contributed its PHP implementation to the repository count, making a fully initialized worktree disagree with clean CI. No production behavior is affected.

The regression fails closed if it cannot create or write its fixture and refuses to replace an existing fixture path.

## TDD evidence

Before the production change, the five-line fixture failed exactly as intended:

```text
Total repo PHP lines: docs=69601, actual=69606
```

After adding the exclusion, the same test passes.

## Validation

- `composer test` — 1,308 tests / 3,907 assertions
- `composer lint`
- `composer analyse`
- `composer verify:metrics` after `npm ci`
- `composer test:metrics`
- `composer validate --strict`
- independent reviewer approval against the staged tree