### PR TITLE
docs(finding): retract the distinguished-identity capability-floor design

### DIFF
--- a/docs/finding.md
+++ b/docs/finding.md
@@ -1,7 +1,7 @@
 # Finding: route enumeration and post-submission interception cannot provide ecosystem-wide action-gated reauthentication
 
 **Status:** final finding; constructive direction, not a Core patch proposal
-**Date:** 2026-07-29, revised 2026-08-02 (rev. 4)
+**Date:** 2026-07-29, revised 2026-08-02 (rev. 5)
 **Source project:** WP Sudo (research prototype — see `PROJECT-STATUS.md`)
 
 ---
@@ -429,66 +429,98 @@ registry, reusable window, and inline-modal architecture predate this finding
 and are superseded as a production-security design. Preserve it for comparison;
 do not present it as the successor to WP Sudo.
 
-### 4.9 A second, orthogonal track: raising the capability floor
+### 4.9 A second, orthogonal track: raising the capability floor (revised after review)
 
 Everything in §4.1–§4.7 answers one question: *did this actor prove it
 recently, for this specific action?* WordPress's own capability system already
 answers a different question — *may this actor do this at all* — and §4.4
 already treats these as separate axes. A second track, sketched in discussion
-after this finding's initial drafting (2026-08-02) but **not built or tested**,
-works entirely on the second axis instead.
+after this finding's initial drafting (2026-08-02), works entirely on the
+second axis instead. **This section replaces an earlier version of itself**,
+retracted the same day after an architecture review (Codex) and the source
+audit §6 requires found it wrong in three independent, verified ways. The
+original text and why each part failed are kept below rather than deleted,
+consistent with how §2.5 records a withdrawn claim.
 
-The idea: no account — not even the site owner's ordinary login — holds
-capabilities such as `install_plugins` or `edit_plugins` at rest. Those are
-stripped from every account, unconditionally, via a `user_has_cap` filter
-living outside the database (a must-use plugin, so a database-level tamper
-cannot restore them). Exactly one distinguished account is exempted, checked
-by identity rather than role. That account has no usable password or email —
-the credential fields hold values that cannot authenticate through any of
-core's own login paths — so it cannot be reached directly. Reaching it
-requires a separate, deliberate step: authenticate again, then have the
-session switched into that identity, in the shape of `sudo -i` opening a shell
-rather than `sudo` wrapping one command.
+**What was originally proposed, and what was actually wrong with it.**
 
-This closes a class of failure the seven bypasses in §2.1 exemplify without
-being defeated by any of them, because `user_has_cap` is the one universal
-point every `current_user_can()` call passes through regardless of which
-route, method, or superglobal a request arrived by — there is no second
-predicate over the request for it to drift against. Three points were checked,
-not assumed, before crediting it with that: the "disable dangerous controls
-until reauth" pattern is secure only because the disabling is a rendering
-*consequence* of the real `user_has_cap` denial, not a substitute for it —
-otherwise it is exactly the client-side-authorization trap named in §4.5 and
-§5; the same protection extends to REST calls authenticated by the same
-session cookie, and to XML-RPC, for free, through the identical chokepoint;
-and Application Passwords issued to the distinguished account would bypass the
-whole mechanism, since that credential never touches the elevate step —
-closing it requires explicitly forcing
-`wp_is_application_passwords_available_for_user` false for that one identity.
-WP-CLI and cron are correctly outside its scope rather than insecurely
-covered: CLI access already implies filesystem trust the filter cannot add to,
-and cron has no logged-in human for a capability check to resolve against.
+The original design routed the capability floor through a `user_has_cap`
+filter, exempted exactly one "distinguished" account with unusable credentials,
+and reached it by switching the session into that identity — `sudo -i`
+opening a shell, rather than `sudo` wrapping one command. Three things were
+checked and confirmed to be genuine errors, not stylistic quibbles:
 
-**This is not a substitute for §4.1–§4.7 — it is the other axis, and the two
-compose rather than compete.** A capability floor with no veto layer has a
-residual: once switched into the distinguished identity, every dangerous
-action is available for the rest of that session with no further check, so a
-stolen session cookie during the elevated window regains everything the floor
-was built to deny elsewhere. An approval-token veto with no capability floor
-has the mirror residual: it demands fresh proof before an action executes, but
-has no opinion on which account was allowed to hold that capability in the
-first place, so a role-flip bug that hands the raw capability to the wrong
-account still only has to clear the veto once to use it. Put together, each
-closes exactly the gap the other leaves open.
+1. **The floor is not universal — it silently fails on multisite.**
+   `WP_User::has_cap()` calls `map_meta_cap()` first, and if the caller is a
+   multisite Super Admin, returns `true` immediately — *before* the
+   `user_has_cap` filter ever runs — unless `map_meta_cap()` has already added
+   `do_not_allow` to the required capabilities
+   (`wp-includes/class-wp-user.php`, verified against WordPress 7.0.1 source).
+   `is_multisite()` is false on a single-site install, so this branch never
+   triggers there and the original claim held for that case — but "universal"
+   was stated without the carve-out, and on multisite every Super Admin
+   bypasses the floor entirely. Reaching them at all requires denial inside
+   `map_meta_cap()` itself, which is a different and larger mechanism than a
+   single filter, with its own multisite test surface.
+2. **Gating one "elevate" action does not gate the actions it was meant to
+   protect.** §6's own "session-window independence" test demanded that every
+   dangerous action, not just the act of switching identity, re-check a
+   fresh single-use approval. But the design described only gated the
+   elevation step itself — a declared Ability behind a vetoable filter. Once
+   a session held the distinguished identity, `install_plugins`,
+   `promote_user`, and every other capability check downstream would see an
+   account that legitimately holds the capability and proceed exactly as
+   normal, with no further check. The document had asked a test to verify a
+   property its own described mechanism never supplied. Compounding this,
+   the text named the wrong hook — "the vetoable `wp_before_execute_ability`
+   filter" — when §4.6 proposes a *different*, new filter
+   (`wp_pre_execute_ability`); `wp_before_execute_ability` is the existing
+   action already established in §4.6 as unable to veto anything.
+3. **The distinguished identity does not earn its complexity, and the
+   evidence cited for it does not actually involve one.** Reading `#470`'s
+   actual implementation (`tests/e2e/fixtures/phase27-wordpress-adapter.php`,
+   on the preserved `research/action-gate-phase-27` branch) — the audit §6
+   requires before trusting any recommendation built on it — shows every
+   route gated by `current_user_can( 'install_plugins' )` against the
+   ordinary, already-authenticated user. There is no identity switch, no
+   distinguished account, anywhere in it. `#470` achieves recency and
+   effect-binding entirely on the actor's own session. Citing it as evidence
+   for a design built around switching identity was citing evidence for a
+   different design than the one on the page — and the identity switch adds
+   real cost without adding a property `#470` needed to work: it attributes
+   dangerous actions to a synthetic account rather than the human who
+   performed them, raises its own multisite Super Admin questions, and
+   requires separately closing an Application Passwords path for an account
+   that need not have existed.
 
-**The concrete synthesis:** the elevate step does not need a purpose-built
-mechanism of its own. "Switch this session into the distinguished identity" is
-itself a consequential action. Declared as an Abilities API ability and gated
-by the vetoable `wp_before_execute_ability` filter proposed in §4.6, with the
-#470 approval-token candidate attached at that gate, it becomes one prototype
-that proves both pieces at once — a refusable core chokepoint, and a working
-proof mechanism — rather than two separate, unconnected experiments. §6
-restates the next experiment in exactly these terms.
+**The corrected model** keeps the human actor's identity stable throughout —
+no switch, no synthetic account:
+
+1. Dangerous capabilities are denied by default through a Core-owned
+   capability-assurance layer implemented in `map_meta_cap()`, not
+   `user_has_cap` — reaching multisite Super Admins requires this, per point 1
+   above.
+2. Reauthentication adds a short-lived, server-held assurance claim to the
+   actor's *existing* login session. Nothing switches; the same person, the
+   same session, the same audit trail.
+3. That claim does not itself authorize arbitrary work. Each consequential
+   effect consumes its own action-bound, single-use approval naming the
+   actor, the operation, the target, and — where bytes matter, as `#470`'s
+   digest-bound intents demonstrate — a content digest.
+4. Core-owned effect vetoes remain authoritative. Disabled UI controls are a
+   rendering *consequence* of a real denial, never a substitute for one —
+   otherwise it is exactly the client-side-authorization trap named in §4.5
+   and §5.
+5. Cron, CLI, and automated updates use the separately declared machine
+   policy from §4.3, not simulated human reauthentication — unaffected by
+   this correction.
+
+This keeps what the original section got right — no standing dangerous
+capability, disabling as a consequence rather than a boundary, composing
+with rather than replacing §4.1–§4.7's recency axis — while dropping the one
+piece (the distinguished identity) that added complexity without adding a
+security property, and correcting the one piece (`user_has_cap`) that was
+verified wrong outright. §6 is revised to match.
 
 ## 5. Consequences for the prototype
 
@@ -514,36 +546,37 @@ restates the next experiment in exactly these terms.
 
 ## 6. Next experiment
 
-The approval protocol candidate is already tested (#470) — against its own
-fixtures and mutation-testing harness, not yet against the independent,
-read-the-source discipline that found the seven bypasses in §2.1. Those are
-different claims. The next experiment is **integration**: the #470 candidate
-joined to **one real wp-admin preflight adapter** and **one genuine effect
-veto**.
+**The read-the-source audit this section called for has now run, on
+`#470`'s actual implementation** (`tests/e2e/fixtures/phase27-wordpress-adapter.php`
+and `phase27-real-upgrader.php`, on the preserved `research/action-gate-phase-27`
+branch), independently of `#470`'s own fixtures. It found the ghost-identity
+design in an earlier draft of §4.9 was evidence for a different mechanism than
+the one on the page — see §4.9 for the correction — and it found what `#470`
+actually validates: every route gated by the actor's ordinary
+`current_user_can()`, a session-bound and `__Host`-prefixed binding cookie
+independent of the login cookie, digest-bound single-use intents consumed
+atomically against a dedicated table (with a genuine concurrency race in
+`WP_Upgrader`'s shared unpack directory found and fixed honestly, not
+loosened, per that file's own comments), password re-verification with a real
+account-scoped lockout, and revocation wired to `wp_logout` and
+`after_password_reset`. This is real, substantial evidence for the recency
+mechanism in §4.1–§4.7 and the corrected §4.9. It remains evidence
+tested against its own fixtures, not yet against an adversarial audit
+constructed by someone who did not write it — the same gap that let the seven
+bypasses in §2.1 stand for as long as they did.
 
-**The concrete instance recommended is §4.9's elevate step**, not an
-unspecified adapter chosen separately. Declare "switch this session into the
-distinguished identity" as an Abilities API ability, attach the #470 candidate
-to a vetoable `wp_before_execute_ability` filter as that ability's gate, and
-pair it with the capability floor described in §4.9 so there is a real
-elevated identity on the other side of the gate worth protecting. This gives
-the abstract "one adapter, one veto" experiment a concrete, minimal, and
-independently motivated shape, instead of requiring a second, unrelated choice
-of what to prototype.
+The next experiment is **integration**: `#470`'s pattern — a session-bound,
+digest-bound, single-use intent, consumed atomically at the actual effect —
+joined to **one real wp-admin effect that is not already a research fixture**.
+`#470` already exercises the real `WP_Upgrader` path; the natural next step is
+attaching this pattern to that path (or a declared Abilities API equivalent,
+gated by the new `wp_pre_execute_ability` filter proposed in §4.6, if plugin
+install is ever expressed as an ability) as a **live** feature rather than a
+test-only adapter — with **no identity switch anywhere in the design**, per
+§4.9's correction.
 
-**Before any of the checks below are trusted, apply the audit that found §2.1
-to the new integration point, not only to the old one.** That means reading
-`wp-includes/abilities-api/class-wp-ability.php` and whatever session or token
-code #470 actually integrates with — independently, not through #470's own
-fixtures — and checking #470's assumptions about WordPress's real session,
-request, and effect behaviour against what the source does. #470 has been
-extensively tested against itself; it has not yet had this done to it. Skipping
-this and going straight to the checks below would repeat, on the successor
-design, the exact failure this document describes: a mechanism whose own tests
-cannot see past the model it was tested against.
-
-It must also preserve the documented copied-cookie-only claim of §2.4 — not
-widen it — and must test at least:
+It must preserve the documented copied-cookie-only claim of §2.4 — not widen
+it — and must test at least:
 
 - **bypass** — the effect veto still refuses when the adapter is skipped entirely;
 - **parameter mutation** — an approved token cannot be redirected to different
@@ -553,15 +586,16 @@ widen it — and must test at least:
 - **expiry** — behaviour at and past the window boundary, including any grace;
 - **active-XSS boundary** — confirming the documented concession holds exactly
   where §2.4 and #470 say it does, and no further;
-- **session-window independence** — a stolen cookie from an already-elevated
-  session must not be sufficient for a second dangerous action once its
-  single-use approval is consumed; each action re-checks its own approval, not
-  merely which identity the session belongs to. This is the specific residual
-  §4.9 claims the combination closes, and the claim is untested until this
-  runs.
+- **cross-effect independence** — a valid session and binding cookie, on their
+  own, must not be sufficient for an effect the actor was never issued a
+  matching intent for. This is the corrected form of what an earlier draft of
+  this section called "session-window independence": there is no elevated
+  session to protect, only individual approvals, and each one must stand
+  alone.
 
 Success is not "it feels smooth," and it is not "#470's own tests still pass."
-Until the audit above and the checks below both run, §4 is a design sketch.
+Until this runs as a live feature rather than a research fixture, §4 is a
+design sketch with unusually strong supporting evidence.
 
 ---
 
@@ -577,10 +611,23 @@ about WordPress core are registered in `docs/upstream-sources.md` and checked by
 
 §4.9 and the corresponding §6 revision were added 2026-08-02, after this
 project's conclusion and archival, from a design conversation — not from new
-implementation or testing. Its three security claims (server-enforced versus
-client-side disabling; automatic coverage of REST-by-cookie and XML-RPC; the
-Application Passwords residual and its close) were reasoned through in that
-conversation against the mechanisms named, not verified by running code. The
-capability-floor idea itself remains unbuilt; see
-`docs/sudo-architecture-history.md` for the fuller, plain-language account of
-where it fits among every approach this project tried.
+implementation or testing. Its original three security claims (server-enforced
+versus client-side disabling; automatic coverage of REST-by-cookie and
+XML-RPC; the Application Passwords residual and its close) were reasoned
+through in that conversation against the mechanisms named, not verified by
+running code.
+
+§4.9 was revised the same day. An architecture review (Codex) identified three
+errors in the original text: the `user_has_cap` floor does not reach multisite
+Super Admins, gating one "elevate" action does not gate the effects it was
+meant to protect, and the distinguished-identity mechanism was unsupported by
+the evidence cited for it. The multisite claim was verified against
+`wp-includes/class-wp-user.php` on WordPress 7.0.1. The third claim was
+verified by the source audit §6 requires, run for the first time in this
+revision, against `#470`'s actual implementation
+(`tests/e2e/fixtures/phase27-wordpress-adapter.php`,
+`phase27-real-upgrader.php`) rather than its own fixtures — the identity switch
+does not appear anywhere in that code. The capability-floor idea, corrected,
+remains unbuilt; see `docs/sudo-architecture-history.md` for the fuller,
+plain-language account of where it fits among every approach this project
+tried, itself corrected for the same errors.

--- a/docs/sudo-architecture-history.md
+++ b/docs/sudo-architecture-history.md
@@ -87,79 +87,102 @@ than trusting a window opened minutes earlier for something unrelated.
 specific login session so it can't be copied elsewhere or reused for a
 different action.
 
-This design was tested, not just theorized — in a separate demo project
-(`consequential-actions`) and a testing effort called Phase 27, both of
-which showed the mechanism holds up under deliberate attack attempts. What's
-unsettled is getting WordPress core to actually adopt anything like it —
-that part is still a proposal, not a patch.
+The current design (item 5) was tested, not just theorized, in a testing
+effort called Phase 27 — a mechanism that holds up under deliberate attack
+attempts, including a genuine WordPress concurrency bug it found and fixed
+along the way. A separate demo project, `consequential-actions`, is not a
+second, independent test of the same thing — it demonstrates item 3, the
+earlier reusable-window design that item 4 replaced, and is preserved for
+comparison rather than as supporting evidence for item 5. What's unsettled for
+Phase 27's design is getting WordPress core to actually adopt anything like
+it — that part is still a proposal, not a patch.
 
-## The newest idea (not built yet)
+## The newest idea (not built yet, and revised once already)
 
 Came up in conversation after the project concluded, and neither track above
 tried it: instead of gating requests or gating individual core actions,
-change who holds dangerous permissions *at all*.
+change who holds dangerous permissions *at all*. No real account holds
+capabilities like "install a plugin" while just sitting there — they're
+denied by default, and unlocked only by a deliberate, separate proof-of-
+identity step.
 
-No real account — not even the site owner's everyday login — holds
-capabilities like "install a plugin" while just sitting there. Those live on
-one separate account with no working password or email (so it can never be
-logged into directly). Using those capabilities requires a deliberate,
-separate proof-of-identity step first, which then switches the session into
-that account — like `sudo -i` on Unix giving you a root shell you then use
-normally, instead of asking permission for every command.
+**The first version of this idea was wrong in a specific, checkable way, and
+got corrected the same day.** It proposed one special account with no working
+password or email, reached by switching the session into it after reauth —
+like `sudo -i` opening a root shell you then use freely. Three things turned
+out to be wrong with that, found by an outside review and by actually reading
+the code this idea leaned on for evidence, not by further discussion:
 
-This sidesteps the one problem neither prior track solved: what to do with
-a dangerous request that's already in flight when it gets refused. If proof
-happens *before* anyone attempts anything dangerous, there's no half-finished
-request left to replay, refuse, or reconstruct a landing page for.
+- The mechanism proposed for denying capabilities by default doesn't reach
+  every account on a multisite install — a multisite Super Admin bypasses it
+  entirely, for a specific, verifiable reason in how WordPress checks
+  capabilities.
+- Switching one dangerous action (the "become admin" step) behind a proof
+  requirement doesn't put a proof requirement on the *other* dangerous
+  actions. Once switched in, installing a plugin or promoting a user would
+  proceed completely normally, with no further check — the design didn't
+  actually deliver the "every action needs its own proof" property it was
+  supposed to.
+- The evidence cited for this design — Phase 27 — doesn't contain anything
+  like a special account or a session switch when you actually read its code.
+  It proves a *different, better* idea: that this can all be done to the
+  same account, the site owner's own, without ever creating a synthetic
+  identity.
 
-It also isn't fooled by the seven bugs that broke the plugin's own
-request-matching, because it checks WordPress's actual permission system —
-which fires the same way regardless of how the request arrived — instead of
-guessing from the outside what a request means.
+**The corrected version keeps the site owner's own account throughout.**
+Nothing switches. A short-lived proof of identity attaches to the person's
+existing login. That proof doesn't authorize everything by itself — each
+dangerous action still has to consume its own one-time approval, tied to
+that specific action and, where it matters, to the exact bytes involved.
+Disabling the button in the browser is still just a visible side effect of a
+real, server-side "no" — never the "no" itself. This keeps everything the
+first version got right and drops the one piece (a synthetic account) that
+added complexity without adding any real protection.
 
-**Checked, not assumed, before trusting this:** disabling admin UI elements
-until reauth is only secure if the disabling is a *consequence* of a real
-server-side capability denial, not a substitute for one — otherwise it's
-exactly the "client-side disabling as authorization" trap `docs/finding.md`
-already warns against. Confirmed it holds across surfaces: REST calls
-authenticated by cookie inherit the same protection automatically; XML-RPC
-and direct login are closed the same way the special account is closed
-everywhere else; WP-CLI and cron are correctly out of scope rather than
-insecurely uncovered, since CLI access already implies filesystem trust this
-design can't add to, and cron has no logged-in human to check in the first
-place. One real, specific, closeable gap: Application Passwords issued to
-the special account would bypass the whole thing, since that credential
-never touches the reauth step at all.
+**Checked, not assumed:** REST calls authenticated by the same login cookie
+inherit the same protection automatically; XML-RPC is closed the same way
+direct login already is; WP-CLI and cron are correctly out of scope rather
+than insecurely uncovered, since CLI access already implies a level of trust
+this can't add to, and cron has no logged-in human to check against in the
+first place. One real, specific, closeable gap either version shares:
+Application Passwords issued to whatever account holds the elevated proof
+would bypass the whole thing, since that credential never touches the reauth
+step at all.
 
-It would not stop everything. A vulnerable plugin that writes a dangerous
-file without ever asking WordPress's permission system anything would still
-get through — there's no check there to intercept. And anyone who already
-has direct file access to the server could simply edit the rule enforcing
-all of this. But within its scope, it's more solid than either prior track,
-because it hooks the one place WordPress core itself already checks
-"can this person really do this," instead of guessing from outside.
+It would not stop everything, either version. A vulnerable plugin that writes
+a dangerous file without ever asking WordPress's permission system anything
+would still get through — there's no check there to intercept. And anyone who
+already has direct file access to the server could simply edit the rule
+enforcing all of this. But within its scope, the corrected version is more
+solid than either prior track, because it hooks the one place WordPress core
+itself already checks "can this person really do this," instead of guessing
+from outside — and it does so without inventing a second identity that never
+needed to exist.
 
 ## Next best steps
 
 **Track 1 — a working prototype of a real core change.**
 WordPress 6.9/7.0 already added a small, relevant hook
 (`wp_before_execute_ability`) at the point where a declared "ability" runs —
-but it can only watch, not refuse. The concrete next step: a working patch
-that makes that hook able to say no, with the already-tested proof mechanism
-(the B′ design) attached to it, proven on one real WordPress admin screen
-plus one real dangerous action. Not a redesign — a small, working
-demonstration that two already-proven pieces (a refusable hook, a working
-proof mechanism) actually fit together in real WordPress.
+but it can only watch, not refuse. The concrete next step: a *new*, separate
+filter at that same point that can actually say no, with the already-tested
+proof mechanism (Phase 27) attached to it, proven as a live feature on one
+real WordPress admin screen plus one real dangerous action — not the test-only
+adapter Phase 27 already built, but the same pattern wired into something a
+site actually runs. Before trusting the result, read Phase 27's own code
+independently first, rather than trusting that it does what its own tests say
+it does — that step is what caught the special-account mistake above, and
+skipping it here would risk the same kind of error a second time.
 
 **Track 2 — a new mu-plugin, built from scratch around "no standing admin."**
-Never built, only sketched. The next step is a small, working version: one
-rule file that strips dangerous capabilities from everyone, one special
-account with no usable password or email (and Application Passwords
-explicitly disabled for it), one small "prove it's you, then switch me in"
-page, and a written list of what's deliberately left out (server-level
-access, and non-capability-checked vulnerabilities in third-party code).
-Before trusting it, test it two ways: against the same seven bugs the
-plugin's own request-matching failed on, and with a server-bypass check on
-every surface — submit the raw request with the UI skipped entirely, on
-admin, REST-cookie, REST-app-password, and XML-RPC, and confirm the server
-still refuses each one.
+Never built, only sketched, and revised once already after the special-account
+version above didn't hold up. The next step is a small, working version: a
+denial layer written at the point WordPress actually resolves capabilities
+(not a shortcut that skips multisite's Super Admins), a short-lived proof
+attached to the site owner's own login rather than a second account, one
+small "prove it's you" step that unlocks it, and one dangerous action wired
+to require its own one-time approval before it runs. Before trusting it, test
+it two ways: against the same seven bugs the plugin's own request-matching
+failed on, and with a server-bypass check on every surface — submit the raw
+request with the UI skipped entirely, on admin, REST-cookie, REST-app-password,
+and XML-RPC, and confirm the server still refuses each one.


### PR DESCRIPTION
## Summary
An architecture review (Codex) and the source audit §6 already required found three independent, verified errors in the §4.9 capability-floor track added earlier today:

1. **`user_has_cap` is not universal.** `WP_User::has_cap()` returns early for a multisite Super Admin before the `user_has_cap` filter runs. Verified against `wp-includes/class-wp-user.php` (WP 7.0.1). True on single-site, false on multisite as originally stated.
2. **Gating one "elevate" action doesn't gate what it was meant to protect.** Once switched into the distinguished identity, every other capability check passes normally. The §6 test demanded a property the mechanism never supplied. The text also named the wrong hook (`wp_before_execute_ability` instead of the `wp_pre_execute_ability` §4.6 actually proposes).
3. **The distinguished identity is unsupported by its own cited evidence.** Reading `#470`'s actual implementation — the audit §6 requires, run here for the first time against source rather than `#470`'s own fixtures — shows every route gated by ordinary `current_user_can()`. No identity switch anywhere in it.

§4.9 is revised, not deleted — the original text and why each part failed are kept, matching how §2.5 already handles a withdrawn claim. The corrected model keeps the human actor's identity stable: denial via `map_meta_cap`, a short-lived assurance claim on the existing session, per-effect single-use approval, matching what `#470` actually validates. §6 and Provenance are revised to match.

`docs/sudo-architecture-history.md` gets the same correction in its own register, plus a separate fix: it presented `consequential-actions` and Phase 27 as two independent tests of the same design, when `finding.md` §4.8 already correctly says `consequential-actions` demonstrates the earlier, superseded reusable-window model.

## Validation
Docs-only; both files already carry their docs-lint exclusions. Swept both files and the rest of the repo for stale references to the retracted design — none remain outside the retraction narrative itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)